### PR TITLE
Rename generated class suffix from `_McpTools` to `_QuarksusMcpTools`

### DIFF
--- a/lattice/extensions/mcp/lattice-mcp/src/main/java/com/flipkart/krystal/lattice/ext/mcp/McpServerDopant.java
+++ b/lattice/extensions/mcp/lattice-mcp/src/main/java/com/flipkart/krystal/lattice/ext/mcp/McpServerDopant.java
@@ -9,10 +9,8 @@ import com.flipkart.krystal.lattice.core.doping.DopantType;
 import com.flipkart.krystal.lattice.ext.mcp.api.McpServer;
 import com.flipkart.krystal.lattice.krystex.KrystexDopant;
 import com.flipkart.krystal.lattice.vajram.VajramRequestExecutionContext;
-import com.flipkart.krystal.pooling.LeaseUnavailableException;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 @Singleton

--- a/lattice/extensions/mcp/quarkus/lattice-mcp-quarkus-codegen/src/main/java/com/flipkart/krystal/lattice/ext/mcp/quarkus/codegen/QuarkusMcpCodegenProvider.java
+++ b/lattice/extensions/mcp/quarkus/lattice-mcp-quarkus-codegen/src/main/java/com/flipkart/krystal/lattice/ext/mcp/quarkus/codegen/QuarkusMcpCodegenProvider.java
@@ -61,7 +61,7 @@ public class QuarkusMcpCodegenProvider implements LatticeCodeGeneratorProvider {
       ClassName mcpToolsClassName =
           ClassName.get(
               util.getPackageName(latticeAppTypeElement),
-              latticeAppTypeElement.getSimpleName().toString() + "_McpTools");
+              latticeAppTypeElement.getSimpleName().toString() + "_QuarkusMcpTools");
 
       TypeSpec.Builder mcpToolsClassBuilder =
           util.classBuilder(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the naming convention for generated MCP tools classes in the Quarkus code generation module.
  * Removed unused imports to improve code quality and reduce unnecessary dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->