### PR TITLE
Task scoped injection

### DIFF
--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
@@ -104,7 +104,8 @@ public class RequestLevelCache implements KryonDecorator {
                   forwardBatch.inputNames(),
                   ImmutableMap.copyOf(cacheMisses),
                   forwardBatch.dependantChain(),
-                  ImmutableMap.copyOf(skippedRequests)));
+                  ImmutableMap.copyOf(skippedRequests),
+                  forwardBatch.providersForRequests()));
 
       cacheMissesResponse.whenComplete(
           (kryonResponse, throwable) -> {

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/commands/ForwardBatch.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/commands/ForwardBatch.java
@@ -3,6 +3,7 @@ package com.flipkart.krystal.krystex.commands;
 import com.flipkart.krystal.data.Facets;
 import com.flipkart.krystal.krystex.kryon.DependantChain;
 import com.flipkart.krystal.krystex.kryon.KryonId;
+import com.flipkart.krystal.krystex.providers.Providers;
 import com.flipkart.krystal.krystex.request.RequestId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -14,7 +15,8 @@ public record ForwardBatch(
     ImmutableSet<String> inputNames,
     ImmutableMap<RequestId, Facets> executableRequests,
     DependantChain dependantChain,
-    ImmutableMap<RequestId, String> skippedRequests)
+    ImmutableMap<RequestId, String> skippedRequests,
+    ImmutableMap<RequestId, Providers> providersForRequests)
     implements BatchCommand {
 
   @Override

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonExecutionConfig.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonExecutionConfig.java
@@ -1,12 +1,15 @@
 package com.flipkart.krystal.krystex.kryon;
 
+import com.flipkart.krystal.krystex.providers.Providers;
 import com.google.common.collect.ImmutableSet;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record KryonExecutionConfig(
-    String executionId, ImmutableSet<DependantChain> disabledDependantChains) {
+    String executionId,
+    ImmutableSet<DependantChain> disabledDependantChains,
+    Providers providersForRequest) {
 
   private static final AtomicLong EXEC_COUNT = new AtomicLong();
 

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/providers/Provider.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/providers/Provider.java
@@ -1,0 +1,5 @@
+package com.flipkart.krystal.krystex.providers;
+
+public interface Provider<T> {
+  T get();
+}

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/providers/Providers.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/providers/Providers.java
@@ -1,0 +1,26 @@
+package com.flipkart.krystal.krystex.providers;
+
+import java.util.Collections;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public record Providers(Map<Class<?>, Provider<?>> providersMap) {
+
+  public boolean containsProviderFor(Class<?> clazz) {
+    return providersMap.containsKey(clazz) && clazz.isInstance(providersMap.get(clazz).get());
+  }
+
+  public @Nullable Provider<?> getProviderFor(Class<?> clazz) {
+    if (!containsProviderFor(clazz)) {
+      throw new RuntimeException(
+          "Provider for the class "
+              + clazz.getSimpleName()
+              + " was not found or the wrong provider is mapped against this class");
+    }
+    return providersMap.get(clazz);
+  }
+
+  public static Providers empty() {
+    return new Providers(Collections.emptyMap());
+  }
+}

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/providers/Providers.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/providers/Providers.java
@@ -2,7 +2,7 @@ package com.flipkart.krystal.krystex.providers;
 
 import java.util.Collections;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import java.util.Optional;
 
 public record Providers(Map<Class<?>, Provider<?>> providersMap) {
 
@@ -10,14 +10,11 @@ public record Providers(Map<Class<?>, Provider<?>> providersMap) {
     return providersMap.containsKey(clazz) && clazz.isInstance(providersMap.get(clazz).get());
   }
 
-  public @Nullable Provider<?> getProviderFor(Class<?> clazz) {
+  public Optional<Provider<?>> getProviderFor(Class<?> clazz) {
     if (!containsProviderFor(clazz)) {
-      throw new RuntimeException(
-          "Provider for the class "
-              + clazz.getSimpleName()
-              + " was not found or the wrong provider is mapped against this class");
+      return Optional.empty();
     }
-    return providersMap.get(clazz);
+    return Optional.ofNullable(providersMap.get(clazz));
   }
 
   public static Providers empty() {

--- a/krystex/src/main/java/module-info.java
+++ b/krystex/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module flipkart.krystal.krystex {
       flipkart.krystal.vajramexecutor.krystex;
   exports com.flipkart.krystal.krystex.kryondecoration;
   exports com.flipkart.krystal.krystex.caching;
+  exports com.flipkart.krystal.krystex.providers;
 
   requires com.google.common;
   requires org.checkerframework.checker.qual;

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/inputinjection/InjectingDecoratedKryon.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/inputinjection/InjectingDecoratedKryon.java
@@ -109,7 +109,8 @@ class InjectingDecoratedKryon implements Kryon<KryonCommand, KryonResponse> {
             ImmutableSet.copyOf(newInputsNames),
             newRequests.build(),
             forwardBatch.dependantChain(),
-            forwardBatch.skippedRequests()));
+            forwardBatch.skippedRequests(),
+            forwardBatch.providersForRequests()));
   }
 
   private Facets injectFacetsOfVajram(


### PR DESCRIPTION
There are some "task" scoped variables which are a part of the defined inputs (InputSouce: CLIENT) and contribute to the hash-key object while caching the response of a Vajram. This leads to the wastage of resources as these variables unnecessarily increases the size of the hash-key object. Increase in number of Vajrams will also increase the wastage of memory as we will be storing more and more number of hash-key objects in-memory. 
So, to optimise the size of hash-key object, there is a need to somehow inject the "task" scoped variables as well (change the input source to SESSION) instead of having them as a part of the defined inputs.

Doing this will remove the "task" scoped variables from the hash-key objects, but they will still be available to use it in Vajrams.