### PR TITLE
Handle generic error handling for executeCompute, decorator.executeCommand and in BatchingDecorator

### DIFF
--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchKryon.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchKryon.java
@@ -548,8 +548,8 @@ final class BatchKryon extends AbstractKryon<BatchCommand, BatchResponse> {
           log.error(
               """
                   Error while flushing decorator: {}. \
-                  This is most probably a bug, and \
-                  can cause unpredictable behaviour in the krystal graph execution. \
+                  This is most probably a bug since decorator methods are not supposed to throw exceptions. \
+                  This can cause unpredictable behaviour in the krystal graph execution. \
                   Please fix!""",
               decorator,
               e);

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/ComputeVajram.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/ComputeVajram.java
@@ -1,8 +1,6 @@
 package com.flipkart.krystal.vajram;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.concurrent.CompletableFuture.failedFuture;
-import static java.util.function.Function.identity;
 
 import com.flipkart.krystal.data.Errable;
 import com.flipkart.krystal.data.Facets;
@@ -28,12 +26,8 @@ public abstract non-sealed class ComputeVajram<T> extends AbstractVajram<T> {
   @Override
   public final ImmutableMap<Facets, CompletableFuture<@Nullable T>> execute(
       ImmutableList<Facets> facetsList) {
-    try {
-      return executeCompute(facetsList).entrySet().stream()
-          .collect(toImmutableMap(Entry::getKey, ComputeVajram::toFuture));
-    } catch (Throwable e) {
-      return facetsList.stream().collect(toImmutableMap(identity(), i -> failedFuture(e)));
-    }
+    return executeCompute(facetsList).entrySet().stream()
+        .collect(toImmutableMap(Entry::getKey, ComputeVajram::toFuture));
   }
 
   private static <T> CompletableFuture<@Nullable T> toFuture(Entry<Facets, Errable<T>> e) {

--- a/vajram/src/main/java/com/flipkart/krystal/vajram/MandatoryFacetsMissingException.java
+++ b/vajram/src/main/java/com/flipkart/krystal/vajram/MandatoryFacetsMissingException.java
@@ -33,7 +33,7 @@ public class MandatoryFacetsMissingException extends RuntimeException {
                 failedMandatoryInputs.keySet().stream()
                     .map(
                         s ->
-                            "%s (Cause: %s)"
+                            "'%s' (Cause: %s)"
                                 .formatted(
                                     s,
                                     String.valueOf(

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
@@ -490,7 +490,7 @@ public final class VajramKryonGraph implements VajramExecutableGraph {
                 .error()
                 .orElse(
                     new NoSuchElementException(
-                        "No value present for input %s".formatted(mandatoryInput.name()))));
+                        "No value present for input '%s'".formatted(mandatoryInput.name()))));
       }
     }
     if (missingMandatoryValues.isEmpty()) {
@@ -529,8 +529,13 @@ public final class VajramKryonGraph implements VajramExecutableGraph {
                   });
               @SuppressWarnings("unchecked")
               Vajram<Object> vajram = (Vajram<Object>) vajramDefinition.getVajram();
-              ImmutableMap<Facets, CompletableFuture<@Nullable Object>> validResults =
-                  vajram.execute(ImmutableList.copyOf(validInputs));
+              ImmutableMap<Facets, CompletableFuture<@Nullable Object>> validResults;
+              try {
+                validResults = vajram.execute(ImmutableList.copyOf(validInputs));
+              } catch (Throwable e) {
+                return validInputs.stream()
+                    .collect(toImmutableMap(identity(), i -> failedFuture(e)));
+              }
 
               return ImmutableMap.<Facets, CompletableFuture<@Nullable Object>>builder()
                   .putAll(validResults)

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/testharness/VajramTestHarness.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/testharness/VajramTestHarness.java
@@ -24,15 +24,16 @@ public class VajramTestHarness {
 
   @Inject
   public VajramTestHarness(
-      KrystexVajramExecutorConfig kryonExecutorBuilder, RequestLevelCache requestLevelCache) {
-    this.kryonExecutorConfigBuilder = kryonExecutorBuilder;
+      KrystexVajramExecutorConfig krystexVajramExecutorConfig,
+      RequestLevelCache requestLevelCache) {
+    this.kryonExecutorConfigBuilder = krystexVajramExecutorConfig;
     this.requestLevelCache = requestLevelCache;
     this.vajramIdMockData = new HashMap<>();
   }
 
   public static VajramTestHarness prepareForTest(
-      KrystexVajramExecutorConfig kryonExecutorBuilder, RequestLevelCache requestLevelCache) {
-    return new VajramTestHarness(kryonExecutorBuilder, requestLevelCache);
+      KrystexVajramExecutorConfig executorConfig, RequestLevelCache requestLevelCache) {
+    return new VajramTestHarness(executorConfig, requestLevelCache);
   }
 
   @SuppressWarnings("unchecked")

--- a/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexVajramExecutorTest.java
+++ b/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexVajramExecutorTest.java
@@ -308,7 +308,7 @@ class KrystexVajramExecutorTest {
         .withMessageContaining(
             "Vajram v<"
                 + getVajramIdString(Hello.class)
-                + "> did not receive these mandatory inputs: [ name");
+                + "> did not receive these mandatory inputs: [ 'name'");
   }
 
   @ParameterizedTest

--- a/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/calculator/adder/Adder.java
+++ b/vajram/vajram-samples/src/main/java/com/flipkart/krystal/vajram/samples/calculator/adder/Adder.java
@@ -1,9 +1,10 @@
 package com.flipkart.krystal.vajram.samples.calculator.adder;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 
-import com.flipkart.krystal.vajram.ComputeVajram;
+import com.flipkart.krystal.vajram.IOVajram;
 import com.flipkart.krystal.vajram.Input;
 import com.flipkart.krystal.vajram.Output;
 import com.flipkart.krystal.vajram.VajramDef;
@@ -11,26 +12,41 @@ import com.flipkart.krystal.vajram.batching.Batch;
 import com.flipkart.krystal.vajram.batching.BatchedFacets;
 import com.flipkart.krystal.vajram.samples.calculator.adder.AdderFacetUtil.AdderCommonFacets;
 import com.flipkart.krystal.vajram.samples.calculator.adder.AdderFacetUtil.AdderInputBatch;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.LongAdder;
 
 @VajramDef
 @SuppressWarnings("initialization.field.uninitialized")
-public abstract class Adder extends ComputeVajram<Integer> {
+public abstract class Adder extends IOVajram<Integer> {
+
+  public static final String FAIL_ADDER_FLAG = "failAdder";
+
   static class _Facets {
     @Batch @Input int numberOne;
     @Batch @Input Optional<Integer> numberTwo;
+
+    @Inject
+    @Named(FAIL_ADDER_FLAG)
+    Optional<Boolean> fail;
   }
 
   public static final LongAdder CALL_COUNTER = new LongAdder();
 
   @Output
-  static Map<AdderInputBatch, Integer> add(
+  static Map<AdderInputBatch, CompletableFuture<Integer>> add(
       BatchedFacets<AdderInputBatch, AdderCommonFacets> batchedFacets) {
+    if (batchedFacets.commonFacets().fail().orElse(false)) {
+      throw new RuntimeException("Adder failed because fail flag was set");
+    }
     CALL_COUNTER.increment();
     return batchedFacets.batchedInputs().stream()
-        .collect(toImmutableMap(identity(), im -> add(im.numberOne(), im.numberTwo().orElse(0))));
+        .collect(
+            toImmutableMap(
+                identity(), im -> completedFuture(add(im.numberOne(), im.numberTwo().orElse(0)))));
   }
 
   public static int add(int a, int b) {

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/A2MinusB2Test.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/A2MinusB2Test.java
@@ -32,7 +32,6 @@ class A2MinusB2Test {
         graph.createExecutor(KrystexVajramExecutorConfig.builder().requestId(REQUEST_ID).build())) {
       future = executeVajram(krystexVajramExecutor, A2MinusB2Request.builder().a(3).b(2).build());
     }
-    //noinspection AssertBetweenInconvertibleTypes https://youtrack.jetbrains.com/issue/IDEA-342354
     assertThat(future).succeedsWithin(1, HOURS).isEqualTo(2);
   }
 

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/greeting/GreetingTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/greeting/GreetingTest.java
@@ -6,6 +6,7 @@ import static com.flipkart.krystal.vajram.VajramID.vajramID;
 import static com.flipkart.krystal.vajram.Vajrams.getVajramIdString;
 import static com.google.inject.Guice.createInjector;
 import static java.lang.System.*;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
@@ -53,7 +54,7 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class GreetingVajramTest {
+class GreetingTest {
 
   private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
@@ -134,7 +135,9 @@ class GreetingVajramTest {
                     .build())) {
       future = executeVajram(krystexVajramExecutor, requestContext);
     }
-    assertThat(future.get()).contains(USER_ID);
+    assertThat(future)
+        .succeedsWithin(1, SECONDS)
+        .isEqualTo("Hello Firstname Lastname (user@123)! Hope you are doing well!");
     assertThat(analyticsEventSink.events).hasSize(1);
     out.println(
         objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(kryonExecutionReport));
@@ -182,8 +185,7 @@ class GreetingVajramTest {
             vajramKryonGraph.createExecutor(
                 VajramTestHarness.prepareForTest(
                         executorConfig
-                            .inputInjectionProvider(
-                                new VajramGuiceInjector(injector))
+                            .inputInjectionProvider(new VajramGuiceInjector(injector))
                             .build(),
                         requestLevelCache)
                     .withMock(
@@ -211,8 +213,7 @@ class GreetingVajramTest {
             vajramKryonGraph.createExecutor(
                 VajramTestHarness.prepareForTest(
                         executorConfig
-                            .inputInjectionProvider(
-                                new VajramGuiceInjector(injector))
+                            .inputInjectionProvider(new VajramGuiceInjector(injector))
                             .build(),
                         requestLevelCache)
                     .withMock(


### PR DESCRIPTION
so that the case where execute method of IOVajram with configured Batcher throwing an exception causes the graph to hang.