### PR TITLE
Vajram Code Generator Bug Fixes and feature addition

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -122,6 +122,7 @@
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
       <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
       <option name="CALL_PARAMETERS_WRAP" value="1" />
       <option name="METHOD_PARAMETERS_WRAP" value="1" />
       <option name="EXTENDS_LIST_WRAP" value="1" />

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 ext {
     clojarsusername = project.properties['clojarsusername'] ?: ""
     clojarspassword = project.properties['clojarspassword'] ?: ""
-    krystal_version = '2.1'
+    krystal_version = '2.2-SNAPSHOT'
 }
 
 subprojects {

--- a/krystal-common/src/main/java/com/flipkart/krystal/data/ValueOrError.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/data/ValueOrError.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
 /**
  * A wrapper object representing a value or an error. This can be seen as a 'completed' version of a
  * {@link CompletableFuture}. This class avoids the prevalence of {@code null}s in the codebase and
- * also allows reactive frameworks to gracefully handle scenarios where a computation led to a error
+ * also allows reactive frameworks to gracefully handle scenarios where a computation led to an error
  * because of which some value could not be computed.
  *
  * <p>Example states:

--- a/vajram/vajram-codegen/build.gradle
+++ b/vajram/vajram-codegen/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.flipkart.krystal:vajram:'+ '2.1'//project.krystal_version
+        classpath 'com.flipkart.krystal:vajram:'+ project.krystal_version
     }
 }
 

--- a/vajram/vajram-codegen/build.gradle
+++ b/vajram/vajram-codegen/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.flipkart.krystal:vajram:'+ project.krystal_version
+        classpath 'com.flipkart.krystal:vajram:'+ '2.1'//project.krystal_version
     }
 }
 

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
@@ -479,8 +479,7 @@ public class VajramCodeGenerator {
               }
             });
     returnBuilder.add(
-        "\nreturn $T.valueOrError(() -> $L(new $T(\n",
-        clsDeps.get(VAL_ERR),
+        "\nreturn $L(new $T(\n",
         vajramDefs.get(vajramName).vajramLogic().getName(),
         ClassName.get(
             packageName, getInputUtilClassName(vajramName), getAllInputsClassname(vajramName)));
@@ -493,7 +492,7 @@ public class VajramCodeGenerator {
         returnBuilder.add(",\n");
       }
     }
-    returnBuilder.add(")));\n");
+    returnBuilder.add("));\n");
     returnBuilder.add("}));\n");
     executeBuilder.addCode(returnBuilder.build());
   }

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
@@ -835,7 +835,7 @@ public class VajramCodeGenerator {
               depType,
               variableName,
               clsDeps.get(DEP_RESP),
-              CodegenUtils.getMethodReturnType(method),
+              depType,
               usingInputName,
               clsDeps.get(IM_MAP),
               ClassName.get(depPackageName, requestClass),

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/utils/CodegenUtils.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/utils/CodegenUtils.java
@@ -93,11 +93,10 @@ public final class CodegenUtils {
   }
 
   public static TypeName getMethodReturnType(Method method) {
-    ParameterizedTypeName parameterizedTypeName;
-    if (method.getGenericReturnType() instanceof ParameterizedType genericReturnType) {
+    if (method.getGenericReturnType() instanceof ParameterizedType) {
       return getType(method.getGenericReturnType());
     } else {
-      return ClassName.get(Primitives.wrap(method.getReturnType()));
+      return TypeName.get(method.getReturnType());
     }
   }
 

--- a/vajram/vajram-codegen/src/test/java/com/flipkart/krystal/vajram/codegen/utils/CodegenUtilsTest.java
+++ b/vajram/vajram-codegen/src/test/java/com/flipkart/krystal/vajram/codegen/utils/CodegenUtilsTest.java
@@ -36,7 +36,7 @@ public class CodegenUtilsTest {
         ((ParameterizedTypeName) methodReturnType).rawType, ClassName.get(Set.class));
 
     final TypeName methodReturnType2 = CodegenUtils.getMethodReturnType(getMethod);
-    Assertions.assertEquals(((ClassName) methodReturnType2), ClassName.get(Object.class));
+    Assertions.assertEquals(methodReturnType2, ClassName.get(Object.class));
 
     final TypeName classGenericArgumentsType =
         CodegenUtils.getClassGenericArgumentsType(ClassTest1.class);

--- a/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/benchmarks/calculator/Formula.java
+++ b/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/benchmarks/calculator/Formula.java
@@ -10,6 +10,7 @@ import com.flipkart.krystal.vajram.inputs.Using;
 import com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaInputUtil.FormulaAllInputs;
 import com.flipkart.krystal.vajram.samples.benchmarks.calculator.adder.AdderRequest;
 import com.flipkart.krystal.vajram.samples.benchmarks.calculator.divider.DividerRequest;
+import java.util.Optional;
 
 /** a/(p+q) */
 @VajramDef(ID)


### PR DESCRIPTION
Fix Bug: When a resolver accepts a native java type as @Using dependency type, the codegenerator is using the resolver return type rather than the dependency type

Fix Bug: When an IOVajram does not have inputModulation enabled, the code generator is wrapping the returned completable future in a ValueOrError (just like in ComputeVajrams) instead of returning the CompletableFuture as it is.

Add validations: resolvers cannot accept `Type` for optional dependencies as @Using param type

Add support: Now resolvers can accept `ValueOrError<Type>` for dependencies as @Using param type
Add support: Now resolvers can accept `Optional<Type>` for dependencies as @Using param type