### PR TITLE
Make StackTracelessException a CompletionException

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,6 +28,7 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
           <package name="" withSubpackages="true" static="false" />

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 ext {
     clojarsusername = project.properties['clojarsusername'] ?: ""
     clojarspassword = project.properties['clojarspassword'] ?: ""
-    krystal_version = '7.0.3'
+    krystal_version = '7.0.4'
 }
 
 checkerFramework {

--- a/krystal-common/src/main/java/com/flipkart/krystal/except/StackTracelessCancellationException.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/except/StackTracelessCancellationException.java
@@ -1,0 +1,38 @@
+package com.flipkart.krystal.except;
+
+import java.util.concurrent.CancellationException;
+
+/**
+ * An exception whose stacktrace is not useful. For example, exceptions used for internal purposes
+ * or for failing completable futures with a marker exception.
+ *
+ * <p>This class extends {@link CancellationException} so that CompletableFutures can be cancelled
+ * without paying the price of filling the stack trace. This unnecessary wrapping has been observed
+ * to have a negative impact on performance - in some instances taking up upto 6% of the total CPU
+ * resources.
+ *
+ * @implNote This class overrides {@link Throwable#fillInStackTrace()} and skips filling the stack
+ *     trace to improve performance.
+ */
+public class StackTracelessCancellationException extends CancellationException {
+
+  private static final StackTracelessCancellationException INSTANCE =
+      new StackTracelessCancellationException();
+
+  private StackTracelessCancellationException() {}
+
+  public StackTracelessCancellationException(String message) {
+    super(message);
+  }
+
+  @SuppressWarnings("NonSynchronizedMethodOverridesSynchronizedMethod")
+  @Override
+  public final Throwable fillInStackTrace() {
+    // This exception is used to complete exceptions. Stack trace is not useful.
+    return this;
+  }
+
+  public static StackTracelessCancellationException stackTracelessCancellation() {
+    return INSTANCE;
+  }
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/except/StackTracelessException.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/except/StackTracelessException.java
@@ -1,19 +1,26 @@
 package com.flipkart.krystal.except;
 
+import java.util.concurrent.CompletionException;
+
 /**
  * An exception whose stacktrace is not useful. For example, exceptions used for internal purposes
  * or for failing completable futures with a marker exception.
  *
+ * <p>This class extends {@link CompletionException} so that CompletableFutures do not unnecessarily
+ * wrap this exception in another CompletionException. This unnecessary wrapping has been observed
+ * to have a negative impact on performance - in some instances taking up upto 20% of the total CPU
+ * resources.
+ *
  * @implNote This class overrides {@link Throwable#fillInStackTrace()} and skips filling the stack
  *     trace to improve performance.
  */
-public class StackTracelessException extends RuntimeException {
+public class StackTracelessException extends CompletionException {
 
   public StackTracelessException(String message) {
     super(message);
   }
 
-  public StackTracelessException(String message, Exception cause) {
+  public StackTracelessException(String message, Throwable cause) {
     super(message, cause);
   }
 
@@ -22,5 +29,13 @@ public class StackTracelessException extends RuntimeException {
   public final Throwable fillInStackTrace() {
     // This exception is used to complete exceptions. Stack trace is not useful.
     return this;
+  }
+
+  public static CompletionException stackTracelessWrap(Throwable t) {
+    if (t instanceof CompletionException) {
+      return (CompletionException) t;
+    }
+    String message = t.getMessage();
+    return new StackTracelessException(message != null ? message : t.getClass().getName(), t);
   }
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/utils/Futures.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/utils/Futures.java
@@ -1,5 +1,8 @@
 package com.flipkart.krystal.utils;
 
+import static com.flipkart.krystal.except.StackTracelessCancellationException.stackTracelessCancellation;
+import static com.flipkart.krystal.except.StackTracelessException.stackTracelessWrap;
+
 import java.util.concurrent.CompletableFuture;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
@@ -9,7 +12,7 @@ public final class Futures {
     from.whenComplete(
         (unused, throwable) -> {
           if (from.isDone() && !to.isDone()) {
-            to.cancel(true);
+            to.completeExceptionally(stackTracelessCancellation());
           }
         });
   }
@@ -19,7 +22,7 @@ public final class Futures {
     from.whenComplete(
         (result, error) -> {
           if (error != null) {
-            to.completeExceptionally(error);
+            to.completeExceptionally(stackTracelessWrap(error));
           } else {
             to.complete(result);
           }
@@ -30,12 +33,10 @@ public final class Futures {
    * Sets up completable Futures such that
    *
    * <ul>
-   *   when {@code sourceFuture} completes, its completion is propagated to {@code
-   *   destinationFuture}.
-   * </ul>
-   *
-   * <ul>
-   *   when {@code destinationFuture} is cancelled, {@code sourceFuture is cancelled}
+   *   <li>when {@code sourceFuture} completes, its completion is propagated to {@code
+   *       destinationFuture}.
+   *   <li>when {@code destinationFuture} is completed, {@code sourceFuture} is cancelled if it is
+   *       not yet completed
    * </ul>
    *
    * Calling this method is equivalent to calling {@link #propagateCompletion(CompletableFuture,

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
@@ -1,5 +1,6 @@
 package com.flipkart.krystal.krystex.caching;
 
+import static com.flipkart.krystal.except.StackTracelessException.stackTracelessWrap;
 import static com.flipkart.krystal.utils.Futures.linkFutures;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.concurrent.CompletableFuture.allOf;
@@ -123,7 +124,7 @@ public class RequestLevelCache implements KryonDecorator {
                   (requestId, response) -> {
                     newCacheEntries
                         .computeIfAbsent(requestId, _r -> new CompletableFuture<@Nullable Object>())
-                        .completeExceptionally(throwable);
+                        .completeExceptionally(stackTracelessWrap(throwable));
                   });
             } else {
               RuntimeException e =

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchKryon.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchKryon.java
@@ -2,6 +2,7 @@ package com.flipkart.krystal.krystex.kryon;
 
 import static com.flipkart.krystal.data.Errable.empty;
 import static com.flipkart.krystal.data.Errable.withError;
+import static com.flipkart.krystal.except.StackTracelessException.stackTracelessWrap;
 import static com.flipkart.krystal.krystex.kryon.KryonUtils.enqueueOrExecuteCommand;
 import static com.flipkart.krystal.krystex.resolution.ResolverCommand.multiExecuteWith;
 import static com.flipkart.krystal.krystex.resolution.ResolverCommand.skip;
@@ -148,7 +149,7 @@ final class BatchKryon extends AbstractKryon<BatchCommand, BatchResponse> {
           executeOutputLogicIfPossible(dependantChain);
       outputLogicFuture.ifPresent(f -> linkFutures(f, resultForDepChain));
     } catch (Throwable e) {
-      resultForDepChain.completeExceptionally(e);
+      resultForDepChain.completeExceptionally(stackTracelessWrap(e));
     }
     return resultForDepChain;
   }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/GranularKryon.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/GranularKryon.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.krystex.kryon;
 
 import static com.flipkart.krystal.data.Errable.withError;
+import static com.flipkart.krystal.except.StackTracelessException.stackTracelessWrap;
 import static com.flipkart.krystal.krystex.kryon.KryonUtils.enqueueOrExecuteCommand;
 import static com.google.common.base.Functions.identity;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -142,7 +143,7 @@ final class GranularKryon extends AbstractKryon<GranularCommand, GranuleResponse
       }
       executeOutputLogicIfPossible(requestId, resultForRequest);
     } catch (Throwable e) {
-      resultForRequest.completeExceptionally(e);
+      resultForRequest.completeExceptionally(stackTracelessWrap(e));
     }
     return resultForRequest;
   }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonExecutor.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonExecutor.java
@@ -1,5 +1,6 @@
 package com.flipkart.krystal.krystex.kryon;
 
+import static com.flipkart.krystal.except.StackTracelessException.stackTracelessWrap;
 import static com.flipkart.krystal.krystex.kryon.FacetType.INPUT;
 import static com.flipkart.krystal.krystex.kryon.KryonExecutor.GraphTraversalStrategy.BREADTH;
 import static com.flipkart.krystal.utils.Futures.linkFutures;
@@ -214,9 +215,10 @@ public final class KryonExecutor implements KrystalExecutor {
                   CompletableFuture<@Nullable Object> future = new CompletableFuture<>();
                   if (allExecutions.containsKey(requestId)) {
                     future.completeExceptionally(
-                        new IllegalArgumentException(
-                            "Received duplicate requests for same instanceId '%s' and execution Id '%s'"
-                                .formatted(instanceId, executionId)));
+                        stackTracelessWrap(
+                            new IllegalArgumentException(
+                                "Received duplicate requests for same instanceId '%s' and execution Id '%s'"
+                                    .formatted(instanceId, executionId))));
                   } else {
                     allExecutions.put(
                         requestId,
@@ -476,7 +478,9 @@ public final class KryonExecutor implements KrystalExecutor {
                       (responses, throwable) -> {
                         for (KryonExecution kryonExecution : kryonResults) {
                           if (throwable != null) {
-                            kryonExecution.future().completeExceptionally(throwable);
+                            kryonExecution
+                                .future()
+                                .completeExceptionally(stackTracelessWrap(throwable));
                           } else {
                             Errable<Object> result =
                                 responses.getOrDefault(


### PR DESCRIPTION
Make StackTracelessException a CompletionException and use it when failing Futures to prevent CompletableFuture from unnecessarily wrapping with CompletionException and causing fillInStackTrace to waste CPU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by wrapping exceptions with a stack-traceless wrapper across various components, resulting in cleaner and more efficient exception propagation.

* **New Features**
  * Introduced utilities for stack-traceless exception and cancellation exception wrapping, enhancing performance and reducing redundant stack trace generation in asynchronous operations.

* **Chores**
  * Updated a dependency version to ensure compatibility and access to the latest improvements.
  * Adjusted Java code style settings for import layout consistency.

* **Documentation**
  * Clarified and improved Javadoc comments for better understanding of method behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->