### PR TITLE
Type safe facet specs

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -553,6 +553,7 @@
           <option value="NonBooleanMethodNameMayNotStartWithQuestion" />
           <option value="ZeroLengthArrayAllocation" />
           <option value="initialization.field.uninitialized" />
+          <option value="AssertBetweenInconvertibleTypes" />
         </list>
       </option>
     </inspection_tool>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -298,6 +298,7 @@
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
     </inspection_tool>
     <inspection_tool class="LoggingConditionDisagreesWithLogStatement" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="LombokGetterMayBeUsed" enabled="true" level="INFORMATION" enabled_by_default="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     <inspection_tool class="LoopWithImplicitTerminationCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MagicNumber" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
@@ -488,7 +489,6 @@
     <inspection_tool class="SimplifiedTestNGAssertion" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SimplifyStreamApiCallChains" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Singleton" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SleepWhileHoldingLock" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SocketResource" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="insideTryAllowed" value="false" />

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramDepFanoutTypeSpec.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramDepFanoutTypeSpec.java
@@ -2,8 +2,7 @@ package com.flipkart.krystal.vajram.facets;
 
 import static lombok.EqualsAndHashCode.CacheStrategy.LAZY;
 
-import com.flipkart.krystal.vajram.Vajram;
-import java.util.Collection;
+import com.flipkart.krystal.vajram.VajramRequest;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -15,10 +14,11 @@ import lombok.EqualsAndHashCode;
  * @param <DV> The dependency vajram
  */
 @EqualsAndHashCode(callSuper = true, cacheStrategy = LAZY)
