### PR TITLE
Add `-parameters` compiler arg to compilation stage

### DIFF
--- a/vajram/src/main/java/com/flipkart/krystal/vajram/exec/VajramDefinition.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/exec/VajramDefinition.java
@@ -30,7 +30,6 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -116,18 +115,14 @@ public final class VajramDefinition {
       String[] targetInputs = resolver.depInputs();
       ImmutableSet<String> sources =
           Arrays.stream(resolverMethod.getParameters())
-              .map(Parameter::getAnnotations)
               .map(
-                  annotations ->
-                      Arrays.stream(annotations)
+                  parameter ->
+                      Arrays.stream(parameter.getAnnotations())
                           .filter(annotation -> annotation instanceof Using)
                           .map(annotation -> (Using) annotation)
-                          .findAny())
-              .filter(Optional::isPresent)
-              .map(Optional::orElseThrow)
-              .toList()
-              .stream()
-              .map(Using::value)
+                          .findAny()
+                          .map(Using::value)
+                          .orElseGet(parameter::getName))
               .collect(toImmutableSet());
       inputResolvers.add(
           new DefaultInputResolverDefinition(

--- a/vajram/vajram-codegen/src/main/groovy/com/flipkart/krystal/vajram/VajramPlugin.groovy
+++ b/vajram/vajram-codegen/src/main/groovy/com/flipkart/krystal/vajram/VajramPlugin.groovy
@@ -63,7 +63,17 @@ class VajramPlugin implements Plugin<Project> {
 
         project.tasks.named('compileJava', JavaCompile).configure {
             dependsOn 'codeGenVajramModels'
-            options.compilerArgs += ['-A' + COGENGEN_PHASE_KEY + '=' + IMPLS]
+
+            options.compilerArgs += [
+
+                    // So that vajram impls are generated during compilation
+                    '-A' + COGENGEN_PHASE_KEY + '=' + IMPLS,
+
+                    // So that @Resolver method param names can be read at runtime
+                    // in case @Using annotation has not been used on the parameters
+                    // See VajramDefinition#parseInputResolvers
+                    '-parameters'
+            ]
         }
 
         project.tasks.register('testCodeGenVajramModels', JavaCompile) {

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/VajramCodeGenerator.java
@@ -86,7 +86,6 @@ import com.flipkart.krystal.vajram.facets.InputDef;
 import com.flipkart.krystal.vajram.facets.InputSource;
 import com.flipkart.krystal.vajram.facets.MultiExecute;
 import com.flipkart.krystal.vajram.facets.SingleExecute;
-import com.flipkart.krystal.vajram.facets.Using;
 import com.flipkart.krystal.vajram.facets.VajramDepFanoutTypeSpec;
 import com.flipkart.krystal.vajram.facets.VajramDepSingleTypeSpec;
 import com.flipkart.krystal.vajram.facets.VajramFacetDefinition;

--- a/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/greeting/Greeting.java
+++ b/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/greeting/Greeting.java
@@ -1,6 +1,5 @@
 package com.flipkart.krystal.vajram.samples.greeting;
 
-import static com.flipkart.krystal.vajram.samples.greeting.GreetingRequest.userId_n;
 import static com.flipkart.krystal.vajram.samples.greeting.GreetingRequest.userInfo_n;
 
 import com.flipkart.krystal.vajram.ComputeVajram;
@@ -8,7 +7,6 @@ import com.flipkart.krystal.vajram.Dependency;
 import com.flipkart.krystal.vajram.Input;
 import com.flipkart.krystal.vajram.Output;
 import com.flipkart.krystal.vajram.VajramDef;
-import com.flipkart.krystal.vajram.facets.Using;
 import com.flipkart.krystal.vajram.facets.resolution.sdk.Resolve;
 import com.flipkart.krystal.vajram.samples.greeting.GreetingFacetUtil.GreetingFacets;
 import jakarta.inject.Inject;


### PR DESCRIPTION
So that resolver param names can be accessed at runtime in case `@Using` annotation is missing