### PR TITLE
Mojo plugin to avoid computation of recursive dependency project

### DIFF
--- a/mojo-publish-plugin/build.gradle
+++ b/mojo-publish-plugin/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.flipkart.mojopublish'
-version '1.1.0-SNAPSHOT'
+version '1.1.1'
 
 gradlePlugin {
     plugins {

--- a/mojo-publish-plugin/src/main/java/com/flipkart/krystal/mojo/Publisher.java
+++ b/mojo-publish-plugin/src/main/java/com/flipkart/krystal/mojo/Publisher.java
@@ -371,6 +371,10 @@ final class Publisher {
               .<Set<ProjectDependency>>map(d -> d.withType(ProjectDependency.class))
               .flatMap(Collection::stream)
               .map(ProjectDependency::getDependencyProject)
+              // to avoid cases where the project depends on itself for runtime image creation or
+              // any other tasks. Cyclic dependencies need not to be checked here as that would
+              // be taken care of by gradle itslef.
+              .filter(p -> !p.equals(project))
               .collect(Collectors.toSet());
       projectDependencies.put(project, allProjectDependencies);
       allProjectDependencies.forEach(


### PR DESCRIPTION
Mojo plugin was getting into infinite recursion because of the project depending on itself for image formation plugins. So this PR is to filter the dependent project if it depends on itself.