### PR TITLE
Standard Singular Loop Variable Name 

### DIFF
--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQlRespJsonModelGen.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQlRespJsonModelGen.java
@@ -1100,7 +1100,7 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
 
       // Get element type name for loop variable
       TypeMirror elementType = getListElementType(returnType);
-      String singularName = fieldName + "_item";
+      String singularName = "_item";
 
       directSetter.beginControlFlow("for ($T $L : $L)", elementType, singularName, fieldName);
       directSetter.addStatement("_result.add($T.withValue($L))", Errable.class, singularName);


### PR DESCRIPTION
Use a standard singular loop variable name (_item) instead of singular name inferring in the GraphQLRespJson generation in order to avoid java keyword conflict caused by singular name inferring (Example: For packages -> singular name: package - conflict with Java keyword)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted code generation behavior for list field iteration in GraphQL code generation. No changes to public APIs or end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->