### PR TITLE
Replace ThreadPoolExecutor with ForkJoinPool(asyncMode=true) as the commandQueue in #Krystex

### DIFF
--- a/krystal-common/src/main/java/com/flipkart/krystal/utils/DistributeLeases.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/utils/DistributeLeases.java
@@ -1,0 +1,13 @@
+package com.flipkart.krystal.utils;
+
+/**
+ *
+ *
+ *
+ * @param maxActiveObjects Prefer to distribute leases equally among this many active objects if
+ *     each object already has {@code minActiveLeasesPerObject} active leases.
+ * @param distributionTriggerThreshold distribute leases equally/create new objects only after all
+ *     objects have reached this threshold
+ */
+public record DistributeLeases(int maxActiveObjects, int distributionTriggerThreshold)
+    implements MultiLeasePolicy {}

--- a/krystal-common/src/main/java/com/flipkart/krystal/utils/MultiLeasePolicy.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/utils/MultiLeasePolicy.java
@@ -1,0 +1,5 @@
+package com.flipkart.krystal.utils;
+
+public sealed interface MultiLeasePolicy permits PreferObjectReuse, DistributeLeases {
+
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/utils/PreferObjectReuse.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/utils/PreferObjectReuse.java
@@ -1,0 +1,6 @@
+package com.flipkart.krystal.utils;
+
+import java.util.Optional;
+
+public record PreferObjectReuse(int maxActiveLeasesPerObject, Optional<Integer> maxActiveObjects)
+    implements MultiLeasePolicy {}

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/ForkJoinExecutorPool.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/ForkJoinExecutorPool.java
@@ -1,0 +1,21 @@
+package com.flipkart.krystal.krystex;
+
+import static java.lang.Math.max;
+import static java.lang.Runtime.getRuntime;
+import static java.util.concurrent.Executors.newWorkStealingPool;
+
+import com.flipkart.krystal.utils.DistributeLeases;
+import com.flipkart.krystal.utils.MultiLeasePool;
+import java.util.concurrent.ExecutorService;
+
+public final class ForkJoinExecutorPool extends MultiLeasePool<ExecutorService>
+    implements AutoCloseable {
+
+  public ForkJoinExecutorPool(double maxParallelismPerCore) {
+    super(
+        () -> newWorkStealingPool(1),
+        new DistributeLeases(
+            max(1, (int) (getRuntime().availableProcessors() * maxParallelismPerCore)), 1),
+        ExecutorService::shutdown);
+  }
+}

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/SingleThreadExecutorPool.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/SingleThreadExecutorPool.java
@@ -1,9 +1,12 @@
 package com.flipkart.krystal.krystex;
 
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
 import com.flipkart.krystal.utils.MultiLeasePool;
+import com.flipkart.krystal.utils.PreferObjectReuse;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public final class SingleThreadExecutorPool extends MultiLeasePool<ExecutorService>
     implements AutoCloseable {
@@ -12,11 +15,11 @@ public final class SingleThreadExecutorPool extends MultiLeasePool<ExecutorServi
   public SingleThreadExecutorPool(int maxActiveLeasesPerObject) {
     super(
         () ->
-            Executors.newSingleThreadExecutor(
+            newSingleThreadExecutor(
                 new ThreadFactoryBuilder()
                     .setNameFormat("KrystalNodeExecutor-%s".formatted(EXECUTOR_SERVICE_COUNTER++))
                     .build()),
-        maxActiveLeasesPerObject,
+        new PreferObjectReuse(maxActiveLeasesPerObject, Optional.empty()),
         ExecutorService::shutdown);
   }
 }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/node/KrystalNodeExecutor.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/node/KrystalNodeExecutor.java
@@ -11,7 +11,6 @@ import com.flipkart.krystal.data.Inputs;
 import com.flipkart.krystal.krystex.KrystalExecutor;
 import com.flipkart.krystal.krystex.MainLogicDefinition;
 import com.flipkart.krystal.krystex.RequestId;
-import com.flipkart.krystal.krystex.SingleThreadExecutorPool;
 import com.flipkart.krystal.krystex.commands.ExecuteWithInputs;
 import com.flipkart.krystal.krystex.commands.Flush;
 import com.flipkart.krystal.krystex.commands.NodeRequestCommand;
@@ -21,6 +20,7 @@ import com.flipkart.krystal.krystex.decoration.LogicExecutionContext;
 import com.flipkart.krystal.krystex.decoration.MainLogicDecorator;
 import com.flipkart.krystal.krystex.decoration.MainLogicDecoratorConfig.DecoratorContext;
 import com.flipkart.krystal.utils.MultiLeasePool;
+import com.flipkart.krystal.utils.MultiLeasePool.Lease;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ public final class KrystalNodeExecutor implements KrystalExecutor {
 
   private final NodeDefinitionRegistry nodeDefinitionRegistry;
   private final LogicDecorationOrdering logicDecorationOrdering;
-  private final MultiLeasePool.Lease<ExecutorService> commandQueueLease;
+  private final Lease<? extends ExecutorService> commandQueueLease;
   private final RequestId requestId;
 
   /** DecoratorType -> {InstanceId -> Decorator} */
@@ -56,7 +56,7 @@ public final class KrystalNodeExecutor implements KrystalExecutor {
   public KrystalNodeExecutor(
       NodeDefinitionRegistry nodeDefinitionRegistry,
       LogicDecorationOrdering logicDecorationOrdering,
-      SingleThreadExecutorPool commandQueuePool,
+      MultiLeasePool<? extends ExecutorService> commandQueuePool,
       String requestId) {
     this.nodeDefinitionRegistry = nodeDefinitionRegistry;
     this.logicDecorationOrdering = logicDecorationOrdering;

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/decorators/resilience4j/Resilience4JBulkheadTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/decorators/resilience4j/Resilience4JBulkheadTest.java
@@ -7,10 +7,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flipkart.krystal.config.ConfigProvider;
 import com.flipkart.krystal.data.Inputs;
+import com.flipkart.krystal.krystex.ForkJoinExecutorPool;
 import com.flipkart.krystal.krystex.IOLogicDefinition;
 import com.flipkart.krystal.krystex.LogicDefinitionRegistry;
 import com.flipkart.krystal.krystex.MainLogicDefinition;
-import com.flipkart.krystal.krystex.SingleThreadExecutorPool;
 import com.flipkart.krystal.krystex.decoration.LogicDecorationOrdering;
 import com.flipkart.krystal.krystex.decoration.MainLogicDecoratorConfig;
 import com.flipkart.krystal.krystex.node.KrystalNodeExecutor;
@@ -46,7 +46,7 @@ class Resilience4JBulkheadTest {
         new KrystalNodeExecutor(
             nodeDefinitionRegistry,
             new LogicDecorationOrdering(ImmutableSet.of()),
-            new SingleThreadExecutorPool(1),
+            new ForkJoinExecutorPool(1),
             "test");
     this.executorService = Executors.newSingleThreadExecutor();
   }

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/node/KrystalNodeExecutorTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/node/KrystalNodeExecutorTest.java
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.flipkart.krystal.data.Inputs;
 import com.flipkart.krystal.krystex.ComputeLogicDefinition;
+import com.flipkart.krystal.krystex.ForkJoinExecutorPool;
 import com.flipkart.krystal.krystex.LogicDefinitionRegistry;
 import com.flipkart.krystal.krystex.MainLogicDefinition;
-import com.flipkart.krystal.krystex.SingleThreadExecutorPool;
 import com.flipkart.krystal.krystex.decoration.LogicDecorationOrdering;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -40,7 +40,7 @@ class KrystalNodeExecutorTest {
         new KrystalNodeExecutor(
             nodeDefinitionRegistry,
             new LogicDecorationOrdering(ImmutableSet.of()),
-            new SingleThreadExecutorPool(1),
+            new ForkJoinExecutorPool(1),
             "test");
   }
 

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexVajramExecutor.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexVajramExecutor.java
@@ -1,14 +1,15 @@
 package com.flipkart.krystal.vajramexecutor.krystex;
 
-import com.flipkart.krystal.krystex.SingleThreadExecutorPool;
 import com.flipkart.krystal.krystex.KrystalExecutor;
 import com.flipkart.krystal.krystex.decoration.LogicDecorationOrdering;
 import com.flipkart.krystal.krystex.node.KrystalNodeExecutor;
+import com.flipkart.krystal.utils.MultiLeasePool;
 import com.flipkart.krystal.vajram.ApplicationRequestContext;
 import com.flipkart.krystal.vajram.VajramID;
 import com.flipkart.krystal.vajram.VajramRequest;
 import com.flipkart.krystal.vajram.exec.VajramExecutor;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 public class KrystexVajramExecutor<C extends ApplicationRequestContext>
@@ -21,7 +22,7 @@ public class KrystexVajramExecutor<C extends ApplicationRequestContext>
   public KrystexVajramExecutor(
       VajramNodeGraph vajramNodeGraph,
       LogicDecorationOrdering logicDecorationOrdering,
-      SingleThreadExecutorPool executorServicePool,
+      MultiLeasePool<? extends ExecutorService> executorServicePool,
       C applicationRequestContext) {
     this.vajramNodeGraph = vajramNodeGraph;
     this.applicationRequestContext = applicationRequestContext;
@@ -51,7 +52,7 @@ public class KrystexVajramExecutor<C extends ApplicationRequestContext>
   }
 
   @Override
-  public void flush(){
+  public void flush() {
     krystalExecutor.flush();
   }
 


### PR DESCRIPTION
At extremely high qps (~ 10_000 qps), for certain workloads, this change enables 
- 8x reduction in thread usage AND
- 5x reduction in platform latency cost across percentiles (p50, p75, p90, p99 and p999)