### PR TITLE
skipping new SkipExecution exception creation for every skip dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 ext {
     clojarsusername = project.properties['clojarsusername'] ?: ""
     clojarspassword = project.properties['clojarspassword'] ?: ""
-    krystal_version = '7.1.0'
+    krystal_version = '7.1.1-SKIP-SNAPSHOT'
 }
 
 checkerFramework {

--- a/krystal-common/src/main/java/com/flipkart/krystal/utils/SkippedExecutionException.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/utils/SkippedExecutionException.java
@@ -7,4 +7,7 @@ public class SkippedExecutionException extends StackTracelessException {
   public SkippedExecutionException(String message) {
     super(message);
   }
+
+  public static final SkippedExecutionException SKIPPED_EXECUTION_EXCEPTION =
+      new SkippedExecutionException("Execution was skipped due to a skip command.");
 }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
@@ -19,7 +19,6 @@ import com.flipkart.krystal.krystex.kryon.KryonResponse;
 import com.flipkart.krystal.krystex.kryondecoration.KryonDecorationInput;
 import com.flipkart.krystal.krystex.kryondecoration.KryonDecorator;
 import com.flipkart.krystal.krystex.request.RequestId;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/commands/BatchCommand.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/commands/BatchCommand.java
@@ -6,5 +6,4 @@ import java.util.Set;
 public sealed interface BatchCommand extends KryonCommand permits ForwardBatch, CallbackBatch {
 
   Set<RequestId> requestIds();
-
 }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/commands/CallbackBatch.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/commands/CallbackBatch.java
@@ -6,9 +6,6 @@ import com.flipkart.krystal.data.Results;
 import com.flipkart.krystal.krystex.kryon.DependantChain;
 import com.flipkart.krystal.krystex.kryon.KryonId;
 import com.flipkart.krystal.krystex.request.RequestId;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/commands/ForwardBatch.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/commands/ForwardBatch.java
@@ -4,8 +4,6 @@ import com.flipkart.krystal.data.Facets;
 import com.flipkart.krystal.krystex.kryon.DependantChain;
 import com.flipkart.krystal.krystex.kryon.KryonId;
 import com.flipkart.krystal.krystex.request.RequestId;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Set;

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchKryon.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchKryon.java
@@ -411,8 +411,7 @@ final class BatchKryon extends AbstractKryon<BatchCommand, BatchResponse> {
     CompletableFuture<BatchResponse> outputLogicResult = null;
     ForwardBatch forwardCommand = getForwardCommand(dependantChain);
     if (forwardCommand.shouldSkip()) {
-      outputLogicResult =
-          failedFuture(new SkippedExecutionException(getSkipMessage(forwardCommand)));
+      outputLogicResult = failedFuture(SkippedExecutionException.SKIPPED_EXECUTION_EXCEPTION);
     }
     // If all the inputs and dependency values needed by the output logic are available, then
     // prepare to run outputLogic

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchResponse.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/BatchResponse.java
@@ -2,8 +2,6 @@ package com.flipkart.krystal.krystex.kryon;
 
 import com.flipkart.krystal.data.Errable;
 import com.flipkart.krystal.krystex.request.RequestId;
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-public record BatchResponse(Map<RequestId, Errable<Object>> responses)
-    implements KryonResponse {}
+public record BatchResponse(Map<RequestId, Errable<Object>> responses) implements KryonResponse {}

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/GranularKryon.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/GranularKryon.java
@@ -100,7 +100,7 @@ final class GranularKryon extends AbstractKryon<GranularCommand, GranuleResponse
   }
 
   private static SkippedExecutionException skipKryonException(SkipGranule skip) {
-    return new SkippedExecutionException(skip.skipDependencyCommand().reason());
+    return SkippedExecutionException.SKIPPED_EXECUTION_EXCEPTION;
   }
 
   @Override

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/logicdecoration/InitiateActiveDepChains.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/logicdecoration/InitiateActiveDepChains.java
@@ -2,7 +2,6 @@ package com.flipkart.krystal.krystex.logicdecoration;
 
 import com.flipkart.krystal.krystex.kryon.DependantChain;
 import com.flipkart.krystal.krystex.kryon.KryonId;
-import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 public record InitiateActiveDepChains(KryonId kryonId, Set<DependantChain> dependantsChains)

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/inputinjection/InjectingDecoratedKryon.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/inputinjection/InjectingDecoratedKryon.java
@@ -21,7 +21,6 @@ import com.flipkart.krystal.vajram.facets.InputSource;
 import com.flipkart.krystal.vajram.facets.VajramFacetDefinition;
 import com.flipkart.krystal.vajramexecutor.krystex.VajramKryonGraph;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/FormulaTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/FormulaTest.java
@@ -34,7 +34,6 @@ import com.flipkart.krystal.vajramexecutor.krystex.KrystexVajramExecutorConfig;
 import com.flipkart.krystal.vajramexecutor.krystex.VajramKryonGraph;
 import com.flipkart.krystal.vajramexecutor.krystex.VajramKryonGraph.Builder;
 import com.flipkart.krystal.vajramexecutor.krystex.testharness.VajramTestHarness;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;


### PR DESCRIPTION
Avoiding new SkippedExecution exception creation for every skip dependency. Created a default SkippedExecutionException class which is reused. 
Benefits : New exception object creation is avoided.
Degradation : Exception cause and message is not captured.

Future scope: This can be default strategy. We can have a "DEBUG" flag which can enable new execution with cause and message created.