### PR TITLE
Disallow facets starting with '_'. Deprecate risky flags

### DIFF
--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonExecutorConfig.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonExecutorConfig.java
@@ -34,12 +34,12 @@ import lombok.Singular;
  * @param singleThreadExecutor MANDATORY! This is used as the event loop for the message passing
  *     within this execution.
  * @param traitDispatchDecorator used to determine the conformant vajrams bound to traits
- * @param debug If true, more human readable names are give to entities - might be memory
+ * @param debug If true, more human-readable names are give to entities - might be memory
  *     ineffecient.
  * @param _riskyOpenAllKryonsForExternalInvocation DO NOT SET THIS TO TRUE IN PRODUCTION CODE - ELSE
- *     NEW VERSIONS OF CODE CAN BREAK BACKWARD COMPATIBILITY. {@code true} if all vajrams are
- *     allowed to be invoked from outside the krystal graph intead of only allowing vajrams tagged
- *     with @{@link ExternallyInvocable}(allow=true)
+ *     NEW VERSIONS OF CODE CAN BREAK BACKWARD COMPATIBILITY. TO BE USED IN TESTING CODE ONLY.
+ *     {@code true} if all vajrams are allowed to be invoked from outside the krystal graph instead
+ *     of only allowing vajrams tagged with @{@link ExternallyInvocable}(allow=true)
  */
 public record KryonExecutorConfig(
     LogicDecorationOrdering logicDecorationOrdering,
@@ -53,8 +53,8 @@ public record KryonExecutorConfig(
     TraitDispatchDecorator traitDispatchDecorator,
     boolean enableFlush,
     boolean debug,
-    /******* Risky Flags ********/
-    boolean _riskyOpenAllKryonsForExternalInvocation) {
+    /* ****** Risky Flags ********/
+    @Deprecated boolean _riskyOpenAllKryonsForExternalInvocation) {
 
   @Builder(toBuilder = true)
   public KryonExecutorConfig {

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/Utils.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/Utils.java
@@ -370,7 +370,21 @@ public class Utils {
                 .collect(toImmutableList()),
             conformsToTraitInfo);
     note("VajramInfo: %s".formatted(vajramInfo));
+    validateVajramInfo(vajramInfo);
     return vajramInfo;
+  }
+
+  private void validateVajramInfo(VajramInfo vajramInfo) {
+    vajramInfo
+        .facetStream()
+        .forEach(
+            facetGenModel -> {
+              if (facetGenModel.name().startsWith("_")) {
+                error(
+                    "Facet names cannot start with an underscore (_). These are reserved for platform specific identifiers",
+                    facetGenModel.facetField());
+              }
+            });
   }
 
   private DefaultFacetModel toGivenFacetModel(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity and corrected typos in parameter descriptions.
  - Updated documentation to clearly state that a specific configuration flag is for testing use only.
- **Refactor**
  - Marked a configuration flag as deprecated.
- **New Features**
  - Added validation to prevent facet names from starting with an underscore, reserving them for platform use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->