### PR TITLE
Add github workflow to publish to maven central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# Publish to Maven Central with GPG-signed artifacts.
+# Requires secrets: CENTRAL_USERNAME, CENTRAL_TOKEN, GPG_PRIVATE_KEY, GPG_PASSPHRASE
+
+name: Publish Package to the Maven Central
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+      GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: 'maven'
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          settings-path: ${{ github.workspace }}
+
+      - name: Build and publish to Maven Central (with GPG signing)
+        run: gradle publish -PunsafeCompile=true #Unsafe compile temporarily needed due to a checker-framework issue
+        env:
+          GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }} # Setting both as of now.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
       CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
       GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY: ${{ secrets.FOSS_GPG_KEY }}
 
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
                 url = "https://central.sonatype.com/api/v1/publisher/deployments/maven"
                 credentials {
                     username = System.getenv("CENTRAL_USERNAME")
-                    password = System.getenv("CENTRAL_PASSWORD")
+                    password = System.getenv("CENTRAL_TOKEN")
                 }
             }
         }
@@ -84,7 +84,7 @@ subprojects {
         def signingKey = System.getenv("GPG_PRIVATE_KEY")
         def signingPassword = System.getenv("GPG_PASSPHRASE")
         useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications.matching { it.name == "mavenJava" }
+        sign publishing.publications.withType(MavenPublication)
         required { System.getenv("CI") != null }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
 
 subprojects {
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
     apply plugin: 'idea'
 
     group = 'com.flipkart.krystal'
@@ -39,23 +40,52 @@ subprojects {
     publishing {
         repositories {
             maven {
-                url = "https://clojars.org/repo"
+                name = "MavenCentral"
+                url = "https://central.sonatype.com/api/v1/publisher/deployments/maven"
                 credentials {
-                    username = rootProject.ext.clojarsusername
-                    password = rootProject.ext.clojarspassword
+                    username = System.getenv("CENTRAL_USERNAME")
+                    password = System.getenv("CENTRAL_PASSWORD")
                 }
             }
         }
         publications.withType(MavenPublication).configureEach {
             pom {
+                name = project.name
+                description = project.description
+                url = 'https://github.com/flipkart-incubator/Krystal'
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
                         url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
+                developers {
+                    developer {
+                        id = 'RamAnvesh'
+                        name = 'Ram Anvesh Reddy'
+                        email = '2082745+RamAnvesh@users.noreply.github.com'
+                        organization = 'Flipkart'
+                        organizationUrl = 'https://www.flipkart.com'
+                        roles = ['Developer', 'Maintainer', 'Architect']
+                        timezone = 'Asia/Kolkata'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/flipkart-incubator/Krystal'
+                    developerConnection = 'scm:git:ssh://github.com/flipkart-incubator/Krystal'
+                    url = 'https://github.com/flipkart-incubator/Krystal'
+                }
+
             }
         }
+    }
+
+    signing {
+        def signingKey = System.getenv("GPG_PRIVATE_KEY")
+        def signingPassword = System.getenv("GPG_PASSPHRASE")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.matching { it.name == "mavenJava" }
+        required { System.getenv("CI") != null }
     }
 
     idea {
@@ -169,7 +199,7 @@ configure(subprojects.findAll {
     if (project.name !in ['vajram-lang', 'vajram-codegen'] && project.subprojects.isEmpty()) {
         publishing {
             publications {
-                maven(MavenPublication) {
+                mavenJava(MavenPublication) {
                     groupId = project.group
                     artifactId = project.name
                     version = project.version

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,9 @@ subprojects {
         repositories {
             maven {
                 name = "MavenCentral"
-                url = "https://central.sonatype.com/api/v1/publisher/deployments/maven"
+                url = version.endsWith('SNAPSHOT')
+                        ? "https://central.sonatype.com/repository/maven-snapshots/"
+                        : "https://central.sonatype.com/api/v1/publisher/deployments/maven"
                 credentials {
                     username = System.getenv("CENTRAL_USERNAME")
                     password = System.getenv("CENTRAL_TOKEN")
@@ -215,6 +217,7 @@ configure(subprojects.findAll {
 
     java {
         withSourcesJar()
+        withJavadocJar()
     }
 
     compileJava {

--- a/krystal-bom/build.gradle
+++ b/krystal-bom/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
 publishing {
     publications {
-        maven(MavenPublication) {
+        mavenJava(MavenPublication) {
             groupId = project.group
             artifactId = project.name
             version = project.version

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/BasicModelListBuilder.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.ListIterator;
 import lombok.Getter;
 import lombok.Setter;
-import org.jspecify.annotations.NonNull;
 
 final class BasicModelListBuilder<M extends Model, I extends ImmutableModel, B extends Builder>
     implements ModelListBuilder<M, I, B> {

--- a/lattice/lattice-bom/build.gradle
+++ b/lattice/lattice-bom/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 publishing {
     publications {
-        maven(MavenPublication) {
+        mavenJava(MavenPublication) {
             groupId = project.group
             artifactId = project.name
             version = project.version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packages are now published to Maven Central via an automated GitHub Actions workflow (supports tag-triggered and manual dispatch).
  * Published artifacts include enhanced metadata (name, description, URL, developers, and SCM) and are GPG-signed for verification.

* **Chores**
  * Build configuration updated to enable publishing, signing, and Maven Central deployment using modern JDK tooling.
  * Minor cleanup: removed an unused import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->