### PR TITLE
Add support proto model list builders

### DIFF
--- a/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
@@ -233,7 +233,7 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
     }
 
     @Override
-    public @NonNull Iterator<T> iterator() {
+    public Iterator<T> iterator() {
       if (!delegate.isEmpty()) {
         ensureMutable();
       }
@@ -241,12 +241,12 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
     }
 
     @Override
-    public @NonNull Object[] toArray() {
+    public Object[] toArray() {
       return delegate.toArray();
     }
 
     @Override
-    public @NonNull <T1> T1[] toArray(@NonNull T1[] a) {
+    public <T1> T1[] toArray(T1[] a) {
       return delegate.toArray(a);
     }
 
@@ -258,39 +258,42 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
     @Override
     public boolean remove(Object o) {
+      ensureMutable();
       return delegate.remove(o);
     }
 
     @SuppressWarnings("SlowListContainsAll")
     @Override
-    public boolean containsAll(@NonNull Collection<?> c) {
+    public boolean containsAll(Collection<?> c) {
       return delegate.containsAll(c);
     }
 
     @Override
-    public boolean addAll(@NonNull Collection<? extends T> c) {
+    public boolean addAll(Collection<? extends T> c) {
       ensureMutable();
       return delegate.addAll(c);
     }
 
     @Override
     public boolean addAll(int index, Collection<? extends T> c) {
-      if (!c.isEmpty()) {
-        ensureMutable();
+      if (c.isEmpty()) {
+        return false;
       }
+      ensureMutable();
       return delegate.addAll(index, c);
     }
 
     @Override
-    public boolean removeAll(@NonNull Collection<?> c) {
-      if (!c.isEmpty()) {
-        ensureMutable();
+    public boolean removeAll(Collection<?> c) {
+      if (c.isEmpty()) {
+        return false;
       }
+      ensureMutable();
       return delegate.removeAll(c);
     }
 
     @Override
-    public boolean retainAll(@NonNull Collection<?> c) {
+    public boolean retainAll(Collection<?> c) {
       ensureMutable();
       return delegate.retainAll(c);
     }
@@ -337,23 +340,19 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
     }
 
     @Override
-    public @NonNull ListIterator<T> listIterator() {
-      if (!delegate.isEmpty()) {
-        ensureMutable();
-      }
+    public ListIterator<T> listIterator() {
+      ensureMutable();
       return delegate.listIterator();
     }
 
     @Override
-    public @NonNull ListIterator<T> listIterator(int index) {
-      if (!delegate.isEmpty()) {
-        ensureMutable();
-      }
+    public ListIterator<T> listIterator(int index) {
+      ensureMutable();
       return delegate.listIterator(index);
     }
 
     @Override
-    public @NonNull List<T> subList(int fromIndex, int toIndex) {
+    public List<T> subList(int fromIndex, int toIndex) {
       return delegate.subList(fromIndex, toIndex);
     }
   }

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
@@ -1,0 +1,365 @@
+package com.flipkart.krystal.model;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+import com.flipkart.krystal.model.ImmutableModel.Builder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import lombok.Getter;
+import lombok.Setter;
+import org.jspecify.annotations.NonNull;
+
+final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B extends Builder>
+    implements ModelListBuilder<M, I, B> {
+
+  public static <M extends Model, I extends ImmutableModel, B extends Builder>
+      BasicModelListBuilder<M, I, B> empty() {
+    return new BasicModelListBuilder<>(ImmutableList.of());
+  }
+
+  /**
+   * A list which can contain either an immutable model or it's builder. Immutable models are
+   * replaced with Builders on-demand when the value needs to be mutated. This strategy allows us to
+   * prevent unnecessary object creation unless actually needed.
+   */
+  private final ListHolder<Model> models;
+
+  private final ModelsListView<M, I> immutModelsView;
+  private final UnmodifiableModelList<M, I> unmodifiableModelsView;
+
+  @SuppressWarnings("unchecked")
+  private BasicModelListBuilder(List<M> models) {
+    ListHolder<M> listHolder;
+    if (models instanceof ImmutableList) {
+      listHolder = new ListHolder<>(models);
+    } else {
+      listHolder = new ListHolder<>(new ArrayList<>(models));
+    }
+    this.models = (ListHolder<Model>) listHolder;
+    this.immutModelsView = new ModelsListView<>(this, unmodifiableList(listHolder));
+    this.unmodifiableModelsView = new UnmodifiableModelList<>(immutModelsView);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public ModelsListView<M, I> immutModelsView() {
+    return immutModelsView;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public UnmodifiableModelList<M, I> unmodifiableModelsView() {
+    return unmodifiableModelsView;
+  }
+
+  @Override
+  public int size() {
+    return models.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return models.isEmpty();
+  }
+
+  @Override
+  public boolean addModel(M model) {
+    ensureMutable();
+    return models.add(model);
+  }
+
+  @Override
+  public void addModel(int index, M element) {
+    ensureMutable();
+    models.add(index, element);
+  }
+
+  @Override
+  public boolean addBuilder(B b) {
+    ensureMutable();
+    return models.add(b);
+  }
+
+  @Override
+  public void addBuilder(int index, B element) {
+    ensureMutable();
+    models.add(index, element);
+  }
+
+  @Override
+  public boolean addAllModels(Iterable<? extends M> iterable) {
+    if (!iterable.iterator().hasNext()) {
+      return false;
+    }
+    ensureMutable();
+    if (iterable instanceof Collection<? extends M> c) {
+      return models.addAll(c);
+    }
+    for (M m : iterable) {
+      models.add(m);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean addAllModels(int index, Iterable<? extends M> iterable) {
+    if (!iterable.iterator().hasNext()) {
+      return false;
+    }
+    ensureMutable();
+    if (iterable instanceof Collection<? extends M> c) {
+      return models.addAll(index, c);
+    }
+    int i = index;
+    for (M m : iterable) {
+      models.add(i++, m);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean addAllBuilders(Iterable<? extends B> iterable) {
+    if (!iterable.iterator().hasNext()) {
+      return false;
+    }
+    ensureMutable();
+    if (iterable instanceof Collection<? extends B> c) {
+      return models.addAll(c);
+    }
+    for (B b : iterable) {
+      models.add(b);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean addAllBuilders(int index, Iterable<? extends B> iterable) {
+    if (!iterable.iterator().hasNext()) {
+      return false;
+    }
+    ensureMutable();
+    if (iterable instanceof Collection<? extends B> c) {
+      return models.addAll(index, c);
+    }
+    int i = index;
+    for (B b : iterable) {
+      models.add(i++, b);
+    }
+    return true;
+  }
+
+  @Override
+  public void clear() {
+    ensureMutable();
+    models.clear();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public M getModel(int index) {
+    Model model = models.get(index);
+    if (model instanceof ImmutableModel) {
+      return (M) model;
+    } else {
+      return (M) model._build();
+    }
+  }
+
+  @Override
+  public B getBuilder(int index) {
+    return ensureBuilderAtIndex(index);
+  }
+
+  @Override
+  public void setModel(int index, M element) {
+    ensureMutable();
+    models.set(index, element);
+  }
+
+  @Override
+  public void setBuilder(int index, B element) {
+    ensureMutable();
+    models.set(index, element);
+  }
+
+  @Override
+  public Model remove(int index) {
+    ensureMutable();
+    return models.remove(index);
+  }
+
+  @Override
+  public Iterator<M> modelsIterator() {
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Iterator<B> buildersIterator() {
+    for (int i = 0; i < models.size(); i++) {
+      ensureBuilderAtIndex(i);
+    }
+    return Iterators.transform(models.iterator(), model -> (B) requireNonNull(model)._asBuilder());
+  }
+
+  private void ensureMutable() {
+    models.ensureMutable();
+  }
+
+  @SuppressWarnings("unchecked")
+  private B ensureBuilderAtIndex(int i) {
+    Model elementAtIndex = models.get(i);
+    if (elementAtIndex instanceof ImmutableModel _immut) {
+      ensureMutable();
+      Builder builder = _immut._asBuilder();
+      models.set(i, builder);
+      return (B) builder;
+    } else {
+      return (B) elementAtIndex._asBuilder();
+    }
+  }
+
+  /**
+   * A holder for a list that can be mutable or immutable. An immutable list is swapped with a
+   * mutable list only when the list needs ot be modified, thus preventing unnecessary memory
+   * allocation.
+   *
+   * @param <T>
+   */
+  private static class ListHolder<T> implements List<T> {
+    @Getter @Setter private List<T> delegate;
+
+    private ListHolder(List<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    private void ensureMutable() {
+      List<T> delegate = delegate();
+      if (delegate instanceof ImmutableList<?>) {
+        delegate(new ArrayList<>(delegate));
+      }
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return delegate.contains(o);
+    }
+
+    @Override
+    public @NonNull Iterator<T> iterator() {
+      return delegate.iterator();
+    }
+
+    @Override
+    public @NonNull Object[] toArray() {
+      return delegate.toArray();
+    }
+
+    @Override
+    public @NonNull <T1> T1[] toArray(@NonNull T1[] a) {
+      return delegate.toArray(a);
+    }
+
+    @Override
+    public boolean add(T t) {
+      return delegate.add(t);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      return delegate.remove(o);
+    }
+
+    @SuppressWarnings("SlowListContainsAll")
+    @Override
+    public boolean containsAll(@NonNull Collection<?> c) {
+      return delegate.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(@NonNull Collection<? extends T> c) {
+      return delegate.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, @NonNull Collection<? extends T> c) {
+      return delegate.addAll(index, c);
+    }
+
+    @Override
+    public boolean removeAll(@NonNull Collection<?> c) {
+      return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(@NonNull Collection<?> c) {
+      return delegate.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+      delegate.clear();
+    }
+
+    @Override
+    public T get(int index) {
+      return delegate.get(index);
+    }
+
+    @Override
+    public T set(int index, T element) {
+      return delegate.set(index, element);
+    }
+
+    @Override
+    public void add(int index, T element) {
+      delegate.add(index, element);
+    }
+
+    @Override
+    public T remove(int index) {
+      return delegate.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+      return delegate.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+      return delegate.lastIndexOf(o);
+    }
+
+    @Override
+    public @NonNull ListIterator<T> listIterator() {
+      return delegate.listIterator();
+    }
+
+    @Override
+    public @NonNull ListIterator<T> listIterator(int index) {
+      return delegate.listIterator(index);
+    }
+
+    @Override
+    public @NonNull List<T> subList(int fromIndex, int toIndex) {
+      return delegate.subList(fromIndex, toIndex);
+    }
+  }
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
@@ -1,11 +1,9 @@
 package com.flipkart.krystal.model;
 
 import static java.util.Collections.unmodifiableList;
-import static java.util.Objects.requireNonNull;
 
 import com.flipkart.krystal.model.ImmutableModel.Builder;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -70,36 +68,31 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
   @Override
   public boolean addModel(M model) {
-    ensureMutable();
     return models.add(model);
   }
 
   @Override
   public void addModel(int index, M element) {
-    ensureMutable();
     models.add(index, element);
   }
 
   @Override
   public boolean addBuilder(B b) {
-    ensureMutable();
     return models.add(b);
   }
 
   @Override
   public void addBuilder(int index, B element) {
-    ensureMutable();
     models.add(index, element);
   }
 
   @Override
   public boolean addAllModels(Iterable<? extends M> iterable) {
-    if (!iterable.iterator().hasNext()) {
-      return false;
-    }
-    ensureMutable();
     if (iterable instanceof Collection<? extends M> c) {
       return models.addAll(c);
+    }
+    if (!iterable.iterator().hasNext()) {
+      return false;
     }
     for (M m : iterable) {
       models.add(m);
@@ -109,12 +102,11 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
   @Override
   public boolean addAllModels(int index, Iterable<? extends M> iterable) {
-    if (!iterable.iterator().hasNext()) {
-      return false;
-    }
-    ensureMutable();
     if (iterable instanceof Collection<? extends M> c) {
       return models.addAll(index, c);
+    }
+    if (!iterable.iterator().hasNext()) {
+      return false;
     }
     int i = index;
     for (M m : iterable) {
@@ -125,12 +117,11 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
   @Override
   public boolean addAllBuilders(Iterable<? extends B> iterable) {
-    if (!iterable.iterator().hasNext()) {
-      return false;
-    }
-    ensureMutable();
     if (iterable instanceof Collection<? extends B> c) {
       return models.addAll(c);
+    }
+    if (!iterable.iterator().hasNext()) {
+      return false;
     }
     for (B b : iterable) {
       models.add(b);
@@ -140,12 +131,11 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
   @Override
   public boolean addAllBuilders(int index, Iterable<? extends B> iterable) {
-    if (!iterable.iterator().hasNext()) {
-      return false;
-    }
-    ensureMutable();
     if (iterable instanceof Collection<? extends B> c) {
       return models.addAll(index, c);
+    }
+    if (!iterable.iterator().hasNext()) {
+      return false;
     }
     int i = index;
     for (B b : iterable) {
@@ -156,7 +146,6 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
   @Override
   public void clear() {
-    ensureMutable();
     models.clear();
   }
 
@@ -178,34 +167,17 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
   @Override
   public void setModel(int index, M element) {
-    ensureMutable();
     models.set(index, element);
   }
 
   @Override
   public void setBuilder(int index, B element) {
-    ensureMutable();
     models.set(index, element);
   }
 
   @Override
   public Model remove(int index) {
-    ensureMutable();
     return models.remove(index);
-  }
-
-  @Override
-  public Iterator<M> modelsIterator() {
-    return null;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public Iterator<B> buildersIterator() {
-    for (int i = 0; i < models.size(); i++) {
-      ensureBuilderAtIndex(i);
-    }
-    return Iterators.transform(models.iterator(), model -> (B) requireNonNull(model)._asBuilder());
   }
 
   private void ensureMutable() {
@@ -240,7 +212,6 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
     }
 
     private void ensureMutable() {
-      List<T> delegate = delegate();
       if (delegate instanceof ImmutableList<?>) {
         delegate(new ArrayList<>(delegate));
       }
@@ -263,6 +234,9 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
     @Override
     public @NonNull Iterator<T> iterator() {
+      if (!delegate.isEmpty()) {
+        ensureMutable();
+      }
       return delegate.iterator();
     }
 
@@ -278,6 +252,7 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
     @Override
     public boolean add(T t) {
+      ensureMutable();
       return delegate.add(t);
     }
 
@@ -294,27 +269,38 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
     @Override
     public boolean addAll(@NonNull Collection<? extends T> c) {
+      ensureMutable();
       return delegate.addAll(c);
     }
 
     @Override
-    public boolean addAll(int index, @NonNull Collection<? extends T> c) {
+    public boolean addAll(int index, Collection<? extends T> c) {
+      if (!c.isEmpty()) {
+        ensureMutable();
+      }
       return delegate.addAll(index, c);
     }
 
     @Override
     public boolean removeAll(@NonNull Collection<?> c) {
+      if (!c.isEmpty()) {
+        ensureMutable();
+      }
       return delegate.removeAll(c);
     }
 
     @Override
     public boolean retainAll(@NonNull Collection<?> c) {
+      ensureMutable();
       return delegate.retainAll(c);
     }
 
     @Override
     public void clear() {
-      delegate.clear();
+      if (!delegate.isEmpty()) {
+        ensureMutable();
+        delegate.clear();
+      }
     }
 
     @Override
@@ -324,16 +310,19 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
     @Override
     public T set(int index, T element) {
+      ensureMutable();
       return delegate.set(index, element);
     }
 
     @Override
     public void add(int index, T element) {
+      ensureMutable();
       delegate.add(index, element);
     }
 
     @Override
     public T remove(int index) {
+      ensureMutable();
       return delegate.remove(index);
     }
 
@@ -349,11 +338,17 @@ final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B e
 
     @Override
     public @NonNull ListIterator<T> listIterator() {
+      if (!delegate.isEmpty()) {
+        ensureMutable();
+      }
       return delegate.listIterator();
     }
 
     @Override
     public @NonNull ListIterator<T> listIterator(int index) {
+      if (!delegate.isEmpty()) {
+        ensureMutable();
+      }
       return delegate.listIterator(index);
     }
 

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/ImmutableModelList.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/ImmutableModelList.java
@@ -1,0 +1,12 @@
+package com.flipkart.krystal.model;
+
+import java.util.List;
+
+public interface ImmutableModelList<M extends Model, I extends ImmutableModel> extends List<I> {
+  <B extends ImmutableModel.Builder> ModelListBuilder<M, I, B> modelsBuilder();
+
+  @SuppressWarnings("unchecked")
+  default UnmodifiableModelList<M, I> asModelsView() {
+    return new UnmodifiableModelList<>(this);
+  }
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/ModelListBuilder.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/ModelListBuilder.java
@@ -1,7 +1,5 @@
 package com.flipkart.krystal.model;
 
-import java.util.Iterator;
-
 public interface ModelListBuilder<
     M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder> {
   static <M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder>
@@ -44,8 +42,4 @@ public interface ModelListBuilder<
   void setBuilder(int index, B element);
 
   Model remove(int index);
-
-  Iterator<M> modelsIterator();
-
-  Iterator<B> buildersIterator();
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/ModelListBuilder.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/ModelListBuilder.java
@@ -1,290 +1,51 @@
 package com.flipkart.krystal.model;
 
-import static java.util.Objects.requireNonNull;
-import static lombok.AccessLevel.PACKAGE;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import lombok.Getter;
-import lombok.Setter;
-import org.jspecify.annotations.NonNull;
 
-public final class ModelListBuilder<
+public interface ModelListBuilder<
     M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder> {
-
-  public static <M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder>
+  static <M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder>
       ModelListBuilder<M, I, B> empty() {
-    return new ModelListBuilder<>(ImmutableList.of());
+    return BasicModelListBuilder.empty();
   }
 
-  @SuppressWarnings("unchecked")
-  public static <M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder>
-      ModelListBuilder<M, I, B> ofModels(ModelsListView<M, I> modelsListView) {
-    return (ModelListBuilder<M, I, B>) modelsListView.source();
-  }
+  ImmutableModelList<M, I> immutModelsView();
 
-  @Getter(PACKAGE)
-  private final ListHolder<Model> models;
+  UnmodifiableModelList<M, I> unmodifiableModelsView();
 
-  @SuppressWarnings("unchecked")
-  private ModelListBuilder(List<M> models) {
-    if (models instanceof ImmutableList) {
-      this.models = new ListHolder<>((List<Model>) models);
-    } else {
-      this.models = new ListHolder<>(new ArrayList<>(models));
-    }
-  }
+  int size();
 
-  public int size() {
-    return models().size();
-  }
+  boolean isEmpty();
 
-  public boolean isEmpty() {
-    return models().isEmpty();
-  }
+  boolean addModel(M model);
 
-  @SuppressWarnings("unchecked")
-  public boolean addModel(M m) {
-    ensureMutable();
-    return models().add(m);
-  }
+  void addModel(int index, M element);
 
-  public void addModel(int index, M element) {
-    ensureMutable();
-    models().add(index, element);
-  }
+  boolean addBuilder(B b);
 
-  @SuppressWarnings("unchecked")
-  public boolean addBuilder(B b) {
-    ensureMutable();
-    return models().add(b);
-  }
+  void addBuilder(int index, B element);
 
-  public void addBuilder(int index, B element) {
-    ensureMutable();
-    models().add(index, element);
-  }
+  boolean addAllModels(Iterable<? extends M> c);
 
-  @SuppressWarnings("unchecked")
-  public boolean addAllModels(Collection<? extends M> c) {
-    ensureMutable();
-    return models().addAll(c);
-  }
+  boolean addAllModels(int index, Iterable<? extends M> c);
 
-  @SuppressWarnings("unchecked")
-  public boolean addAllModels(int index, Collection<? extends M> c) {
-    ensureMutable();
-    return models().addAll(index, c);
-  }
+  boolean addAllBuilders(Iterable<? extends B> c);
 
-  @SuppressWarnings("unchecked")
-  public boolean addAllBuilders(Collection<? extends B> c) {
-    ensureMutable();
-    return models().addAll(c);
-  }
+  boolean addAllBuilders(int index, Iterable<? extends B> c);
 
-  @SuppressWarnings("unchecked")
-  public boolean addAllBuilders(int index, Collection<? extends B> c) {
-    ensureMutable();
-    return models().addAll(index, c);
-  }
+  void clear();
 
-  public void clear() {
-    ensureMutable();
-    models().clear();
-  }
+  M getModel(int index);
 
-  public B get(int index) {
-    return ensureBuilderAtIndex(index);
-  }
+  B getBuilder(int index);
 
-  @SuppressWarnings("unchecked")
-  public void setModel(int index, M element) {
-    ensureMutable();
-    models().set(index, element);
-  }
+  void setModel(int index, M element);
 
-  @SuppressWarnings("unchecked")
-  public void setBuilder(int index, B element) {
-    ensureMutable();
-    models().set(index, element);
-  }
+  void setBuilder(int index, B element);
 
-  public Model remove(int index) {
-    ensureMutable();
-    return models().remove(index);
-  }
+  Model remove(int index);
 
-  @SuppressWarnings("unchecked")
-  public Iterator<B> iterator() {
-    for (int i = 0; i < models().size(); i++) {
-      ensureBuilderAtIndex(i);
-    }
-    return Iterators.transform(
-        models().iterator(), model -> (B) requireNonNull(model)._asBuilder());
-  }
+  Iterator<M> modelsIterator();
 
-  public ModelsListView<M, I> modelsListView() {
-    return new ModelsListView<>(this);
-  }
-
-  private void ensureMutable() {
-    models.ensureMutable();
-  }
-
-  @SuppressWarnings("unchecked")
-  private B ensureBuilderAtIndex(int i) {
-    Model elementAtIndex = models().get(i);
-    if (elementAtIndex instanceof ImmutableModel _immut) {
-      ensureMutable();
-      ImmutableModel.Builder builder = _immut._asBuilder();
-      models().set(i, builder);
-      return (B) builder;
-    } else {
-      return (B) elementAtIndex._asBuilder();
-    }
-  }
-
-  /**
-   * A holder for a list that can be mutable or immutable. This class allows the {@link
-   * ModelListBuilder#models()} to be used to create a view of the current models in the models
-   * list.
-   *
-   * @param <T>
-   */
-  static class ListHolder<T> implements List<T> {
-    @Getter @Setter private List<T> delegate;
-
-    private ListHolder(List<T> delegate) {
-      this.delegate = delegate;
-    }
-
-    private void ensureMutable() {
-      List<T> delegate = delegate();
-      if (delegate instanceof ImmutableList<?>) {
-        delegate(new ArrayList<>(delegate));
-      }
-    }
-
-    @Override
-    public int size() {
-      return delegate.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-      return delegate.isEmpty();
-    }
-
-    @Override
-    public boolean contains(Object o) {
-      return delegate.contains(o);
-    }
-
-    @Override
-    public @NonNull Iterator<T> iterator() {
-      return delegate.iterator();
-    }
-
-    @Override
-    public @NonNull Object[] toArray() {
-      return delegate.toArray();
-    }
-
-    @Override
-    public @NonNull <T1> T1[] toArray(@NonNull T1[] a) {
-      return delegate.toArray(a);
-    }
-
-    @Override
-    public boolean add(T t) {
-      return delegate.add(t);
-    }
-
-    @Override
-    public boolean remove(Object o) {
-      return delegate.remove(o);
-    }
-
-    @SuppressWarnings("SlowListContainsAll")
-    @Override
-    public boolean containsAll(@NonNull Collection<?> c) {
-      return delegate.containsAll(c);
-    }
-
-    @Override
-    public boolean addAll(@NonNull Collection<? extends T> c) {
-      return delegate.addAll(c);
-    }
-
-    @Override
-    public boolean addAll(int index, @NonNull Collection<? extends T> c) {
-      return delegate.addAll(index, c);
-    }
-
-    @Override
-    public boolean removeAll(@NonNull Collection<?> c) {
-      return delegate.removeAll(c);
-    }
-
-    @Override
-    public boolean retainAll(@NonNull Collection<?> c) {
-      return delegate.retainAll(c);
-    }
-
-    @Override
-    public void clear() {
-      delegate.clear();
-    }
-
-    @Override
-    public T get(int index) {
-      return delegate.get(index);
-    }
-
-    @Override
-    public T set(int index, T element) {
-      return delegate.set(index, element);
-    }
-
-    @Override
-    public void add(int index, T element) {
-      delegate.add(index, element);
-    }
-
-    @Override
-    public T remove(int index) {
-      return delegate.remove(index);
-    }
-
-    @Override
-    public int indexOf(Object o) {
-      return delegate.indexOf(o);
-    }
-
-    @Override
-    public int lastIndexOf(Object o) {
-      return delegate.lastIndexOf(o);
-    }
-
-    @Override
-    public @NonNull ListIterator<T> listIterator() {
-      return delegate.listIterator();
-    }
-
-    @Override
-    public @NonNull ListIterator<T> listIterator(int index) {
-      return delegate.listIterator(index);
-    }
-
-    @Override
-    public @NonNull List<T> subList(int fromIndex, int toIndex) {
-      return delegate.subList(fromIndex, toIndex);
-    }
-  }
+  Iterator<B> buildersIterator();
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/ModelsListView.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/ModelsListView.java
@@ -1,50 +1,49 @@
 package com.flipkart.krystal.model;
 
 import static java.util.Objects.requireNonNull;
-import static lombok.AccessLevel.PACKAGE;
 
 import com.google.common.collect.Lists;
 import java.util.AbstractList;
 import java.util.List;
 import java.util.RandomAccess;
-import lombok.Getter;
 
-public class ModelsListView<M extends Model, I extends ImmutableModel> extends AbstractList<M>
-    implements RandomAccess, UnmodifiableModelList<M, I> {
+public class ModelsListView<M extends Model, I extends ImmutableModel> extends AbstractList<I>
+    implements RandomAccess, ImmutableModelList<M, I> {
 
-  private final List<M> delegate;
-
-  @Getter(PACKAGE)
-  private final ModelListBuilder<M, I, ?> source;
-
-  public ModelsListView() {
-    this(ModelListBuilder.empty());
+  public static <M extends Model, I extends ImmutableModel> ModelsListView<M, I> empty() {
+    return BasicModelListBuilder.<M, I, ImmutableModel.Builder>empty().immutModelsView();
   }
 
+  private final List<I> delegate;
+
+  private final ModelListBuilder<M, I, ?> modelsBuilder;
+
   @SuppressWarnings("unchecked")
-  public ModelsListView(ModelListBuilder<M, I, ?> modelListBuilder) {
-    this.source = modelListBuilder;
+  ModelsListView(ModelListBuilder<M, I, ?> modelListBuilder, List<M> models) {
+    this.modelsBuilder = modelListBuilder;
     this.delegate =
         Lists.transform(
-            modelListBuilder.models(),
+            models,
             model ->
                 model instanceof ImmutableModel immut
-                    ? (M) immut
-                    : (M) requireNonNull(model)._asBuilder()._build());
+                    ? (I) immut
+                    : (I) requireNonNull(model)._asBuilder()._build());
   }
 
   @Override
-  public M get(int index) {
+  @SuppressWarnings("unchecked")
+  public <B extends ImmutableModel.Builder> ModelListBuilder<M, I, B> modelsBuilder() {
+    return (ModelListBuilder<M, I, B>) modelsBuilder;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public I get(int index) {
     return delegate.get(index);
   }
 
   @Override
   public int size() {
     return delegate.size();
-  }
-
-  @SuppressWarnings("unchecked")
-  public ModelsListView<I, I> asImmutableModelsList() {
-    return (ModelsListView<I, I>) this;
   }
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/UnmodifiableModelList.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/UnmodifiableModelList.java
@@ -1,5 +1,28 @@
 package com.flipkart.krystal.model;
 
-import java.util.List;
+import java.util.AbstractList;
 
-public interface UnmodifiableModelList<M extends Model, I extends ImmutableModel> extends List<M> {}
+public final class UnmodifiableModelList<M extends Model, I extends ImmutableModel>
+    extends AbstractList<M> {
+
+  private final ImmutableModelList<M, I> delegate;
+
+  public UnmodifiableModelList(ImmutableModelList<M, I> delegate) {
+    this.delegate = delegate;
+  }
+
+  public <B extends ImmutableModel.Builder> ModelListBuilder<M, I, B> modelsBuilder() {
+    return delegate.modelsBuilder();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public M get(int index) {
+    return (M) delegate.get(index);
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+}

--- a/lattice/samples/grpc-proto3-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/grpc/proto/sampleProtoService/ProtoMessage.java
+++ b/lattice/samples/grpc-proto3-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/grpc/proto/sampleProtoService/ProtoMessage.java
@@ -6,12 +6,13 @@ import com.flipkart.krystal.model.IfAbsent;
 import com.flipkart.krystal.model.Model;
 import com.flipkart.krystal.model.ModelRoot;
 import com.flipkart.krystal.model.ModelRoot.ModelType;
+import com.flipkart.krystal.model.PlainJavaObject;
 import com.flipkart.krystal.model.SupportedModelProtocols;
 import com.flipkart.krystal.serial.SerialId;
 import com.flipkart.krystal.vajram.protobuf3.Protobuf3;
 
 @ModelRoot(type = ModelType.RESPONSE)
-@SupportedModelProtocols(Protobuf3.class)
+@SupportedModelProtocols({Protobuf3.class, PlainJavaObject.class})
 public interface ProtoMessage extends Model {
   @SerialId(1)
   @IfAbsent(FAIL)

--- a/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto/sampleProtoService/ModelListBuilderTest.java
+++ b/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto/sampleProtoService/ModelListBuilderTest.java
@@ -1,6 +1,5 @@
 package com.flipkart.krystal.lattice.samples.grpc.proto.sampleProtoService;
 
-import static com.flipkart.krystal.model.ModelListBuilder.ofModels;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flipkart.krystal.model.ModelListBuilder;
@@ -11,22 +10,25 @@ class ModelListBuilderTest {
   @Test
   void test() {
 
-    var modelListView =
-        ModelListBuilder
-            .<Proto3LatticeSampleResponse, Proto3LatticeSampleResponse_Immut,
-                Proto3LatticeSampleResponse_Immut.Builder>
-                ofModels(new ModelsListView<>())
-            .modelsListView();
+    ModelsListView<Proto3LatticeSampleResponse, Proto3LatticeSampleResponse_Immut> og =
+        ModelsListView.empty();
 
+    var modelListView = og.modelsBuilder().immutModelsView();
     assertThat(modelListView).size().isZero();
 
     ModelListBuilder<
             Proto3LatticeSampleResponse,
             Proto3LatticeSampleResponse_Immut,
             Proto3LatticeSampleResponse_Immut.Builder>
-        newBuilder = ofModels(modelListView);
+        newBuilder = modelListView.modelsBuilder();
     newBuilder.addModel(Proto3LatticeSampleResponse_ImmutProto._builder()._build());
 
+    assertThat(og).size().isOne();
     assertThat(modelListView).size().isOne();
+
+    newBuilder.addBuilder(Proto3LatticeSampleResponse_ImmutProto._builder());
+
+    assertThat(og).size().isEqualTo(2);
+    assertThat(modelListView).size().isEqualTo(2);
   }
 }

--- a/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto/sampleProtoService/ProtoListBuilderTest.java
+++ b/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto/sampleProtoService/ProtoListBuilderTest.java
@@ -1,0 +1,29 @@
+package com.flipkart.krystal.lattice.samples.grpc.proto.sampleProtoService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.flipkart.krystal.model.ImmutableModel.Builder;
+import com.flipkart.krystal.model.ModelListBuilder;
+import org.junit.jupiter.api.Test;
+
+class ProtoListBuilderTest {
+
+  @Test
+  void protoBuilderListModification_success() {
+    SubMessage_ImmutProto.Builder subMessageBuilder = SubMessage_ImmutProto._builder();
+    ModelListBuilder<ProtoMessage, ProtoMessage_Immut, Builder> protoMessagesBuilder =
+        subMessageBuilder.protoMessages().modelsBuilder();
+    protoMessagesBuilder.addBuilder(ProtoMessage_ImmutProto._builder().count(1));
+    protoMessagesBuilder.addModel(ProtoMessage_ImmutProto._builder().count(2)._build());
+
+    ModelListBuilder<ProtoMessage, ProtoMessage_Immut, ProtoMessage_Immut.Builder>
+        protoMessagesBuilder2 = subMessageBuilder.protoMessages().modelsBuilder();
+
+    protoMessagesBuilder2.addBuilder(ProtoMessage_ImmutPojo._builder().count(3));
+    protoMessagesBuilder2.addModel(ProtoMessage_ImmutPojo._builder().count(4)._build());
+
+    SubMessage_Immut subMessage = subMessageBuilder._build();
+
+    assertThat(subMessage.protoMessages()).hasSize(4);
+  }
+}

--- a/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/proto3/Proto3LatticeSampleTest.java
+++ b/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/proto3/Proto3LatticeSampleTest.java
@@ -26,6 +26,7 @@ import com.flipkart.krystal.pooling.LeaseUnavailableException;
 import com.flipkart.krystal.vajram.VajramDef;
 import com.flipkart.krystal.vajram.exception.MandatoryFacetsMissingException;
 import com.flipkart.krystal.vajram.guice.injection.VajramGuiceInputInjector;
+import com.flipkart.krystal.vajram.protobuf3.SerializableProtoModel;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph.KrystexGraphBuilder;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexVajramExecutor;
@@ -134,7 +135,7 @@ class Proto3LatticeSampleTest {
         .succeedsWithin(1, SECONDS)
         .extracting(Proto3LatticeSampleResponse::protoMessage)
         .asInstanceOf(type(ProtoMessage_ImmutProto.class))
-        .extracting(ProtoMessage_ImmutProto::_proto)
+        .extracting(SerializableProtoModel::_proto)
         .isEqualTo(ProtoMessage_Proto.newBuilder().setCount(100).build());
   }
 

--- a/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/models/InnerDataV2.java
+++ b/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/models/InnerDataV2.java
@@ -7,6 +7,7 @@ import com.flipkart.krystal.model.ModelRoot;
 import com.flipkart.krystal.model.PlainJavaObject;
 import com.flipkart.krystal.model.SupportedModelProtocols;
 import com.flipkart.krystal.vajram.json.Json;
+import java.util.List;
 
 @ModelRoot(type = RESPONSE, builderExtendsModelRoot = true)
 @SupportedModelProtocols({PlainJavaObject.class, Json.class})
@@ -14,4 +15,6 @@ public interface InnerDataV2 extends Model {
   String value();
 
   int count();
+
+  List<InnerData> innerData();
 }

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen/src/main/java/com/flipkart/krystal/vajram/protobuf3/codegen/Proto3ModelsGen.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen/src/main/java/com/flipkart/krystal/vajram/protobuf3/codegen/Proto3ModelsGen.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.vajram.protobuf3.codegen;
 
 import static com.flipkart.krystal.codegen.common.datatypes.StandardJavaType.BYTE;
+import static com.flipkart.krystal.codegen.common.models.CodeGenUtility.ContainerType.LIST;
 import static com.flipkart.krystal.codegen.common.models.CodeGenUtility.capitalizeFirstChar;
 import static com.flipkart.krystal.vajram.protobuf3.Protobuf3.PROTOBUF_3;
 import static com.flipkart.krystal.vajram.protobuf3.codegen.Proto3SchemaGen.validateModelType;
@@ -8,6 +9,8 @@ import static com.flipkart.krystal.vajram.protobuf3.codegen.ProtoGenUtils.isProt
 import static com.flipkart.krystal.vajram.protobuf3.codegen.ProtoGenUtils.isProtoTypeRepeated;
 import static com.flipkart.krystal.vajram.protobuf3.codegen.VajramProtoConstants.MODELS_PROTO_MSG_SUFFIX;
 import static com.squareup.javapoet.MethodSpec.methodBuilder;
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
@@ -25,9 +28,12 @@ import com.flipkart.krystal.model.IfAbsent.IfAbsentThen;
 import com.flipkart.krystal.model.MandatoryFieldMissingException;
 import com.flipkart.krystal.model.Model;
 import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.UnmodifiableModelList;
 import com.flipkart.krystal.serial.SerializableModel;
+import com.flipkart.krystal.vajram.protobuf3.ProtoListBuilder;
 import com.flipkart.krystal.vajram.protobuf3.Protobuf3;
 import com.flipkart.krystal.vajram.protobuf3.SerializableProtoModel;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.squareup.javapoet.AnnotationSpec;
@@ -143,22 +149,24 @@ public class Proto3ModelsGen implements CodeGenerator {
   private TypeSpec generateImplementationTypeSpec(
       TypeElement modelRootType, String packageName, String protoClassName) {
     ClassName immutableProtoType = ClassName.get(packageName, protoClassName);
-    String modelRootName = modelRootType.getSimpleName().toString();
-    ClassName immutModelName = util.getImmutInterfaceName(modelRootType);
-    String protoMsgClassName = modelRootName + MODELS_PROTO_MSG_SUFFIX;
+    ClassName immutInterfaceName = util.getImmutInterfaceName(modelRootType);
+    ClassName immutModelName = immutInterfaceName;
+    ClassName protoMsgType =
+        ClassName.get(
+            packageName, modelRootType.getSimpleName().toString() + MODELS_PROTO_MSG_SUFFIX);
+
+    ClassName protoMsgOrBuilderType =
+        ClassName.get(protoMsgType.packageName(), protoMsgType.simpleName() + "OrBuilder");
 
     // Extract model methods
     List<ExecutableElement> modelMethods = util.extractAndValidateModelMethods(modelRootType);
 
     // Create class interfaces
     TypeName serializableTypeName =
-        ParameterizedTypeName.get(
-            ClassName.get(SerializableProtoModel.class),
-            ClassName.get(packageName, protoMsgClassName));
+        ParameterizedTypeName.get(ClassName.get(SerializableProtoModel.class), protoMsgType);
 
     // Create field types
     TypeName byteArrayType = ArrayTypeName.of(TypeName.BYTE);
-    ClassName protoMsgType = ClassName.get(packageName, protoMsgClassName);
 
     // Create class builder
     Builder classBuilder =
@@ -194,8 +202,16 @@ public class Proto3ModelsGen implements CodeGenerator {
     classBuilder.addMethod(
         MethodSpec.constructorBuilder()
             .addModifiers(PUBLIC)
-            .addParameter(protoMsgType, "_proto")
-            .addStatement("this._proto = _proto")
+            .addParameter(protoMsgOrBuilderType, "_proto")
+            .addCode(
+"""
+    this._proto =
+        _proto instanceof $T _message
+            ? _message
+            : _proto instanceof $T.Builder _builder ? _builder.build() : /* Impossible */ null;
+""",
+                protoMsgType,
+                protoMsgType)
             .addStatement("this._serializedPayload = null")
             .build());
 
@@ -278,7 +294,7 @@ return _serializedPayload;
       TypeMirror returnType = method.getReturnType();
       CodeGenType dataType = new DeclaredTypeVisitor(util, method).visit(returnType);
 
-      classBuilder.addMethod(getterMethod(method, returnType, dataType, false).build());
+      classBuilder.addMethod(getterMethod(method, dataType, false).build());
     }
 
     // Add equals method that delegates to the proto object
@@ -291,18 +307,42 @@ return _serializedPayload;
     // Add Builder inner class
     TypeSpec builderTypeSpec =
         generateBuilderTypeSpec(
-            modelRootType,
-            packageName,
-            protoClassName,
-            protoMsgClassName,
-            immutModelName,
-            modelMethods);
+            modelRootType, packageName, protoClassName, protoMsgType, immutModelName, modelMethods);
     classBuilder.addType(builderTypeSpec);
+    ClassName immutProtoBuilderClass = immutableProtoType.nestedClass("Builder");
     classBuilder.addMethod(
         methodBuilder("_builder")
             .addModifiers(PUBLIC, STATIC)
-            .returns(immutableProtoType.nestedClass("Builder"))
-            .addStatement("return new $T()", immutableProtoType.nestedClass("Builder"))
+            .returns(immutProtoBuilderClass)
+            .addStatement("return new $T()", immutProtoBuilderClass)
+            .build());
+    classBuilder.addMethod(
+        methodBuilder("_proto")
+            .addModifiers(PUBLIC, STATIC)
+            .returns(protoMsgType)
+            .addParameter(TypeName.get(modelRootType.asType()), "_model")
+            .addCode(
+"""
+    return _model instanceof $T _immut
+        ? _immut._proto()
+        : new $T(_model)._proto();
+""",
+                immutableProtoType,
+                immutableProtoType)
+            .build());
+    classBuilder.addMethod(
+        methodBuilder("_proto")
+            .addModifiers(PUBLIC, STATIC)
+            .returns(protoMsgType.nestedClass("Builder"))
+            .addParameter(immutInterfaceName.nestedClass("Builder"), "_builder")
+            .addCode(
+"""
+    return _builder instanceof $T _protoBuilder
+        ? _protoBuilder._proto()
+        : new $T(_builder._build())._asBuilder()._proto();
+""",
+                immutProtoBuilderClass,
+                immutableProtoType)
             .build());
     return classBuilder.build();
   }
@@ -356,23 +396,36 @@ return _serializedPayload;
   }
 
   private MethodSpec.Builder getterMethod(
-      ExecutableElement method, TypeMirror returnType, CodeGenType dataType, boolean isBuilder) {
-    TypeName typeName = TypeName.get(returnType);
+      ExecutableElement method, CodeGenType dataType, boolean isBuilder) {
+    final TypeMirror specifiedType = method.getReturnType();
+    TypeName typeName = TypeName.get(specifiedType);
 
     String methodName = method.getSimpleName().toString();
 
     MethodSpec.Builder getterBuilder =
         methodBuilder(methodName).addAnnotation(Override.class).addModifiers(PUBLIC);
 
+    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(specifiedType);
+    if (isBuilder
+        && fieldModelRootInfo.isPresent()
+        && LIST.equals(fieldModelRootInfo.get().containerType())) {
+      ClassName immutInterfaceName = util.getImmutInterfaceName(fieldModelRootInfo.get().element());
+      typeName =
+          ParameterizedTypeName.get(
+              ClassName.get(UnmodifiableModelList.class),
+              TypeName.get(fieldModelRootInfo.get().type()),
+              immutInterfaceName);
+    }
+
     // Only add @Nullable annotation if the field needs presence check, is not FAIL,
     // and the return type is not Optional
     if (needsPresenceCheckInModels(method)
         && !isMandatoryField(method)
-        && !util.isOptional(returnType)) {
-      getterBuilder.returns(typeName.annotated(AnnotationSpec.builder(Nullable.class).build()));
-    } else {
-      getterBuilder.returns(typeName);
+        && !util.isOptional(specifiedType)) {
+      typeName = typeName.annotated(AnnotationSpec.builder(Nullable.class).build());
     }
+
+    getterBuilder.returns(typeName);
 
     addGetterCode(getterBuilder, method, dataType, methodName, isBuilder);
     return getterBuilder;
@@ -382,29 +435,85 @@ return _serializedPayload;
       MethodSpec.Builder getterBuilder,
       ExecutableElement method,
       CodeGenType dataType,
-      String methodName,
+      String fieldName,
       boolean isBuilder) {
 
     Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
     if (isProtoTypeRepeated(dataType)) {
       if (fieldModelRootInfo.isPresent()) {
-        ClassName immutClassName =
+        ClassName immutProtoClass =
             util.getImmutClassName(fieldModelRootInfo.get().element(), PROTOBUF_3);
-        getterBuilder.addStatement(
-            "return $T.transform(_proto().get$LList(), $T::new)",
-            Lists.class,
-            capitalizeFirstChar(methodName),
-            immutClassName);
+        if (isBuilder) {
+          ClassName protoMsgOrBuilderType =
+              ClassName.get(
+                  immutProtoClass.packageName(),
+                  fieldModelRootInfo.get().element().getSimpleName().toString()
+                      + MODELS_PROTO_MSG_SUFFIX
+                      + "OrBuilder");
+          getterBuilder.addStatement(
+              CodeBlock.builder()
+                  .addNamed(
+"""
+      return new $protoListBuilder:T<>(
+              $modelRoot:T.class,
+              $immutIface:T.class,
+              $immutIface:T.Builder.class,
+              $lists:T.transform(_proto().get$fieldNameCap:LList(), $immutProto:T::new),
+              $lists:T.transform(
+                  _proto().get$fieldNameCap:LBuilderList(), $immutProto:T.Builder::new),
+              _m -> _proto().add$fieldNameCap:L($immutProto:T._proto(_m)),
+              _b -> _proto().add$fieldNameCap:L($immutProto:T._proto(_b)),
+              (index, _model) ->
+                  _proto().add$fieldNameCap:L(index, $immutProto:T._proto(_model)),
+              (index, _builder) ->
+                  _proto().add$fieldNameCap:L(index, $immutProto:T._proto(_builder)),
+              _models -> {
+                _proto()
+                    .addAll$fieldNameCap:L(
+                        $iterables:T.transform(_models, $immutProto:T::_proto));
+                return _models.iterator().hasNext();
+              },
+              _proto()::clear$fieldNameCap:L,
+              (index, _model) ->
+                  _proto().add$fieldNameCap:L(index, $immutProto:T._proto(_model)),
+              (index, _builder) ->
+                  _proto().add$fieldNameCap:L(index, $immutProto:T._proto(_builder)),
+              index -> {
+                $protoMsgOrBuilder:T ret = _proto().get$fieldNameCap:LOrBuilder(index);
+                _proto().remove$fieldNameCap:L(index);
+                return new $immutProto:T(ret);
+              })
+          .unmodifiableModelsView()
+""",
+                      ofEntries(
+                          entry("protoListBuilder", ProtoListBuilder.class),
+                          entry("modelRoot", fieldModelRootInfo.get().type()),
+                          entry(
+                              "immutIface",
+                              util.getImmutInterfaceName(fieldModelRootInfo.get().element())),
+                          entry("immutProto", immutProtoClass),
+                          entry("lists", Lists.class),
+                          entry("fieldNameCap", capitalizeFirstChar(fieldName)),
+                          entry("iterables", Iterables.class),
+                          entry("protoMsgOrBuilder", protoMsgOrBuilderType)))
+                  .build());
+        } else {
+          getterBuilder.addStatement(
+              "return $T.transform(_proto().get$LList(), $T::new)",
+              Lists.class,
+              capitalizeFirstChar(fieldName),
+              immutProtoClass);
+        }
       } else {
         // For repeated fields, use getXList() method
-        getterBuilder.addStatement("return _proto().get$LList()", capitalizeFirstChar(methodName));
+        getterBuilder.addStatement("return _proto().get$LList()", capitalizeFirstChar(fieldName));
       }
       return;
     }
 
     if (isProtoTypeMap(dataType)) {
       // For map fields, use getXMap() method
-      getterBuilder.addStatement("return _proto().get$LMap()", capitalizeFirstChar(methodName));
+      getterBuilder.addStatement("return _proto().get$LMap()", capitalizeFirstChar(fieldName));
       return;
     }
     TypeMirror methodReturnType = method.getReturnType();
@@ -417,7 +526,7 @@ return _serializedPayload;
               """
               if (!_proto().has$L()){
               """,
-              capitalizeFirstChar(methodName));
+              capitalizeFirstChar(fieldName));
 
       // Add validation for mandatory fields
       if (isMandatoryField(method)) {
@@ -430,7 +539,7 @@ return _serializedPayload;
               """,
                 MandatoryFieldMissingException.class,
                 util.getImmutClassName(codeGenContext.modelRootType(), PROTOBUF_3).simpleName(),
-                methodName);
+                fieldName);
       } else if (isOptionalReturnType) {
         getterBuilder
             .addCode(protoPresenceCheck)
@@ -456,8 +565,8 @@ return _serializedPayload;
                     CodeBlock.of(
                         "new $T(_proto().get$L())",
                         util.getImmutClassName(_m.element(), PROTOBUF_3),
-                        capitalizeFirstChar(methodName)))
-            .orElseGet(() -> CodeBlock.of("_proto().get$L()", capitalizeFirstChar(methodName)));
+                        capitalizeFirstChar(fieldName)))
+            .orElseGet(() -> CodeBlock.of("_proto().get$L()", capitalizeFirstChar(fieldName)));
 
     // Get the value from the proto message
     if (isOptionalReturnType) {
@@ -471,7 +580,7 @@ return _serializedPayload;
       TypeElement modelRootType,
       String packageName,
       String protoClassName,
-      String protoMsgClassName,
+      ClassName protoMsgClassName,
       ClassName immutInterfaceName,
       List<ExecutableElement> modelMethods) {
     ModelRoot modelRoot = modelRootType.getAnnotation(ModelRoot.class);
@@ -481,9 +590,7 @@ return _serializedPayload;
     // Create class interfaces
     ClassName builderInterfaceClassName = immutInterfaceName.nestedClass("Builder");
 
-    ClassName protoBuilderClassName =
-        ClassName.get(packageName, protoMsgClassName).nestedClass("Builder");
-    ClassName protoMsgClassNameObj = ClassName.get(packageName, protoMsgClassName);
+    ClassName protoMsgBuilderClassName = protoMsgClassName.nestedClass("Builder");
 
     // Create Builder class
     Builder builderClassBuilder =
@@ -493,12 +600,12 @@ return _serializedPayload;
 
     // Add Builder field
     builderClassBuilder.addField(
-        FieldSpec.builder(protoBuilderClassName, "_proto", PRIVATE, FINAL).build());
+        FieldSpec.builder(protoMsgBuilderClassName, "_proto", PRIVATE, FINAL).build());
 
     // Add Builder constructor with _proto parameter
     builderClassBuilder.addMethod(
         MethodSpec.constructorBuilder()
-            .addParameter(protoBuilderClassName, "_proto")
+            .addParameter(protoMsgBuilderClassName, "_proto")
             .addStatement("this._proto = _proto")
             .build());
 
@@ -506,7 +613,7 @@ return _serializedPayload;
     builderClassBuilder.addMethod(
         MethodSpec.constructorBuilder()
             .addModifiers(PUBLIC)
-            .addStatement("this._proto = $T.newBuilder()", protoMsgClassNameObj)
+            .addStatement("this._proto = $T.newBuilder()", protoMsgClassName)
             .build());
 
     // Add _build method
@@ -545,7 +652,7 @@ return _serializedPayload;
 
       Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType());
       if (modelRoot.builderExtendsModelRoot()) {
-        builderClassBuilder.addMethod(getterMethod(method, returnType, dataType, true).build());
+        builderClassBuilder.addMethod(getterMethod(method, dataType, true).build());
       }
       // Add setter method
       MethodSpec.Builder setterBuilder =
@@ -568,8 +675,7 @@ return _serializedPayload;
             capitalizeFirstChar(fieldName),
             fieldName,
             capitalizeFirstChar(fieldName),
-            fieldModelRoot.isPresent()
-                    && ContainerType.LIST.equals(fieldModelRoot.get().containerType())
+            fieldModelRoot.isPresent() && LIST.equals(fieldModelRoot.get().containerType())
                 ? CodeBlock.of(
 """
 
@@ -677,7 +783,7 @@ return _serializedPayload;
         .addMethod(
             methodBuilder("_proto")
                 .addModifiers(PUBLIC)
-                .returns(protoBuilderClassName)
+                .returns(protoMsgBuilderClassName)
                 .addStatement("return _proto")
                 .build())
         .build();

--- a/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListBuilder.java
+++ b/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListBuilder.java
@@ -68,6 +68,7 @@ public class ProtoListBuilder<
     return modelsView;
   }
 
+  @Override
   public UnmodifiableModelList<M, I> unmodifiableModelsView() {
     return new UnmodifiableModelList<>(immutModelsView());
   }

--- a/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListBuilder.java
+++ b/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListBuilder.java
@@ -4,7 +4,6 @@ import com.flipkart.krystal.model.ImmutableModel;
 import com.flipkart.krystal.model.Model;
 import com.flipkart.krystal.model.ModelListBuilder;
 import com.flipkart.krystal.model.UnmodifiableModelList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -113,8 +112,9 @@ public class ProtoListBuilder<
   @Override
   public boolean addAllModels(int index, Iterable<? extends M> c) {
     boolean result = false;
+    int i = index;
     for (M m : c) {
-      addModel(m);
+      addModel(i++, m);
       result = true;
     }
     return result;
@@ -173,15 +173,5 @@ public class ProtoListBuilder<
   @Override
   public Model remove(int index) {
     return remove.apply(index);
-  }
-
-  @Override
-  public Iterator<M> modelsIterator() {
-    return modelsDelegate.iterator();
-  }
-
-  @Override
-  public Iterator<B> buildersIterator() {
-    return buildersDelegate.iterator();
   }
 }

--- a/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListBuilder.java
+++ b/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListBuilder.java
@@ -1,0 +1,187 @@
+package com.flipkart.krystal.vajram.protobuf3;
+
+import com.flipkart.krystal.model.ImmutableModel;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelListBuilder;
+import com.flipkart.krystal.model.UnmodifiableModelList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ProtoListBuilder<
+        M extends Model, I extends ImmutableModel, B extends ImmutableModel.Builder>
+    implements ModelListBuilder<M, I, B> {
+
+  private final List<M> modelsDelegate;
+  private final List<B> buildersDelegate;
+  private final Consumer<M> addModel;
+  private final Consumer<B> addBuilder;
+  private final BiConsumer<Integer, M> addModelAtIndex;
+  private final BiConsumer<Integer, B> addBuilderAtIndex;
+  private final Predicate<Iterable<? extends M>> addAllModels;
+  private final Runnable clear;
+  private final BiConsumer<Integer, M> setModel;
+  private final BiConsumer<Integer, B> setBuilder;
+  private final Function<Integer, Model> remove;
+  private final boolean builderExtendsModelRoot;
+  private final ProtoListView<M, I> modelsView;
+
+  public ProtoListBuilder(
+      Class<M> modelType,
+      Class<I> immutModelType,
+      Class<B> builderType,
+      List<M> modelsDelegate,
+      List<B> buildersDelegate,
+      Consumer<M> addModel,
+      Consumer<B> addBuilder,
+      BiConsumer<Integer, M> addModelAtIndex,
+      BiConsumer<Integer, B> addBuilderAtIndex,
+      Predicate<Iterable<? extends M>> addAllModels,
+      Runnable clear,
+      BiConsumer<Integer, M> setModel,
+      BiConsumer<Integer, B> setBuilder,
+      Function<Integer, Model> remove) {
+    if (!modelType.isAssignableFrom(immutModelType)) {
+      throw new IllegalArgumentException(
+          "The Immutable Model type %s must be a subtype of the modelType %s"
+              .formatted(immutModelType, modelType));
+    }
+    this.modelsDelegate = modelsDelegate;
+    this.buildersDelegate = buildersDelegate;
+    this.addModel = addModel;
+    this.addBuilder = addBuilder;
+    this.addModelAtIndex = addModelAtIndex;
+    this.addBuilderAtIndex = addBuilderAtIndex;
+    this.addAllModels = addAllModels;
+    this.clear = clear;
+    this.setModel = setModel;
+    this.setBuilder = setBuilder;
+    this.remove = remove;
+    this.builderExtendsModelRoot = modelType.isAssignableFrom(builderType);
+    this.modelsView = new ProtoListView<>(this, modelsDelegate);
+  }
+
+  @Override
+  public ProtoListView<M, I> immutModelsView() {
+    return modelsView;
+  }
+
+  public UnmodifiableModelList<M, I> unmodifiableModelsView() {
+    return new UnmodifiableModelList<>(immutModelsView());
+  }
+
+  @Override
+  public int size() {
+    return modelsDelegate.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return modelsDelegate.isEmpty();
+  }
+
+  @Override
+  public boolean addModel(M model) {
+    addModel.accept(model);
+    return true;
+  }
+
+  @Override
+  public void addModel(int index, M element) {
+    addModelAtIndex.accept(index, element);
+  }
+
+  @Override
+  public boolean addBuilder(B b) {
+    addBuilder.accept(b);
+    return true;
+  }
+
+  @Override
+  public void addBuilder(int index, B element) {
+    addBuilderAtIndex.accept(index, element);
+  }
+
+  @Override
+  public boolean addAllModels(Iterable<? extends M> i) {
+    return addAllModels.test(i);
+  }
+
+  @Override
+  public boolean addAllModels(int index, Iterable<? extends M> c) {
+    boolean result = false;
+    for (M m : c) {
+      addModel(m);
+      result = true;
+    }
+    return result;
+  }
+
+  @Override
+  public boolean addAllBuilders(Iterable<? extends B> c) {
+    boolean result = false;
+    for (B b : c) {
+      addBuilder(b);
+      result = true;
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public boolean addAllBuilders(int index, Iterable<? extends B> c) {
+    if (builderExtendsModelRoot) {
+      return addAllModels(index, (Iterable<? extends M>) c);
+    }
+    boolean result = false;
+    int i = index;
+    for (B b : c) {
+      addBuilder(i++, b);
+      result = true;
+    }
+    return result;
+  }
+
+  @Override
+  public void clear() {
+    clear.run();
+  }
+
+  @Override
+  public M getModel(int index) {
+    return modelsDelegate.get(index);
+  }
+
+  @Override
+  public B getBuilder(int index) {
+    return buildersDelegate.get(index);
+  }
+
+  @Override
+  public void setModel(int index, M element) {
+    setModel.accept(index, element);
+  }
+
+  @Override
+  public void setBuilder(int index, B element) {
+    setBuilder.accept(index, element);
+  }
+
+  @Override
+  public Model remove(int index) {
+    return remove.apply(index);
+  }
+
+  @Override
+  public Iterator<M> modelsIterator() {
+    return modelsDelegate.iterator();
+  }
+
+  @Override
+  public Iterator<B> buildersIterator() {
+    return buildersDelegate.iterator();
+  }
+}

--- a/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListView.java
+++ b/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/com/flipkart/krystal/vajram/protobuf3/ProtoListView.java
@@ -1,0 +1,38 @@
+package com.flipkart.krystal.vajram.protobuf3;
+
+import com.flipkart.krystal.model.ImmutableModel;
+import com.flipkart.krystal.model.ImmutableModel.Builder;
+import com.flipkart.krystal.model.ImmutableModelList;
+import com.flipkart.krystal.model.Model;
+import java.util.AbstractList;
+import java.util.List;
+import java.util.RandomAccess;
+
+public final class ProtoListView<M extends Model, I extends ImmutableModel> extends AbstractList<I>
+    implements RandomAccess, ImmutableModelList<M, I> {
+
+  private final ProtoListBuilder<M, I, ?> builder;
+  private final List<M> delegate;
+
+  ProtoListView(ProtoListBuilder<M, I, ?> builder, List<M> delegate) {
+    this.builder = builder;
+    this.delegate = delegate;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <B extends Builder> ProtoListBuilder<M, I, B> modelsBuilder() {
+    return (ProtoListBuilder<M, I, B>) builder;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public I get(int index) {
+    return (I) delegate.get(index)._build();
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+}

--- a/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/module-info.java
+++ b/vajram/extensions/protobuf/vajram-protobuf3/src/main/java/module-info.java
@@ -3,4 +3,5 @@ module flipkart.krystal.vajram.ext.protobuf {
 
   requires com.google.protobuf;
   requires transitive flipkart.krystal.common;
+  requires static lombok;
 }

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
@@ -780,25 +780,28 @@ this.$L = $L == null
           && !specifiedReturnType.getKind().isPrimitive()) {
         try {
           methodBuilder.addCode(
-              """
-              if($N == null){
-                return $L;
-              }
-              """,
+"""
+    if($N == null){
+      return $L;
+    }
+""",
               fieldName,
-              asClassName(actualReturnType)
-                      .canonicalName()
-                      .equals(UnmodifiableModelList.class.getCanonicalName())
-                  ? CodeBlock.of("new $T()", ModelsListView.class)
+              fieldModelRootInfo.isPresent()
+                      && fieldModelRootInfo.get().containerType().isContainer()
+                  ? CodeBlock.of(
+                      "$T.<$T, $T>empty().asModelsView()",
+                      ModelsListView.class,
+                      TypeName.get(fieldModelRootInfo.get().type()),
+                      util.getImmutInterfaceName(fieldModelRootInfo.get().element()))
                   : new DeclaredTypeVisitor(util, method)
                       .visit(specifiedReturnType)
                       .defaultValueExpr(util.processingEnv()));
         } catch (CodeGenerationException e) {
           throw util.errorAndThrow(
               """
-                  Could not find default value expression for specified type %s. \
-                  Either the relevant type was not configured properly in a DataTypeFactory \
-                  or the @IfAbsent() annotation is incorrectly specified."""
+                Could not find default value expression for specified type %s. \
+                Either the relevant type was not configured properly in a DataTypeFactory \
+                or the @IfAbsent() annotation is incorrectly specified."""
                   .formatted(specifiedReturnType),
               method);
         }
@@ -834,8 +837,7 @@ this.$L = $L == null
                             .nestedClass("Builder"),
                         fieldName,
                         util.getImmutInterfaceName(fieldModelRootInfo.get().element()));
-            case LIST -> CodeBlock.of("$L.modelsListView()", fieldName);
-            case MAP -> CodeBlock.of("$L.modelsMapView()", fieldName);
+            case LIST, MAP -> CodeBlock.of("$L.unmodifiableModelsView()", fieldName);
           };
     }
     return fieldAccessorCode;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added Plain Java Object support alongside Protobuf3 for model protocols.
  - Exposed a new nested list field on REST response models.

* **Improvements**
  - More flexible model-list views and builders: lazy immutability, separate model/builder access, and unmodifiable views.
  - Generated code now yields richer protobuf handling and consistent container return types.

* **Tests**
  - New/updated tests validating list-builder behavior and accumulated list mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->