### PR TITLE
Graphql: Better logging, codegen, javaDoc, and custom subPackage support for entity types

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -485,6 +485,7 @@
           <option value="override.param" />
           <option value="SameParameterValue" />
           <option value="BooleanMethodIsAlwaysInverted" />
+          <option value="ConstantValue" />
         </list>
       </option>
     </inspection_tool>

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 ext {
     clojarsusername = project.properties['clojarsusername'] ?: ""
     clojarspassword = project.properties['clojarspassword'] ?: ""
-    krystal_version = '10.0.0'
-    lattice_version = '0.0.22'
+    krystal_version = '10.0.1'
+    lattice_version = '0.0.23'
 
     java_code_std_version = '5.3'
 

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQLEntityGen.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQLEntityGen.java
@@ -3,6 +3,8 @@ package com.flipkart.krystal.vajram.graphql.codegen;
 import static com.flipkart.krystal.codegen.common.models.Constants.IMMUT_SUFFIX;
 import static com.flipkart.krystal.vajram.graphql.api.Constants.Directives.DATA_FETCHER;
 import static com.flipkart.krystal.vajram.graphql.codegen.GraphQLObjectAggregateGen.GRAPHQL_RESPONSE;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static java.util.Objects.requireNonNullElse;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
@@ -19,6 +21,7 @@ import com.flipkart.krystal.vajram.graphql.api.model.GraphQlEntityId;
 import com.flipkart.krystal.vajram.graphql.api.model.GraphQlObject;
 import com.flipkart.krystal.vajram.graphql.api.model.GraphQlOperationObject;
 import com.flipkart.krystal.vajram.graphql.api.model.GraphQlResponseJson;
+import com.google.common.collect.Maps;
 import com.squareup.javapoet.*;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec.Builder;
@@ -32,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 class GraphQLEntityGen implements CodeGenerator {
 
@@ -51,6 +55,7 @@ class GraphQLEntityGen implements CodeGenerator {
     String rootPackageName = schemaReaderUtil.rootPackageName();
     Optional<SchemaDefinition> schemaDefinition = typeDefinitionRegistry.schemaDefinition();
     if (schemaDefinition.isEmpty()) {
+      util.note("No schema definition found - skipping entity generation");
       return;
     }
     Map<String, OperationTypeDefinition> opDefsByName =
@@ -60,210 +65,223 @@ class GraphQLEntityGen implements CodeGenerator {
                     operationTypeDefinition -> operationTypeDefinition.getTypeName().getName(),
                     od -> od));
 
-    // Write the entity type file
-    writeEntityTypeFile(typeDefinitionRegistry.types(), rootPackageName);
-
-    //noinspection rawtypes
-    for (Entry<String, TypeDefinition> entry : typeDefinitionRegistry.types().entrySet()) {
+    Map<String, TypeDefinition> typesWithDataModels =
+        Maps.filterValues(
+            typeDefinitionRegistry.types(),
+            typeDefinition ->
+                typeDefinition instanceof EnumTypeDefinition
+                    || typeDefinition instanceof ObjectTypeDefinition);
+    util.note("Generating id models and data models for types : %s".formatted(typesWithDataModels));
+    for (Entry<String, TypeDefinition> entry : typesWithDataModels.entrySet()) {
       GraphQLTypeName graphQLTypeName = new GraphQLTypeName(entry.getKey());
-      @SuppressWarnings("rawtypes")
       TypeDefinition typeDefinition = entry.getValue();
-      boolean isEntity = typeDefinition.hasDirective(Directives.ENTITY);
-      OperationTypeDefinition opDef = opDefsByName.get(typeDefinition.getName());
-      boolean isOpType = opDef != null;
-      ClassName entityClassName = schemaReaderUtil.typeClassName(graphQLTypeName);
+      try {
+        ClassName entityClassName = schemaReaderUtil.typeClassName(graphQLTypeName);
 
-      TypeSpec typeSpec;
-      if (typeDefinition instanceof EnumTypeDefinition) {
-        Builder enumTypeSpecBuilder =
-            TypeSpec.enumBuilder(graphQLTypeName.value()).addModifiers(PUBLIC);
+        Builder typeSpec;
+        if (typeDefinition instanceof EnumTypeDefinition) {
+          Builder enumTypeSpecBuilder =
+              TypeSpec.enumBuilder(graphQLTypeName.value()).addModifiers(PUBLIC);
 
-        ((EnumTypeDefinition) typeDefinition)
-            .getEnumValueDefinitions()
-            .forEach(
-                enumValueDefinition ->
-                    enumTypeSpecBuilder.addEnumConstant(enumValueDefinition.getName()));
+          ((EnumTypeDefinition) typeDefinition)
+              .getEnumValueDefinitions()
+              .forEach(
+                  enumValueDefinition ->
+                      enumTypeSpecBuilder.addEnumConstant(enumValueDefinition.getName()));
 
-        typeSpec = enumTypeSpecBuilder.build();
-      } else if (typeDefinition instanceof ObjectTypeDefinition) {
-        List<MethodSpec> methodSpecs = new ArrayList<>();
-        GraphQLTypeName enclosingType = GraphQLTypeName.of(typeDefinition);
+          typeSpec = enumTypeSpecBuilder;
+        } else if (typeDefinition instanceof ObjectTypeDefinition) {
+          boolean isEntity = typeDefinition.hasDirective(Directives.ENTITY);
+          boolean isOpType = opDefsByName.get(typeDefinition.getName()) != null;
+          List<MethodSpec> methodSpecs = new ArrayList<>();
+          GraphQLTypeName enclosingType = GraphQLTypeName.of(typeDefinition);
 
-        boolean idMissing = true;
-        String entityIdFieldName = schemaReaderUtil.getEntityIdFieldName(typeDefinition);
+          boolean idMissing = true;
+          String entityIdFieldName = schemaReaderUtil.getEntityIdFieldName(typeDefinition);
 
-        if (typeDefinition.getChildren() != null) {
-          for (int i = 0; i < typeDefinition.getChildren().size(); i++) {
-            if (typeDefinition.getChildren().get(i) instanceof FieldDefinition fieldDefinition) {
-              String fieldName = fieldDefinition.getName();
-              boolean isEntityIdField = entityIdFieldName.equals(fieldName);
+          if (typeDefinition.getChildren() != null) {
+            for (int i = 0; i < typeDefinition.getChildren().size(); i++) {
+              if (typeDefinition.getChildren().get(i) instanceof FieldDefinition fieldDefinition) {
+                String fieldName = fieldDefinition.getName();
+                boolean isEntityIdField = entityIdFieldName.equals(fieldName);
 
-              GraphQlFieldSpec fieldSpec =
-                  schemaReaderUtil.fieldSpecFromField(fieldDefinition, "", enclosingType);
-              TypeName typeNameForField = graphQlCodeGenUtil.toTypeNameForField(fieldSpec);
+                GraphQlFieldSpec fieldSpec =
+                    schemaReaderUtil.fieldSpecFromField(fieldDefinition, "", enclosingType);
+                TypeName typeNameForField = graphQlCodeGenUtil.toTypeNameForField(fieldSpec);
 
-              if (isEntity && isEntityIdField) {
-                idMissing = false;
-                typeNameForField = schemaReaderUtil.entityIdClassName(graphQLTypeName);
+                if (isEntity && isEntityIdField) {
+                  idMissing = false;
+                  typeNameForField = schemaReaderUtil.entityIdClassName(graphQLTypeName);
+                }
+
+                methodSpecs.add(
+                    MethodSpec.methodBuilder(fieldName)
+                        .addModifiers(PUBLIC, ABSTRACT)
+                        .returns(typeNameForField)
+                        .addJavadoc(getDescription(fieldDefinition))
+                        .build());
               }
-
-              methodSpecs.add(
-                  MethodSpec.methodBuilder(fieldName)
-                      .addModifiers(PUBLIC, ABSTRACT)
-                      .returns(typeNameForField)
-                      .build());
+            }
+            if (isEntity && idMissing) {
+              util.error(
+                  """
+                  The entity %s does not have an '%s' field. Every entity MUST have an id.\
+                  Either remove the '@entity' directive from the type or add an '%s' field"""
+                      .formatted(
+                          entityClassName.simpleName(), entityIdFieldName, entityIdFieldName));
             }
           }
-          if (isEntity && idMissing) {
-            util.error(
-                """
-                The entity %s does not have an '%s' field. Every entity MUST have an id.\
-                Either remove the '@entity' directive from the type or add an '%s' field"""
-                    .formatted(entityClassName.simpleName(), entityIdFieldName, entityIdFieldName));
+
+          ClassName immutableClassName =
+              ClassName.get(
+                  entityClassName.packageName(), entityClassName.simpleName() + "_" + IMMUT_SUFFIX);
+          methodSpecs.add(
+              MethodSpec.overriding(util.getMethod(() -> Model.class.getMethod("_asBuilder")))
+                  .returns(immutableClassName.nestedClass("Builder"))
+                  .addModifiers(PUBLIC, ABSTRACT)
+                  .build());
+
+          typeSpec =
+              util.interfaceBuilder(entityClassName.simpleName(), "")
+                  .addAnnotation(
+                      AnnotationSpec.builder(ModelRoot.class)
+                          .addMember("type", "$T.$L", ModelType.class, ModelType.RESPONSE.name())
+                          .addMember("builderExtendsModelRoot", "true")
+                          .build())
+                  .addAnnotation(
+                      AnnotationSpec.builder(SupportedModelProtocols.class)
+                          .addMember("value", "$T.class", GraphQlResponseJson.class)
+                          .build())
+                  .addModifiers(PUBLIC)
+                  .addMethods(methodSpecs)
+                  .addSuperinterface(
+                      isOpType
+                          ? ClassName.get(GraphQlOperationObject.class)
+                          : ClassName.get(GraphQlObject.class));
+          if (isEntity) {
+            var entityIdClassName = schemaReaderUtil.entityIdClassName(graphQLTypeName);
+            util.generateSourceFile(
+                entityIdClassName.canonicalName(),
+                JavaFile.builder(
+                        entityIdClassName.packageName(),
+                        util.classBuilder(
+                                entityIdClassName.simpleName(), entityClassName.canonicalName())
+                            .addModifiers(PUBLIC)
+                            .addSuperinterface(GraphQlEntityId.class)
+                            .addField(String.class, "value", PRIVATE, FINAL)
+                            .addMethod(
+                                MethodSpec.methodBuilder("value")
+                                    .addModifiers(PUBLIC)
+                                    .returns(String.class)
+                                    .addStatement("return value")
+                                    .build())
+                            .addMethod(
+                                MethodSpec.constructorBuilder()
+                                    .addModifiers(PUBLIC)
+                                    .addParameter(String.class, "value")
+                                    .addStatement("this.value = value")
+                                    .build())
+                            .build())
+                    .build()
+                    .toString(),
+                null);
           }
+        } else {
+          util.note("Skipping unknown entity type: " + typeDefinition);
+          continue;
         }
-
-        ClassName immutableClassName =
-            ClassName.get(
-                entityClassName.packageName(), entityClassName.simpleName() + "_" + IMMUT_SUFFIX);
-        methodSpecs.add(
-            MethodSpec.overriding(util.getMethod(() -> Model.class.getMethod("_asBuilder")))
-                .returns(immutableClassName.nestedClass("Builder"))
-                .addModifiers(PUBLIC, ABSTRACT)
-                .build());
-
-        typeSpec =
-            util.interfaceBuilder(entityClassName.simpleName(), "")
-                .addAnnotation(
-                    AnnotationSpec.builder(ModelRoot.class)
-                        .addMember("type", "$T.$L", ModelType.class, ModelType.RESPONSE.name())
-                        .addMember("builderExtendsModelRoot", "true")
-                        .build())
-                .addAnnotation(
-                    AnnotationSpec.builder(SupportedModelProtocols.class)
-                        .addMember("value", "$T.class", GraphQlResponseJson.class)
-                        .build())
-                .addModifiers(PUBLIC)
-                .addMethods(methodSpecs)
-                .addSuperinterface(
-                    isOpType
-                        ? ClassName.get(GraphQlOperationObject.class)
-                        : ClassName.get(GraphQlObject.class))
-                .build();
-      } else {
-        util.note("Skipping unknown entity type: " + typeDefinition);
-        continue;
-      }
-      util.generateSourceFile(
-          entityClassName.canonicalName(),
-          JavaFile.builder(entityClassName.packageName(), typeSpec).build().toString(),
-          null);
-      if (isEntity) {
-        var entityIdClassName = schemaReaderUtil.entityIdClassName(graphQLTypeName);
+        //noinspection ConstantValue
+        if (typeDefinition instanceof AbstractDescribedNode<?> describedNode) {
+          typeSpec.addJavadoc(getDescription(describedNode));
+        }
         util.generateSourceFile(
-            entityIdClassName.canonicalName(),
-            JavaFile.builder(
-                    entityIdClassName.packageName(),
-                    util.classBuilder(
-                            entityIdClassName.simpleName(), entityClassName.canonicalName())
-                        .addModifiers(PUBLIC)
-                        .addSuperinterface(GraphQlEntityId.class)
-                        .addField(String.class, "value", PRIVATE, FINAL)
-                        .addMethod(
-                            MethodSpec.methodBuilder("value")
-                                .addModifiers(PUBLIC)
-                                .returns(String.class)
-                                .addStatement("return value")
-                                .build())
-                        .addMethod(
-                            MethodSpec.constructorBuilder()
-                                .addModifiers(PUBLIC)
-                                .addParameter(String.class, "value")
-                                .addStatement("this.value = value")
-                                .build())
-                        .build())
-                .build()
-                .toString(),
+            entityClassName.canonicalName(),
+            JavaFile.builder(entityClassName.packageName(), typeSpec.build()).build().toString(),
             null);
+      } catch (Throwable e) {
+        util.error(
+            "Could not generate id models and data models for type '%s' due to error '%s'"
+                .formatted(entry.getKey(), getStackTraceAsString(e)));
       }
     }
 
-    schemaReaderUtil
-        .aggregatableTypes()
-        .forEach(
-            (graphQLTypeName, entityTypeDefinition) -> {
-              // Capture all the data fetchers which are mentioned in multiple field definitions
+    Map<GraphQLTypeName, @NonNull ObjectTypeDefinition> aggregatableTypes =
+        schemaReaderUtil.aggregatableTypes();
+    util.note(
+        "Evaluating '%s' to generate GraphQl Field Models where needed (i.e. if a data fetcher is bound to multiple fields)"
+            .formatted(aggregatableTypes));
+    aggregatableTypes.forEach(
+        (graphQLTypeName, entityTypeDefinition) -> {
+          try {
+            // Capture all the data fetchers which are mentioned in multiple field definitions
 
-              Map<ClassName, List<FieldDefinition>> fieldDefinitions = new HashMap<>();
+            Map<ClassName, List<FieldDefinition>> fieldDefinitions = new HashMap<>();
 
-              for (FieldDefinition fieldDefinition : entityTypeDefinition.getFieldDefinitions()) {
-                if (!fieldDefinition.getDirectives(DATA_FETCHER).isEmpty()) {
-                  fieldDefinitions
-                      .computeIfAbsent(
-                          schemaReaderUtil.getDataFetcherClassName(fieldDefinition),
-                          _k -> new ArrayList<>())
-                      .add(fieldDefinition);
-                }
+            for (FieldDefinition fieldDefinition : entityTypeDefinition.getFieldDefinitions()) {
+              if (!fieldDefinition.getDirectives(DATA_FETCHER).isEmpty()) {
+                fieldDefinitions
+                    .computeIfAbsent(
+                        schemaReaderUtil.getDataFetcherClassName(fieldDefinition),
+                        _k -> new ArrayList<>())
+                    .add(fieldDefinition);
               }
-              // for dataFetchers which have the size greater than one, create the wrapper class
-              // which
-              // contains object of those field types
-              fieldDefinitions.forEach(
-                  (dataFetcherName, fieldDefinitionList) -> {
-                    ClassName className =
-                        ClassName.get(
-                            dataFetcherName.packageName(),
-                            dataFetcherName.simpleName() + GRAPHQL_RESPONSE);
-                    if (fieldDefinitionList.size() > 1) {
-                      TypeSpec.Builder builder = TypeSpec.classBuilder(className);
+            }
+            // for dataFetchers which have the size greater than one, create the wrapper class
+            // which
+            // contains object of those field types
+            fieldDefinitions.forEach(
+                (dataFetcherName, fieldDefinitionList) -> {
+                  ClassName className =
+                      ClassName.get(
+                          dataFetcherName.packageName(),
+                          dataFetcherName.simpleName() + GRAPHQL_RESPONSE);
+                  if (fieldDefinitionList.size() > 1) {
+                    Builder builder = TypeSpec.classBuilder(className);
 
-                      for (FieldDefinition fieldDefinitionDf : fieldDefinitionList) {
-                        builder.addField(
-                            FieldSpec.builder(
-                                    graphQlCodeGenUtil.toTypeNameForField(
-                                        schemaReaderUtil.fieldSpecFromField(
-                                            fieldDefinitionDf, "", graphQLTypeName)),
-                                    fieldDefinitionDf.getName(),
-                                    PUBLIC)
-                                .build());
-                      }
-                      builder
-                          .addModifiers(PUBLIC, FINAL)
-                          .addAnnotation(
-                              AnnotationSpec.builder(
-                                      ClassName.get("lombok.experimental", "Accessors"))
-                                  .addMember("fluent", "true")
-                                  .build())
-                          .addAnnotation(
-                              AnnotationSpec.builder(ClassName.get("lombok", "Getter")).build())
-                          .addAnnotation(
-                              AnnotationSpec.builder(ClassName.get("lombok", "Builder")).build())
-                          .addAnnotation(
-                              AnnotationSpec.builder(ClassName.get("lombok", "Setter")).build());
-                      util.generateSourceFile(
-                          className.canonicalName(),
-                          JavaFile.builder(className.packageName(), builder.build())
-                              .build()
-                              .toString(),
-                          null);
+                    for (FieldDefinition fieldDefinitionDf : fieldDefinitionList) {
+                      builder.addField(
+                          FieldSpec.builder(
+                                  graphQlCodeGenUtil.toTypeNameForField(
+                                      schemaReaderUtil.fieldSpecFromField(
+                                          fieldDefinitionDf, "", graphQLTypeName)),
+                                  fieldDefinitionDf.getName(),
+                                  PUBLIC)
+                              .build());
                     }
-                  });
-            });
+                    builder
+                        .addModifiers(PUBLIC, FINAL)
+                        .addAnnotation(
+                            AnnotationSpec.builder(
+                                    ClassName.get("lombok.experimental", "Accessors"))
+                                .addMember("fluent", "true")
+                                .build())
+                        .addAnnotation(
+                            AnnotationSpec.builder(ClassName.get("lombok", "Getter")).build())
+                        .addAnnotation(
+                            AnnotationSpec.builder(ClassName.get("lombok", "Builder")).build())
+                        .addAnnotation(
+                            AnnotationSpec.builder(ClassName.get("lombok", "Setter")).build());
+                    util.generateSourceFile(
+                        className.canonicalName(),
+                        JavaFile.builder(className.packageName(), builder.build())
+                            .build()
+                            .toString(),
+                        null);
+                  }
+                });
+          } catch (Throwable e) {
+            util.error(
+                "Could not generate GraphQl Fields Models for type '%s' due to error '%s'"
+                    .formatted(graphQLTypeName, getStackTraceAsString(e)));
+          }
+        });
   }
 
-  private void writeEntityTypeFile(
-      Map<String, TypeDefinition> entityTypes, String rootPackageName) {
-    ClassName entityTypeClassName = ClassName.get(rootPackageName, "GraphQLEntityType");
-    TypeSpec.Builder entityTypeBuilder = TypeSpec.enumBuilder(entityTypeClassName);
-    entityTypeBuilder.addModifiers(PUBLIC);
-
-    for (Entry<String, TypeDefinition> entry : entityTypes.entrySet()) {
-      entityTypeBuilder.addEnumConstant(entry.getKey());
+  private static String getDescription(AbstractDescribedNode<?> describedNode) {
+    Description description = describedNode.getDescription();
+    if (description == null) {
+      return "";
     }
-    JavaFile javaFileEntityType =
-        JavaFile.builder(rootPackageName, entityTypeBuilder.build()).build();
-
-    util.generateSourceFile(
-        entityTypeClassName.canonicalName(), javaFileEntityType.toString(), null);
+    return requireNonNullElse(description.getContent(), "");
   }
 }

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Order.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Order.graphqls
@@ -1,7 +1,12 @@
 #TODO Testcases: A, A!, [A], [A]!, [A!], [A!]! -> 4 types of As (Scalars, entities, composedTypes, types)
-directive @test on ARGUMENT_DEFINITION
-type Order @entity{
+"""
+An order
+"""
+type Order @entity @subPackage(name: "order"){
     id: ID
+    """
+    List of order Item names in this order
+    """
     orderItemNames: [String] @dataFetcher(vajramId: "GetOrderItemNames", subPackage: "order")
     nameString: String @dataFetcher(vajramId: "GetOrderItemNames", subPackage: "order")
     dummy(name: String): Dummy @idFetcher(vajramId: "GetDummyIdForOrder", subPackage: "order")

--- a/vajram/extensions/graphql/vajram-graphql/src/main/graphqls/KrystalGraphQLSpec.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql/src/main/graphqls/KrystalGraphQLSpec.graphqls
@@ -56,6 +56,11 @@ the sub package suffix can be specified separately in the @dataFetcher and @idFe
 directive @rootPackage(name: String!) on SCHEMA
 
 """
+Specifies the sub package inside @rootPackage under which all the models corresponding to an object are to be generated
+"""
+directive @subPackage(name: String!) on OBJECT
+
+"""
 Specifies that a given non-entity type can be composed inside an entity of type entityType.
 This means that any @dataFetchers or @idFetchers on the fields of the type must accept
 the entity Id of the specified entity and compute the values of the fields based on the entity Id.

--- a/vajram/extensions/graphql/vajram-graphql/src/main/java/com/flipkart/krystal/vajram/graphql/api/Constants.java
+++ b/vajram/extensions/graphql/vajram-graphql/src/main/java/com/flipkart/krystal/vajram/graphql/api/Constants.java
@@ -16,6 +16,8 @@ public class Constants {
     public static final String ID_FETCHER = "idFetcher";
     public static final String INHERIT_ID_FROM_ARGS = "inferIdFromArgs";
     public static final String INHERIT_ID_FROM_PARENT = "inferIdFromParent";
+    public static final String ROOT_PACKAGE = "rootPackage";
+    public static final String SUB_PACKAGE = "subPackage";
   }
 
   @UtilityClass
@@ -24,6 +26,7 @@ public class Constants {
     public static final String SUB_PACKAGE = "subPackage";
     public static final String VAJRAM_ID = "vajramId";
     public static final String ENTITY_ID_FIELD = "entityIdField";
+    public static final String NAME = "name";
   }
 
   @UtilityClass


### PR DESCRIPTION
Backward incompatible changes: GraphQlEntity enum is not longer generated

Changes impact only Graphql related code. Other code should remain unimpacted.

Changes:
* Better logging of errors
* Continue GraphQl Code generation of other types even if there are errors in one type.
* Add support for specifying custom subPackages on types for code generation
* Remove EntityType enum generation
* Copy graphql schema descriptions to generated javadoc