### PR TITLE
Fix race condition when loading the kryon subgraph parallely just after VajramKryonGraph creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 **/.gradle/
 **/build/
+**/bin/
 
 ## From https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/LogicDefinitionRegistry.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/LogicDefinitionRegistry.java
@@ -3,17 +3,17 @@ package com.flipkart.krystal.krystex;
 import com.flipkart.krystal.krystex.kryon.KryonLogicId;
 import com.flipkart.krystal.krystex.resolution.MultiResolver;
 import com.flipkart.krystal.krystex.resolution.ResolverLogic;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class LogicDefinitionRegistry {
   private final Map<KryonLogicId, OutputLogicDefinition<?>> outputLogicDefinitions =
-      new HashMap<>();
+      new ConcurrentHashMap<>();
   private final Map<KryonLogicId, LogicDefinition<ResolverLogic>> resolverLogicDefinitions =
-      new HashMap<>();
+      new ConcurrentHashMap<>();
   private final Map<KryonLogicId, LogicDefinition<MultiResolver>> multiResolverDefinitions =
-      new HashMap<>();
+      new ConcurrentHashMap<>();
 
   @SuppressWarnings("unchecked")
   public <T> OutputLogicDefinition<T> getOutputLogic(KryonLogicId kryonLogicId) {

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinitionRegistry.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinitionRegistry.java
@@ -10,14 +10,14 @@ import com.flipkart.krystal.krystex.resolution.FacetsFromRequest;
 import com.flipkart.krystal.krystex.resolution.Resolver;
 import com.flipkart.krystal.tags.ElementTags;
 import com.google.common.collect.ImmutableMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class KryonDefinitionRegistry {
 
   private final LogicDefinitionRegistry logicDefinitionRegistry;
-  private final Map<KryonId, KryonDefinition> kryonDefinitions = new LinkedHashMap<>();
+  private final Map<KryonId, KryonDefinition> kryonDefinitions = new ConcurrentHashMap<>();
   private final DependantChainStart dependantChainStart = new DependantChainStart();
 
   public KryonDefinitionRegistry(LogicDefinitionRegistry logicDefinitionRegistry) {

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
@@ -86,8 +86,8 @@ public final class VajramKryonGraph implements VajramExecutableGraph<KrystexVajr
       new ConcurrentHashMap<>();
 
   /**
-   * Maps every vajram to its corresponding kryonId all whose dependencies have also been loaded
-   * recuresively. The mapped kryon id represents the complete executable sub-graph of the vajram
+   * Maps every vajramId to its corresponding kryonId all of whose dependencies have also been loaded
+   * recursively. The mapped kryon id represents the complete executable sub-graph of the vajram.
    */
   private final Map<VajramID, KryonId> vajramExecutables = new ConcurrentHashMap<>();
 

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramKryonGraph.java
@@ -86,8 +86,9 @@ public final class VajramKryonGraph implements VajramExecutableGraph<KrystexVajr
       new ConcurrentHashMap<>();
 
   /**
-   * Maps every vajramId to its corresponding kryonId all of whose dependencies have also been loaded
-   * recursively. The mapped kryon id represents the complete executable sub-graph of the vajram.
+   * Maps every vajramId to its corresponding kryonId all of whose dependencies have also been
+   * loaded recursively. The mapped kryon id represents the complete executable sub-graph of the
+   * vajram.
    */
   private final Map<VajramID, KryonId> vajramExecutables = new ConcurrentHashMap<>();
 
@@ -236,11 +237,16 @@ public final class VajramKryonGraph implements VajramExecutableGraph<KrystexVajr
     synchronized (vajramExecutables) {
       KryonId kryonId;
       if ((kryonId = vajramExecutables.get(vajramId)) != null) {
+        // This means the subgraph is already loaded.
         return kryonId;
       } else if ((kryonId = loadingInProgress.get(vajramId)) != null) {
+        // This means the subgraph is still being loaded, but there is a cyclic dependency. Just
+        // return the kryon to prevent infinite recursion.
         return kryonId;
       }
       kryonId = new KryonId(vajramId.vajramId());
+      // add to loadingInProgress so that this can be used to prevent infinite recursion in the
+      // cases where a vajram depends on itself in a cyclic dependency.
       loadingInProgress.put(vajramId, kryonId);
       VajramDefinition vajramDefinition =
           getVajramDefinition(vajramId)

--- a/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexVajramExecutorTest.java
+++ b/vajram/vajram-krystex/src/test/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexVajramExecutorTest.java
@@ -135,15 +135,14 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeCompute_noDependencies_success(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeCompute_noDependencies_success(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath("com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hello").build();
     CompletableFuture<String> result;
     requestContext.requestId("vajramWithNoDependencies");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId("vajramWithNoDependencies")
                 .build())) {
       result =
@@ -155,15 +154,14 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeCompute_optionalInputProvided_success(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeCompute_optionalInputProvided_success(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath("com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hello").build();
     CompletableFuture<String> result;
     requestContext.requestId("vajramWithNoDependencies");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       result =
@@ -176,8 +174,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeIo_singleRequestNoBatcher_success(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeIo_singleRequestNoBatcher_success(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath("com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.userservice")
             .build();
@@ -185,7 +182,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId("ioVajramSingleRequestNoBatcher");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       userInfo123 =
@@ -201,8 +198,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeIo_withBatcherMultipleRequests_calledOnlyOnce(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeIo_withBatcherMultipleRequests_calledOnlyOnce(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath(
                 "com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.userservice",
@@ -213,7 +209,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId("ioVajramWithBatcherMultipleRequests");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       helloString =
@@ -231,8 +227,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeCompute_sequentialDependency_success(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeCompute_sequentialDependency_success(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath(
                 "com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.userservice",
@@ -246,7 +241,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId("sequentialDependency");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       helloString =
@@ -262,8 +257,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeWithFacets_success(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeWithFacets_success(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath(
                 "com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.userservice",
@@ -277,7 +271,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId("sequentialDependency");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       helloString =
@@ -295,15 +289,14 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void executeCompute_missingMandatoryInput_throwsException(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void executeCompute_missingMandatoryInput_throwsException(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath("com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.hello").build();
     CompletableFuture<String> result;
     requestContext.requestId("vajramWithNoDependencies");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       result =
@@ -322,8 +315,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void execute_multiRequestNoInputBatcher_cacheHitSuccess(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void execute_multiRequestNoInputBatcher_cacheHitSuccess(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath(
                 "com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.userservice",
@@ -334,7 +326,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId("multiRequestNoInputBatcher_cacheHitSuccess");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       userInfo =
@@ -360,8 +352,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void execute_multiRequestWithBatcher_cacheHitSuccess(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  void execute_multiRequestWithBatcher_cacheHitSuccess(GraphTraversalStrategy graphTraversalStrategy) {
     graph =
         loadFromClasspath(
                 "com.flipkart.krystal.vajramexecutor.krystex.test_vajrams.userservice",
@@ -372,7 +363,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId("ioVajramSingleRequestNoBatcher");
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       userInfo =
@@ -404,8 +395,7 @@ class KrystexVajramExecutorTest {
 
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
-  void execute_multiResolverFanouts_permutesTheFanouts(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy)
+  void execute_multiResolverFanouts_permutesTheFanouts(GraphTraversalStrategy graphTraversalStrategy)
       throws Exception {
     graph =
         loadFromClasspath(
@@ -427,7 +417,7 @@ class KrystexVajramExecutorTest {
                 .kryonExecutorConfigBuilder(
                     KryonExecutorConfig.builder()
                         .singleThreadExecutor(executorLease.get())
-                        .kryonExecStrategy(kryonExecStrategy)
+                        .kryonExecStrategy(BATCH)
                         .graphTraversalStrategy(graphTraversalStrategy)
                         .requestScopedLogicDecoratorConfigs(
                             ImmutableMap.of(
@@ -462,7 +452,6 @@ class KrystexVajramExecutorTest {
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void flush_singleDepthParallelDependencyDefaultInputBatcherConfig_flushes2Batchers(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     graph =
@@ -478,7 +467,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -508,7 +497,6 @@ class KrystexVajramExecutorTest {
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void flush_singleDepthParallelDependencySharedInputBatcherConfig_flushes1Batcher(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     graph =
@@ -522,7 +510,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -553,34 +541,33 @@ class KrystexVajramExecutorTest {
             1);
   }
 
-  private KrystexVajramExecutorConfigBuilder getExecutorConfig(
-      KryonExecStrategy kryonExecStrategy, GraphTraversalStrategy graphTraversalStrategy) {
+  private KrystexVajramExecutorConfigBuilder getExecutorConfig(GraphTraversalStrategy graphTraversalStrategy) {
     KryonExecutorConfigBuilder kryonExecutorConfigBuilder =
         KryonExecutorConfig.builder()
-            .kryonExecStrategy(kryonExecStrategy)
+            .kryonExecStrategy(BATCH)
             .graphTraversalStrategy(graphTraversalStrategy)
             .logicDecorationOrdering(logicDecorationOrdering);
-    if (BATCH.equals(kryonExecStrategy)) {
-      RequestLevelCache requestLevelCache = new RequestLevelCache();
-      kryonExecutorConfigBuilder.requestScopedKryonDecoratorConfig(
-          RequestLevelCache.DECORATOR_TYPE,
-          new KryonDecoratorConfig(
-              RequestLevelCache.DECORATOR_TYPE,
-              executionContext -> true,
-              executionContext -> RequestLevelCache.DECORATOR_TYPE,
-              kryonDecoratorContext -> {
-                return requestLevelCache;
-              }));
-    }
+
+    RequestLevelCache requestLevelCache = new RequestLevelCache();
+    kryonExecutorConfigBuilder.requestScopedKryonDecoratorConfig(
+        RequestLevelCache.DECORATOR_TYPE,
+        new KryonDecoratorConfig(
+            RequestLevelCache.DECORATOR_TYPE,
+            executionContext -> true,
+            executionContext -> RequestLevelCache.DECORATOR_TYPE,
+            kryonDecoratorContext -> {
+              return requestLevelCache;
+            }));
+
     return KrystexVajramExecutorConfig.builder()
         .kryonExecutorConfigBuilder(
             kryonExecutorConfigBuilder.singleThreadExecutor(executorLease.get()));
   }
 
+
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void flush_singleDepthSkipParallelDependencySharedInputBatcherConfig_flushes1Batcher(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     graph =
@@ -595,7 +582,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -622,7 +609,6 @@ class KrystexVajramExecutorTest {
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void close_sequentialDependency_flushesBatcher(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     graph =
@@ -642,7 +628,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -664,7 +650,6 @@ class KrystexVajramExecutorTest {
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void flush_sequentialDependency_flushesSharedBatchers(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     graph =
@@ -679,7 +664,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -699,7 +684,6 @@ class KrystexVajramExecutorTest {
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void flush_sequentialSkipDependency_flushesSharedBatchers(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     graph =
@@ -714,7 +698,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -729,7 +713,6 @@ class KrystexVajramExecutorTest {
   @ParameterizedTest
   @MethodSource("executorConfigsToTest")
   void flush_skippingADependency_flushesCompleteCallGraph(
-      KryonExecStrategy kryonExecStrategy,
       GraphTraversalStrategy graphTraversalStrategy,
       TestInfo testInfo) {
     CompletableFuture<FlushCommand> friendServiceFlushCommand = new CompletableFuture<>();
@@ -797,7 +780,7 @@ class KrystexVajramExecutorTest {
     requestContext.requestId(testInfo.getDisplayName());
     try (KrystexVajramExecutor krystexVajramExecutor =
         graph.createExecutor(
-            getExecutorConfig(kryonExecStrategy, graphTraversalStrategy)
+            getExecutorConfig(graphTraversalStrategy)
                 .requestId(requestContext.requestId())
                 .build())) {
       multiHellos =
@@ -888,6 +871,6 @@ class KrystexVajramExecutorTest {
   }
 
   public static Stream<Arguments> executorConfigsToTest() {
-    return Stream.of(Arguments.of(BATCH, DEPTH), Arguments.of(BATCH, BREADTH));
+    return Stream.of(Arguments.of(DEPTH), Arguments.of(BREADTH));
   }
 }

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/FormulaTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/FormulaTest.java
@@ -157,10 +157,7 @@ class FormulaTest {
   void millionExecutors_oneCallEach_singleCore_benchmark() throws Exception {
     int loopCount = 1_000_000;
     SingleThreadExecutor executor = getExecutors(1)[0];
-    VajramKryonGraph graph =
-        this.graph
-            //        .maxParallelismPerCore(10)
-            .build();
+    VajramKryonGraph graph = this.graph.build();
     long javaNativeTimeNs = javaMethodBenchmark(FormulaTest::syncFormula, loopCount);
     long javaFuturesTimeNs = Util.javaFuturesBenchmark(FormulaTest::asyncFormula, loopCount);
     @SuppressWarnings("unchecked")
@@ -245,7 +242,7 @@ class FormulaTest {
         EXEC_POOL);
   }
 
-  @Disabled("Long running benchmark (~16s)")
+  //  @Disabled("Long running benchmark (~9s)")
   @Test
   void thousandExecutors_1000CallsEach_singleCore_benchmark() throws Exception {
     SingleThreadExecutor executor = getExecutors(1)[0];

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/FormulaTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/FormulaTest.java
@@ -9,9 +9,12 @@ import static com.flipkart.krystal.vajram.samples.calculator.divider.Divider.div
 import static com.google.inject.Guice.createInjector;
 import static com.google.inject.name.Names.named;
 import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.stream;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flipkart.krystal.concurrent.SingleThreadExecutor;
@@ -42,20 +45,33 @@ import com.flipkart.krystal.vajramexecutor.krystex.testharness.VajramTestHarness
 import com.google.inject.AbstractModule;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.LongAdder;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class FormulaTest {
 
+  public static final int MAX_THREADS = Runtime.getRuntime().availableProcessors();
+  private static final Lease<SingleThreadExecutor>[] EXECUTOR_LEASES = new Lease[MAX_THREADS];
   private static SingleThreadExecutorsPool EXEC_POOL;
 
   @BeforeAll
-  static void beforeAll() {
-    EXEC_POOL = new SingleThreadExecutorsPool("Test", Runtime.getRuntime().availableProcessors());
+  static void beforeAll() throws LeaseUnavailableException {
+    EXEC_POOL = new SingleThreadExecutorsPool("Test", MAX_THREADS);
+    for (int i = 0; i < MAX_THREADS; i++) {
+      EXECUTOR_LEASES[i] = EXEC_POOL.lease();
+    }
+  }
+
+  @AfterAll
+  static void afterAll() {
+    stream(EXECUTOR_LEASES).forEach(Lease::close);
   }
 
   private VajramKryonGraphBuilder graph;
@@ -65,15 +81,10 @@ class FormulaTest {
   private Lease<SingleThreadExecutor> executorLease;
 
   @BeforeEach
-  void setUp() throws LeaseUnavailableException {
-    this.executorLease = EXEC_POOL.lease();
+  void setUp() {
+    this.executorLease = EXECUTOR_LEASES[0];
     this.graph = Util.loadFromClasspath(Formula.class.getPackageName());
     Adder.CALL_COUNTER.reset();
-  }
-
-  @AfterEach
-  void tearDown() {
-    executorLease.close();
   }
 
   @Test
@@ -152,38 +163,57 @@ class FormulaTest {
         .withMessageContaining("Adder failed because fail flag was set");
   }
 
-  @Disabled("Long running benchmark (~40s)")
-  @Test
-  void millionExecutors_oneCallEach_singleCore_benchmark() throws Exception {
+  @Disabled("Long running benchmarks. 1 core: ~21sec, 2 cores: ~17sec, 4 cores: ~13sec")
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 4}) // test with different values of parallelism
+  void millionExecutors_oneCallEach_NExecutors_benchmark(int executorCount) throws Exception {
     int loopCount = 1_000_000;
-    SingleThreadExecutor executor = getExecutors(1)[0];
+    SingleThreadExecutor[] executors = getExecutors(executorCount);
     VajramKryonGraph graph = this.graph.build();
     long javaNativeTimeNs = javaMethodBenchmark(FormulaTest::syncFormula, loopCount);
     long javaFuturesTimeNs = Util.javaFuturesBenchmark(FormulaTest::asyncFormula, loopCount);
+    CompletableFuture<?>[] submissionFutures = new CompletableFuture[executorCount];
     @SuppressWarnings("unchecked")
     CompletableFuture<Integer>[] futures = new CompletableFuture[loopCount];
     KryonExecutorMetrics[] metrics = new KryonExecutorMetrics[loopCount];
-    long timeToCreateExecutors = 0;
-    long timeToEnqueueVajram = 0;
+    LongAdder timeToCreateExecutors = new LongAdder();
+    LongAdder timeToEnqueueVajram = new LongAdder();
     long startTime = System.nanoTime();
-    for (int value = 0; value < loopCount; value++) {
-      long iterStartTime = System.nanoTime();
-      FormulaRequestContext requestContext = new FormulaRequestContext(100, 20, 5, "formulaTest");
-      try (KrystexVajramExecutor krystexVajramExecutor =
-          graph.createExecutor(
-              KrystexVajramExecutorConfig.builder()
-                  .kryonExecutorConfigBuilder(
-                      KryonExecutorConfig.builder().singleThreadExecutor(executor))
-                  .requestId("formulaTest")
-                  .build())) {
-        timeToCreateExecutors += System.nanoTime() - iterStartTime;
-        metrics[value] =
-            ((KryonExecutor) krystexVajramExecutor.getKrystalExecutor()).getKryonMetrics();
-        long enqueueStart = System.nanoTime();
-        futures[value] = executeVajram(graph, krystexVajramExecutor, value, requestContext);
-        timeToEnqueueVajram += System.nanoTime() - enqueueStart;
-      }
+    int loopCountPerExecutor = loopCount / executorCount;
+
+    for (int currentExecutor : range(0, executorCount).toArray()) {
+      SingleThreadExecutor executor = executors[currentExecutor];
+      int coreCountStart = currentExecutor * loopCountPerExecutor;
+      submissionFutures[currentExecutor] =
+          runAsync(
+              () -> {
+                FormulaRequestContext requestContext =
+                    new FormulaRequestContext(100, 20, 5, "formulaTest");
+                for (int currentLoopCount :
+                    range(coreCountStart, coreCountStart + loopCountPerExecutor).toArray()) {
+                  long iterStartTime = System.nanoTime();
+                  try (KrystexVajramExecutor krystexVajramExecutor =
+                      graph.createExecutor(
+                          KrystexVajramExecutorConfig.builder()
+                              .kryonExecutorConfigBuilder(
+                                  KryonExecutorConfig.builder().singleThreadExecutor(executor))
+                              .requestId("formulaTest")
+                              .build())) {
+                    timeToCreateExecutors.add(System.nanoTime() - iterStartTime);
+                    metrics[currentLoopCount] =
+                        ((KryonExecutor) krystexVajramExecutor.getKrystalExecutor())
+                            .getKryonMetrics();
+                    long enqueueStart = System.nanoTime();
+                    futures[currentLoopCount] =
+                        executeVajram(
+                            graph, krystexVajramExecutor, currentLoopCount, requestContext);
+                    timeToEnqueueVajram.add(System.nanoTime() - enqueueStart);
+                  }
+                }
+              },
+              executor);
     }
+    allOf(submissionFutures).join();
     allOf(futures).join();
     long vajramTimeNs = System.nanoTime() - startTime;
     assertThat(
@@ -198,51 +228,19 @@ class FormulaTest {
         .succeedsWithin(ofSeconds(1));
     assertThat(Adder.CALL_COUNTER.sum()).isEqualTo(loopCount);
 
-    /*
-     * Old Benchmark results (Unable to reproduce :( ) :
-     *    loopCount = 1_000_000
-     *    maxParallelismPerCore = 10
-     *    Processor: 2.6 GHz 6-Core Intel Core i7 (with hyperthreading - 12 virtual cores)
-     * Benchmark result:
-     *    platform overhead over reactive code = ~13 µs (13,000 ns) per request
-     *    maxPoolSize = 120
-     *    maxActiveLeasesPerObject: 170
-     *    peakAvgActiveLeasesPerObject: 122
-     *    Avg. time to Enqueue vajrams : 8,486 ns
-     *    Avg. time to execute vajrams : 14,965 ns
-     *    Throughput executions/sec: 71000
-     */
-    /*
-     * Processor: Apple M1 Pro
-     *
-     * Benchmark results;
-     *    Total java method time: 6,814,167
-     *    Total java futures time: 80,636,209
-     *    Outer Loop Count: 1,000,000
-     *    Inner Loop Count: 1
-     *    Avg. time to Create Executors:444 ns
-     *    Avg. time to Enqueue vajrams:1,147 ns
-     *    Avg. time to execute vajrams:35,673 ns
-     *    Throughput executions/s: 28031
-     *    CommandsQueuedCount: 3,000,000
-     *    CommandQueueBypassedCount: 8,000,000
-     *    Platform overhead over native code: 35,667 ns per request
-     *    Platform overhead over reactive code: 35,593 ns per request
-     *    maxActiveLeasesPerObject: 1, peakAvgActiveLeasesPerObject: 1.0, maxPoolSize: 1
-     */
     printStats(
         loopCount,
         1,
         javaNativeTimeNs,
         javaFuturesTimeNs,
         metrics,
-        timeToCreateExecutors,
-        timeToEnqueueVajram,
+        timeToCreateExecutors.sum(),
+        timeToEnqueueVajram.sum(),
         vajramTimeNs,
         EXEC_POOL);
   }
 
-  //  @Disabled("Long running benchmark (~9s)")
+  @Disabled("Long running benchmark (~9s)")
   @Test
   void thousandExecutors_1000CallsEach_singleCore_benchmark() throws Exception {
     SingleThreadExecutor executor = getExecutors(1)[0];
@@ -495,10 +493,10 @@ class FormulaTest {
         .withMessage("java.lang.ArithmeticException: / by zero");
   }
 
-  private SingleThreadExecutor[] getExecutors(int count) throws LeaseUnavailableException {
+  private SingleThreadExecutor[] getExecutors(int count) {
     SingleThreadExecutor[] singleThreadedExecutors = new SingleThreadExecutor[count];
     for (int i = 0; i < count; i++) {
-      singleThreadedExecutors[i] = EXEC_POOL.lease().get();
+      singleThreadedExecutors[i] = EXECUTOR_LEASES[i].get();
     }
 
     return singleThreadedExecutors;

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/adder/SplitAdderTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/adder/SplitAdderTest.java
@@ -152,6 +152,7 @@ class SplitAdderTest {
                   .requestId("splitAdderTest")
                   .kryonExecutorConfigBuilder(
                       KryonExecutorConfig.builder()
+                          .singleThreadExecutor(executorLease.get())
                           .disabledDependantChains(disabledDepChains(graph)))
                   .build())) {
         metrics[value] =
@@ -223,6 +224,7 @@ class SplitAdderTest {
                   .requestId("splitAdderTest")
                   .kryonExecutorConfigBuilder(
                       KryonExecutorConfig.builder()
+                          .singleThreadExecutor(executorLease.get())
                           .disabledDependantChains(disabledDepChains(graph)))
                   .build())) {
         timeToCreateExecutors += System.nanoTime() - iterStartTime;


### PR DESCRIPTION
Closes #328 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated project configuration to streamline the handling of build artifacts.
  
- **Refactor**
  - Enhanced internal concurrency mechanisms and thread safety across key operations for improved performance and reliability.
  
- **Tests**
  - Simplified test configurations by reducing unnecessary parameters.
  - Introduced benchmark tests and refined parallel execution checks to better assess overall performance.
  - Added parameterized tests for concurrent execution to identify race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->