-public final class VajramDepFanoutTypeSpec<T, CV extends Vajram<?>>
-    extends VajramDependencySpec<Collection<T>, CV> {
+public final class VajramDepFanoutTypeSpec<
+        T, CV extends VajramRequest<?>, DV extends VajramRequest<T>>
+    extends VajramDependencySpec<T, CV, DV> {
 
-  public VajramDepFanoutTypeSpec(String name, Class<CV> ofVajram) {
-    super(name, ofVajram);
+  public VajramDepFanoutTypeSpec(String name, Class<CV> ofVajram, Class<DV> onVajram) {
+    super(name, ofVajram, onVajram);
   }
 }

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramDepSingleTypeSpec.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramDepSingleTypeSpec.java
@@ -2,7 +2,7 @@ package com.flipkart.krystal.vajram.facets;
 
 import static lombok.EqualsAndHashCode.CacheStrategy.LAZY;
 
-import com.flipkart.krystal.vajram.Vajram;
+import com.flipkart.krystal.vajram.VajramRequest;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -14,10 +14,11 @@ import lombok.EqualsAndHashCode;
  * @param <DVR> The dependency vajram
  */
 @EqualsAndHashCode(callSuper = true, cacheStrategy = LAZY)
-public final class VajramDepSingleTypeSpec<T, CV extends Vajram<?>>
-    extends VajramDependencySpec<T, CV> {
+public final class VajramDepSingleTypeSpec<
+        T, CV extends VajramRequest<?>, DV extends VajramRequest<T>>
+    extends VajramDependencySpec<T, CV, DV> {
 
-  public VajramDepSingleTypeSpec(String name, Class<CV> ofVajram) {
-    super(name, ofVajram);
+  public VajramDepSingleTypeSpec(String name, Class<CV> ofVajram, Class<DV> onVajram) {
+    super(name, ofVajram, onVajram);
   }
 }

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramDependencySpec.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramDependencySpec.java
@@ -1,20 +1,18 @@
 package com.flipkart.krystal.vajram.facets;
 
-import com.flipkart.krystal.vajram.Vajram;
+import com.flipkart.krystal.vajram.VajramRequest;
 
 /**
  * Represents a dependency vajram of the current vajram.
  *
- * @param <T> The type of this facet
+ * @param <T> The type of this facet - this is the return type of the dependency vajram
  * @param <CV> The current vajram which has the dependency
  */
-public abstract sealed class VajramDependencySpec<T, CV extends Vajram<?>>
-    extends VajramFacetSpec<T> permits VajramDepFanoutTypeSpec, VajramDepSingleTypeSpec {
+public abstract sealed class VajramDependencySpec<
+        T, CV extends VajramRequest<?>, DV extends VajramRequest<T>>
+    extends VajramFacetSpec<T, CV> permits VajramDepFanoutTypeSpec, VajramDepSingleTypeSpec {
 
-  private final Class<CV> ofVajram;
-
-  VajramDependencySpec(String name, Class<CV> ofVajram) {
-    super(name);
-    this.ofVajram = ofVajram;
+  VajramDependencySpec(String name, Class<CV> ofVajram, Class<DV> onVajram) {
+    super(name, ofVajram);
   }
 }

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramFacetSpec.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/VajramFacetSpec.java
@@ -3,20 +3,22 @@ package com.flipkart.krystal.vajram.facets;
 import static lombok.EqualsAndHashCode.CacheStrategy.LAZY;
 
 import com.flipkart.krystal.schema.FacetSpec;
+import com.flipkart.krystal.vajram.VajramRequest;
 import lombok.EqualsAndHashCode;
 
 /**
- * Represents a facet of the current vajram. This may also represent an input of this vajram or a
+ * Represents a facet of the current vajram. This may represent an input of this vajram or a
  * depenedency of this vajram (See: {@link VajramDependencySpec})
  *
  * @param <T> The data type of the facet.
  */
 @EqualsAndHashCode(cacheStrategy = LAZY)
-public sealed class VajramFacetSpec<T> implements FacetSpec<T> permits VajramDependencySpec {
+public sealed class VajramFacetSpec<T, CV extends VajramRequest<?>> implements FacetSpec<T>
+    permits VajramDependencySpec {
 
   private final String name;
 
-  public VajramFacetSpec(String name) {
+  public VajramFacetSpec(String name, Class<CV> ofVajram) {
     this.name = name;
   }
 

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/FanoutResolverStage.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/FanoutResolverStage.java
@@ -1,6 +1,6 @@
 package com.flipkart.krystal.vajram.facets.resolution;
 
-import com.flipkart.krystal.vajram.Vajram;
+import com.flipkart.krystal.vajram.VajramRequest;
 import com.flipkart.krystal.vajram.facets.VajramFacetSpec;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,12 +15,13 @@ import java.util.function.Predicate;
  * @param <CV> CurrentVajram: The current vajram which is resolving the input
  * @param <DV> DependencyVajram: The vajram whose input is being resolved
  */
-public final class FanoutResolverStage<S, T, CV extends Vajram<?>, DV extends Vajram<?>> {
-  private final VajramFacetSpec<T> targetInput;
-  private final VajramFacetSpec<S> sourceInput;
+public final class FanoutResolverStage<
+    S, T, CV extends VajramRequest<?>, DV extends VajramRequest<?>> {
+  private final VajramFacetSpec<T, DV> targetInput;
+  private final VajramFacetSpec<S, CV> sourceInput;
   private final List<SkipPredicate<S>> skipConditions = new ArrayList<>();
 
-  FanoutResolverStage(VajramFacetSpec<T> targetInput, VajramFacetSpec<S> sourceInput) {
+  FanoutResolverStage(VajramFacetSpec<T, DV> targetInput, VajramFacetSpec<S, CV> sourceInput) {
     this.targetInput = targetInput;
     this.sourceInput = sourceInput;
   }
@@ -40,7 +41,7 @@ public final class FanoutResolverStage<S, T, CV extends Vajram<?>, DV extends Va
    *     collection of the target data type {@code T}
    * @return The resultant {@link SimpleInputResolverSpec}
    */
-  public SimpleInputResolverSpec<S, T> with(
+  public SimpleInputResolverSpec<S, T, CV, DV> with(
       Function<Optional<S>, ? extends Collection<? extends T>> transformer) {
     return new SimpleInputResolverSpec<>(
         targetInput, sourceInput, skipConditions, null, transformer);
@@ -52,16 +53,16 @@ public final class FanoutResolverStage<S, T, CV extends Vajram<?>, DV extends Va
    * @param <T> The data type of the input being resolved.
    * @param <DV> The dependency whose input is being resolved.
    */
-  public static final class ResolveFanoutStage<T, DV extends Vajram<?>> {
+  public static final class ResolveFanoutStage<T, DV extends VajramRequest<?>> {
 
-    private final VajramFacetSpec<T> targetInput;
+    private final VajramFacetSpec<T, DV> targetInput;
 
-    ResolveFanoutStage(VajramFacetSpec<T> targetInput) {
+    ResolveFanoutStage(VajramFacetSpec<T, DV> targetInput) {
       this.targetInput = targetInput;
     }
 
-    public <S, CV extends Vajram<?>> FanoutResolverStage<S, T, CV, DV> using(
-        VajramFacetSpec<S> sourceInput) {
+    public <S, CV extends VajramRequest<?>> FanoutResolverStage<S, T, CV, DV> using(
+        VajramFacetSpec<S, CV> sourceInput) {
       return new FanoutResolverStage<>(targetInput, sourceInput);
     }
   }

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/InputResolvers.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/InputResolvers.java
@@ -3,7 +3,7 @@ package com.flipkart.krystal.vajram.facets.resolution;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolverUtil.toResolver;
 import static java.util.Arrays.stream;
 
-import com.flipkart.krystal.vajram.Vajram;
+import com.flipkart.krystal.vajram.VajramRequest;
 import com.flipkart.krystal.vajram.facets.VajramDependencySpec;
 import com.flipkart.krystal.vajram.facets.VajramFacetSpec;
 import com.flipkart.krystal.vajram.facets.resolution.FanoutResolverStage.ResolveFanoutStage;
@@ -31,12 +31,14 @@ public final class InputResolvers {
    * @param resolverStages The resolver specs of the dependency
    * @return The list of InputResolvers
    * @param <T> The return type of the dependency.
-   * @param <P> The resultant return type of the dependency. If it's a fanout dependency then this
-   *     would be {@link Collection<T>}, else T itself.
    * @param <CV> The current vajram which has the dependency
+   * @param <DV> The dependency vajram
    */
-  public static <T, P, CV extends Vajram<?>> List<InputResolver> dep(
-      VajramDependencySpec<P, CV> dependency, SimpleInputResolverSpec<?, ?>... resolverStages) {
+  @SafeVarargs
+  public static <T, CV extends VajramRequest<?>, DV extends VajramRequest<T>>
+      List<InputResolver> dep(
+          VajramDependencySpec<T, CV, DV> dependency,
+          SimpleInputResolverSpec<?, ?, CV, DV>... resolverStages) {
     return stream(resolverStages)
         .map(
             spec -> {
@@ -51,8 +53,8 @@ public final class InputResolvers {
    * @param <T> The data type of the input
    * @param <DV> The dependency whose input is being resolved.
    */
-  public static <T, DV extends Vajram<?>> ResolveStage<T, DV> depInput(
-      VajramFacetSpec<T> depInput) {
+  public static <T, DV extends VajramRequest<?>> ResolveStage<T, DV> depInput(
+      VajramFacetSpec<T, DV> depInput) {
     return new ResolveStage<>(depInput);
   }
 
@@ -63,8 +65,8 @@ public final class InputResolvers {
    * @param <T> The data type of the input being resolved.
    * @param <DV> The dependency whose input is being resolved.
    */
-  public static <T, DV extends Vajram<?>> ResolveFanoutStage<T, DV> fanout(
-      VajramFacetSpec<T> depInput) {
+  public static <T, DV extends VajramRequest<?>> ResolveFanoutStage<T, DV> fanout(
+      VajramFacetSpec<T, DV> depInput) {
     return new ResolveFanoutStage<>(depInput);
   }
 
@@ -75,8 +77,8 @@ public final class InputResolvers {
    * @param <T> Target Type: The DataType of the dependency target input being resolved
    * @param <DV> DependencyVajram: The vajram whose input is being resolved
    */
-  public static <T, DV extends Vajram<?>> ResolveFanoutStage<T, DV> resolveFanout(
-      VajramFacetSpec<T> depInput) {
+  public static <T, DV extends VajramRequest<?>> ResolveFanoutStage<T, DV> resolveFanout(
+      VajramFacetSpec<T, DV> depInput) {
     return new ResolveFanoutStage<>(depInput);
   }
 

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/SimpleInputResolver.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/SimpleInputResolver.java
@@ -11,7 +11,7 @@ import static java.util.Optional.ofNullable;
 
 import com.flipkart.krystal.data.Inputs;
 import com.flipkart.krystal.data.ValueOrError;
-import com.flipkart.krystal.vajram.Vajram;
+import com.flipkart.krystal.vajram.VajramRequest;
 import com.flipkart.krystal.vajram.facets.DependencyCommand;
 import com.flipkart.krystal.vajram.facets.QualifiedInputs;
 import com.flipkart.krystal.vajram.facets.SingleExecute;
@@ -25,13 +25,16 @@ import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 
 /** A resolver which resolves exactly one input of a dependency. */
-public final class SimpleInputResolver<S, T, CV extends Vajram<?>> extends AbstractInputResolver {
+public final class SimpleInputResolver<
+        S, T, CV extends VajramRequest<?>, DV extends VajramRequest<?>>
+    extends AbstractInputResolver {
   public static final LongAdder TIME = new LongAdder();
-  private final VajramDependencySpec<?, CV> dependency;
-  private final SimpleInputResolverSpec<S, T> resolverSpec;
+  private final VajramDependencySpec<?, CV, DV> dependency;
+  private final SimpleInputResolverSpec<S, T, CV, DV> resolverSpec;
 
   SimpleInputResolver(
-      VajramDependencySpec<?, CV> dependency, SimpleInputResolverSpec<S, T> resolverSpec) {
+      VajramDependencySpec<?, CV, DV> dependency,
+      SimpleInputResolverSpec<S, T, CV, DV> resolverSpec) {
     super(
         ofNullable(resolverSpec.getSourceInput()).stream()
             .map(VajramFacetSpec::name)
@@ -41,11 +44,11 @@ public final class SimpleInputResolver<S, T, CV extends Vajram<?>> extends Abstr
     this.resolverSpec = resolverSpec;
   }
 
-  public VajramDependencySpec<?, ?> getDependency() {
+  public VajramDependencySpec<?, ?, ?> getDependency() {
     return dependency;
   }
 
-  public SimpleInputResolverSpec<?, ?> getResolverSpec() {
+  public SimpleInputResolverSpec<?, ?, ?, ?> getResolverSpec() {
     return resolverSpec;
   }
 

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/SimpleInputResolverSpec.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/facets/resolution/SimpleInputResolverSpec.java
@@ -1,5 +1,6 @@
 package com.flipkart.krystal.vajram.facets.resolution;
 
+import com.flipkart.krystal.vajram.VajramRequest;
 import com.flipkart.krystal.vajram.facets.VajramFacetSpec;
 import java.util.Collection;
 import java.util.List;
@@ -17,10 +18,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <DV> The type of the vajram whose input is being resolved.
  */
 @Getter
-public final class SimpleInputResolverSpec<S, T> {
+public final class SimpleInputResolverSpec<
+    S, T, CV extends VajramRequest<?>, DV extends VajramRequest<?>> {
 
-  private final VajramFacetSpec<T> targetInput;
-  @Nullable private final VajramFacetSpec<S> sourceInput;
+  private final VajramFacetSpec<T, DV> targetInput;
+  @Nullable private final VajramFacetSpec<S, CV> sourceInput;
   private final List<SkipPredicate<S>> skipConditions;
   @Nullable private final Function<Optional<S>, @Nullable T> transformer;
 
@@ -28,8 +30,8 @@ public final class SimpleInputResolverSpec<S, T> {
   private final Function<Optional<S>, ? extends Collection<? extends T>> fanoutTransformer;
 
   SimpleInputResolverSpec(
-      VajramFacetSpec<T> targetInput,
-      @Nullable VajramFacetSpec<S> sourceInput,
+      VajramFacetSpec<T, DV> targetInput,
+      @Nullable VajramFacetSpec<S, CV> sourceInput,
       List<SkipPredicate<S>> skipConditions,
       @Nullable Function<Optional<S>, @Nullable T> transformer,
       @Nullable Function<Optional<S>, ? extends Collection<? extends T>> fanoutTransformer) {

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/Constants.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/Constants.java
@@ -17,8 +17,8 @@ public final class Constants {
   public static final String MAP = "map";
   public static final String LIST = "list";
   public static final String INPUT_DEFINITIONS_VAR = "inputDefinitions";
-  public static final String INPUT_NAME_SUFFIX = "_n";
-  public static final String INPUT_SPEC_SUFFIX = "_s";
+  public static final String FACET_NAME_SUFFIX = "_n";
+  public static final String FACET_SPEC_SUFFIX = "_s";
 
   public static final char DOT_SEPARATOR = '.';
 

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/Utils.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/Utils.java
@@ -231,7 +231,7 @@ public class Utils {
       VajramInfoLite depVajramId = getVajramInfoLite(vajramOrReqElement);
       depBuilder
           .depVajramId(vajramID(depVajramId.vajramId()))
-          .depReqClassName(getVajramReqClassName(vajramOrReqElement))
+          .depReqClassQualifiedName(getVajramReqClassName(vajramOrReqElement))
           .canFanout(dependency.canFanout());
       if (!declaredDataType.equals(depVajramId.responseType())) {
         error(
@@ -280,7 +280,7 @@ public class Utils {
 
   private String getVajramReqClassName(TypeElement vajramClass) {
     if (isRawAssignable(vajramClass.asType(), Vajram.class)) {
-      return vajramClass.getQualifiedName().toString() + "Request";
+      return vajramClass.getQualifiedName().toString() + REQUEST_SUFFIX;
     } else if (isRawAssignable(vajramClass.asType(), VajramRequest.class)) {
       return vajramClass.getQualifiedName().toString();
     } else {

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
@@ -5,6 +5,8 @@ import static com.flipkart.krystal.vajram.codegen.Constants.COMMON_INPUT;
 import static com.flipkart.krystal.vajram.codegen.Constants.COM_FUTURE;
 import static com.flipkart.krystal.vajram.codegen.Constants.DEP_RESP;
 import static com.flipkart.krystal.vajram.codegen.Constants.DEP_RESPONSE;
+import static com.flipkart.krystal.vajram.codegen.Constants.FACET_NAME_SUFFIX;
+import static com.flipkart.krystal.vajram.codegen.Constants.FACET_SPEC_SUFFIX;
 import static com.flipkart.krystal.vajram.codegen.Constants.FUNCTION;
 import static com.flipkart.krystal.vajram.codegen.Constants.GET_INPUT_DEFINITIONS;
 import static com.flipkart.krystal.vajram.codegen.Constants.HASH_MAP;
@@ -17,8 +19,6 @@ import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_DEFINITIONS_VA
 import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_MODULATION;
 import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_MODULATION_CODE_BLOCK;
 import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_MODULATION_FUTURE_CODE_BLOCK;
-import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_NAME_SUFFIX;
-import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_SPEC_SUFFIX;
 import static com.flipkart.krystal.vajram.codegen.Constants.INPUT_SRC;
 import static com.flipkart.krystal.vajram.codegen.Constants.LINK_HASH_MAP;
 import static com.flipkart.krystal.vajram.codegen.Constants.LIST;
@@ -370,7 +370,7 @@ public class VajramCodeGenerator {
             inputDef -> {
               if (inputDef instanceof DependencyModel dependencyModel) {
                 VajramID depVajramId = dependencyModel.depVajramId();
-                String depRequestClass = dependencyModel.depReqClassName();
+                String depRequestClass = dependencyModel.depReqClassQualifiedName();
                 VajramInfoLite depVajramInfo =
                     checkNotNull(
                         vajramDefs.get(depVajramId),
@@ -805,8 +805,7 @@ public class VajramCodeGenerator {
               vajramDefs.get(dependencyModel.depVajramId()),
               "Could not find parsed vajram data for class %s",
               dependencyModel.depVajramId());
-      String requestClass = dependencyModel.depReqClassName();
-
+      String requestClass = dependencyModel.depReqClassQualifiedName();
       TypeName boxedDepType = util.toTypeName(vajramInfoLite.responseType()).box();
       TypeName unboxedDepType =
           boxedDepType.isBoxedPrimitive() ? boxedDepType.unbox() : boxedDepType;
@@ -1195,14 +1194,14 @@ public class VajramCodeGenerator {
       String facetJavaName = toJavaName(facet.name());
       TypeAndName facetType = getTypeName(getDataType(facet));
       TypeAndName boxedFacetType = boxPrimitive(facetType);
-      ClassName vajramClassName = ClassName.get(packageName, vajramName);
-
-      String inputNameFieldName = facetJavaName + INPUT_NAME_SUFFIX;
+      ClassName vajramReqClass = ClassName.get(packageName, requestClassName);
+      String inputNameFieldName = facetJavaName + FACET_NAME_SUFFIX;
       FieldSpec.Builder inputNameField =
           FieldSpec.builder(String.class, inputNameFieldName).initializer("\"$L\"", facet.name());
 
       FieldSpec.Builder inputSpecField;
       if (facet instanceof DependencyModel vajramDepDef) {
+        ClassName depReqClass = ClassName.bestGuess(vajramDepDef.depReqClassQualifiedName());
         ClassName specType =
             ClassName.get(
                 vajramDepDef.canFanout()
@@ -1210,18 +1209,29 @@ public class VajramCodeGenerator {
                     : VajramDepSingleTypeSpec.class);
         inputSpecField =
             FieldSpec.builder(
-                    ParameterizedTypeName.get(specType, boxedFacetType.typeName(), vajramClassName),
-                    facetJavaName + INPUT_SPEC_SUFFIX)
+                    ParameterizedTypeName.get(
+                        specType, boxedFacetType.typeName(), vajramReqClass, depReqClass),
+                    facetJavaName + FACET_SPEC_SUFFIX)
                 .initializer(
-                    "new $T<>($L, $T.class)", specType, inputNameFieldName, vajramClassName);
+                    "new $T<>($L, $T.class, $T.class)",
+                    specType,
+                    inputNameFieldName,
+                    vajramReqClass,
+                    depReqClass);
 
       } else {
         inputSpecField =
             FieldSpec.builder(
                     ParameterizedTypeName.get(
-                        ClassName.get(VajramFacetSpec.class), boxedFacetType.typeName()),
-                    facetJavaName + INPUT_SPEC_SUFFIX)
-                .initializer("new $T<>($L)", VajramFacetSpec.class, inputNameFieldName);
+                        ClassName.get(VajramFacetSpec.class),
+                        boxedFacetType.typeName(),
+                        vajramReqClass),
+                    facetJavaName + FACET_SPEC_SUFFIX)
+                .initializer(
+                    "new $T<>($L, $T.class)",
+                    VajramFacetSpec.class,
+                    inputNameFieldName,
+                    vajramReqClass);
       }
       inputNameFields.add(inputNameField.addModifiers(STATIC, FINAL));
       inputSpecFields.add(inputSpecField.addModifiers(STATIC, FINAL));
@@ -1546,7 +1556,7 @@ public class VajramCodeGenerator {
       return new TypeAndName(
           ParameterizedTypeName.get(
               ClassName.get(DependencyResponse.class),
-              toClassName(dependencyDef.depReqClassName()),
+              toClassName(dependencyDef.depReqClassQualifiedName()),
               boxPrimitive(getTypeName(depResponseType)).typeName()));
     } else {
       return getTypeName(depResponseType, List.of(AnnotationSpec.builder(Nullable.class).build()));

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/models/DependencyModel.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/models/DependencyModel.java
@@ -10,7 +10,7 @@ public record DependencyModel(
     String name,
     VajramID depVajramId,
     DataType<?> responseType,
-    String depReqClassName,
+    String depReqClassQualifiedName,
     boolean isMandatory,
     boolean canFanout,
     String documentation,

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
@@ -316,7 +316,7 @@ public final class VajramKryonGraph implements VajramExecutableGraph {
                                 DependencyCommand<Inputs> dependencyCommand;
                                 try {
                                   if (inputResolverDefinition
-                                      instanceof SimpleInputResolver<?, ?, ?> inputResolver) {
+                                      instanceof SimpleInputResolver<?, ?, ?, ?> inputResolver) {
                                     ResolutionResult resolutionResult =
                                         multiResolve(
                                             List.of(
@@ -377,9 +377,7 @@ public final class VajramKryonGraph implements VajramExecutableGraph {
               for (DependencyResolutionRequest resolutionRequest : resolutionRequests) {
                 Set<ResolverDefinition> resolverDefinitions =
                     resolutionRequest.resolverDefinitions();
-                for (ResolverDefinition definition : resolverDefinitions) {
-                  allResolverDefs.add(definition);
-                }
+                allResolverDefs.addAll(resolverDefinitions);
               }
               Map<String, List<ResolverDefinition>> simpleResolverDefsByDep = new HashMap<>();
               List<ResolverDefinition> complexResolverDefs = new ArrayList<>();
@@ -419,7 +417,7 @@ public final class VajramKryonGraph implements VajramExecutableGraph {
                                                           () ->
                                                               new AssertionError(
                                                                   "Could not find resolver for resolver definition. This should not happen")))
-                                          .map(ird -> (SimpleInputResolver<?, ?, ?>) ird)
+                                          .map(ird -> (SimpleInputResolver<?, ?, ?, ?>) ird)
                                           .toList())),
                       inputs);
               Map<String, List<Map<String, @Nullable Object>>> results =
@@ -610,16 +608,16 @@ public final class VajramKryonGraph implements VajramExecutableGraph {
 
   private ImmutableMap<String, KryonId> createKryonDefinitionsForDependencies(
       VajramDefinition vajramDefinition) {
-    List<Dependency> dependencies = new ArrayList<>();
+    List<Dependency<?>> dependencies = new ArrayList<>();
     for (VajramFacetDefinition vajramInputDefinition :
         vajramDefinition.getVajram().getInputDefinitions()) {
-      if (vajramInputDefinition instanceof Dependency definition) {
+      if (vajramInputDefinition instanceof Dependency<?> definition) {
         dependencies.add(definition);
       }
     }
     Map<String, KryonId> depNameToProviderKryon = new HashMap<>();
     // Create and register sub graphs for dependencies of this vajram
-    for (Dependency dependency : dependencies) {
+    for (Dependency<?> dependency : dependencies) {
       var accessSpec = dependency.dataAccessSpec();
       String dependencyName = dependency.name();
       AccessSpecMatchingResult<DataAccessSpec> accessSpecMatchingResult =

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/testharness/VajramPrimer.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/testharness/VajramPrimer.java
@@ -38,7 +38,7 @@ public class VajramPrimer extends AbstractKryonDecorator {
   private final ImmutableMap<Inputs, ValueOrError<Object>> executionStubs;
   private final VajramID decoratedVajramId;
   private final boolean failIfMockMissing;
-  @MonotonicNonNull private DecoratedKryon decoratedKryon;
+  private @MonotonicNonNull DecoratedKryon decoratedKryon;
 
   public <T> VajramPrimer(
       VajramID mockedVajramId,

--- a/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/test_vajrams/hellofriends/HelloFriends.java
+++ b/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/test_vajrams/hellofriends/HelloFriends.java
@@ -3,11 +3,11 @@ package com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.dep;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.depInput;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.resolve;
+import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends.HelloFriendsInputUtil.userInfo_s;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends.HelloFriendsRequest.friendInfos_n;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends.HelloFriendsRequest.numberOfFriends_n;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends.HelloFriendsRequest.userId_n;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends.HelloFriendsRequest.userId_s;
-import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriends.HelloFriendsRequest.userInfo_s;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 

--- a/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/test_vajrams/hellofriendsv2/HelloFriendsV2.java
+++ b/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/test_vajrams/hellofriendsv2/HelloFriendsV2.java
@@ -5,9 +5,9 @@ import static com.flipkart.krystal.vajram.facets.SingleExecute.executeWith;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.dep;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.fanout;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.resolve;
+import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriendsv2.HelloFriendsV2InputUtil.friendIds_s;
+import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriendsv2.HelloFriendsV2InputUtil.friendInfos_s;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriendsv2.HelloFriendsV2Request.friendIds_n;
-import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriendsv2.HelloFriendsV2Request.friendIds_s;
-import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriendsv2.HelloFriendsV2Request.friendInfos_s;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hellofriendsv2.HelloFriendsV2Request.userId_n;
 import static java.util.stream.Collectors.joining;
 

--- a/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/test_vajrams/multihello/MultiHelloFriends.java
+++ b/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/test_vajrams/multihello/MultiHelloFriends.java
@@ -5,7 +5,7 @@ import static com.flipkart.krystal.vajram.facets.MultiExecute.skipFanout;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.dep;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.fanout;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.resolve;
-import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.multihello.MultiHelloFriendsRequest.hellos_s;
+import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.multihello.MultiHelloFriendsInputUtil.hellos_s;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.multihello.MultiHelloFriendsRequest.userIds_s;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.multihellov2.MultiHelloFriendsV2Request.skip_n;
 import static com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.multihellov2.MultiHelloFriendsV2Request.userIds_n;

--- a/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/benchmarks/calculator/Formula.java
+++ b/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/benchmarks/calculator/Formula.java
@@ -3,11 +3,11 @@ package com.flipkart.krystal.vajram.samples.benchmarks.calculator;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.dep;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.depInput;
 import static com.flipkart.krystal.vajram.facets.resolution.InputResolvers.resolve;
+import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaInputUtil.quotient_s;
+import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaInputUtil.sum_s;
 import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaRequest.a_s;
 import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaRequest.p_s;
 import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaRequest.q_s;
-import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaRequest.quotient_s;
-import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.FormulaRequest.sum_s;
 
 import com.flipkart.krystal.vajram.ComputeVajram;
 import com.flipkart.krystal.vajram.Dependency;
@@ -52,7 +52,7 @@ public abstract class Formula extends ComputeVajram<Integer> {
   }
 
   @VajramLogic
-  public static int result(FormulaInputs allInputs) {
+  static int result(FormulaInputs allInputs) {
     /* Return quotient */
     return allInputs.quotient();
   }

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/benchmarks/calculator/FormulaTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/benchmarks/calculator/FormulaTest.java
@@ -8,6 +8,7 @@ import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.adder.Ad
 import static com.flipkart.krystal.vajram.samples.benchmarks.calculator.divider.Divider.divide;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flipkart.krystal.data.ValueOrError;
@@ -51,7 +52,7 @@ class FormulaTest {
   }
 
   @Test
-  void formula_success() throws Exception {
+  void formula_success() {
     CompletableFuture<Integer> future;
     VajramKryonGraph graph = this.graph.build();
     graph.registerInputModulators(
@@ -61,7 +62,8 @@ class FormulaTest {
         graph.createExecutor(new FormulaRequestContext(100, 20, 5, REQUEST_ID))) {
       future = executeVajram(krystexVajramExecutor, 0);
     }
-    assertThat(future.get()).isEqualTo(4);
+    //noinspection AssertBetweenInconvertibleTypes https://youtrack.jetbrains.com/issue/IDEA-342354
+    assertThat(future).succeedsWithin(1, SECONDS).isEqualTo(4);
     assertThat(Adder.CALL_COUNTER.sum()).isEqualTo(1);
   }
 


### PR DESCRIPTION
Changes made in Krystal 5 removed vajram type safety in facet specs to avoid dependency Vajram classes polluting classpaths of dependent Vajrams.
This PR brings back that type safety, but using VajramRequest instead of Vajram to avoid classpath pollution.

This PR also moves Dependency specs from Request class to InputUtil class to avoid dependency VajramRequest classes polluting classpath.