### PR TITLE
fix for handling classpath for vajram impl codegen

### DIFF
--- a/vajram/vajram-codegen/src/main/groovy/com/flipkart/krystal/vajram/VajramPlugin.groovy
+++ b/vajram/vajram-codegen/src/main/groovy/com/flipkart/krystal/vajram/VajramPlugin.groovy
@@ -60,7 +60,8 @@ class VajramPlugin implements Plugin<Project> {
                 VajramCodeGenFacade.codeGenVajramImpl(
                         project.sourceSets.main.java.srcDirs,
                         compiledMainDir,
-                        mainGeneratedSrcDir)
+                        mainGeneratedSrcDir,
+                        project.configurations.compileClasspath)
             }
         }
 


### PR DESCRIPTION
The vajram impl codegen was not loading all the client classpath files resulting in ClassNotFoundException. This PR fixes the issue. The compile classpath is passed to the Vajram impl codegen method.