### PR TITLE
Throw MandatoryFieldMissingException from builder when needed

### DIFF
--- a/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
+++ b/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
@@ -159,7 +159,9 @@ return _serializedPayload;
     for (ExecutableElement method : modelMethods) {
       Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
       MethodSpec pojoGetterMethod =
-          getterMethod(method, false, JSON, util).addAnnotation(Override.class).build();
+          getterMethod(method, false, JSON, util, null, false)
+              .addAnnotation(Override.class)
+              .build();
       MethodSpec.Builder getterBuilder =
           MethodSpec.methodBuilder(pojoGetterMethod.name)
               .returns(pojoGetterMethod.returnType)
@@ -391,7 +393,8 @@ return _serializedPayload;
 
     ClassName builderType = immutableJsonName.nestedClass("Builder");
     List<MethodSpec> dataAccessMethods =
-        builderGettersAndSetters(modelMethods, builderType, modelRoot, JSON, util);
+        builderGettersAndSetters(
+            modelMethods, builderType, modelRoot, JSON, util, immutableModelName);
 
     // Create the builder class
     return builderSpec

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen/src/main/java/com/flipkart/krystal/vajram/protobuf3/codegen/Proto3ModelsGen.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen/src/main/java/com/flipkart/krystal/vajram/protobuf3/codegen/Proto3ModelsGen.java
@@ -298,7 +298,7 @@ return _serializedPayload;
       TypeMirror returnType = method.getReturnType();
       CodeGenType dataType = new DeclaredTypeVisitor(util, method).visit(returnType);
 
-      classBuilder.addMethod(getterMethod(method, dataType, false).build());
+      classBuilder.addMethod(getterMethod(method, dataType, false, null, null).build());
     }
 
     // Add equals method that delegates to the proto object
@@ -400,7 +400,11 @@ return _serializedPayload;
   }
 
   private MethodSpec.Builder getterMethod(
-      ExecutableElement method, CodeGenType dataType, boolean isBuilder) {
+      ExecutableElement method,
+      CodeGenType dataType,
+      boolean isBuilder,
+      @Nullable ModelRoot modelRoot,
+      @Nullable ClassName immutableProtoTypeName) {
     final TypeMirror specifiedType = method.getReturnType();
     TypeName typeName = TypeName.get(specifiedType);
 
@@ -439,7 +443,8 @@ return _serializedPayload;
 
     getterBuilder.returns(typeName);
 
-    addGetterCode(getterBuilder, method, dataType, methodName, isBuilder);
+    addGetterCode(
+        getterBuilder, method, dataType, methodName, isBuilder, modelRoot, immutableProtoTypeName);
     return getterBuilder;
   }
 
@@ -448,7 +453,9 @@ return _serializedPayload;
       ExecutableElement method,
       CodeGenType dataType,
       String fieldName,
-      boolean isBuilder) {
+      boolean isBuilder,
+      @Nullable ModelRoot modelRoot,
+      @Nullable ClassName immutableProtoTypeName) {
 
     Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
     if (isProtoTypeRepeated(dataType)) {
@@ -586,7 +593,17 @@ return _serializedPayload;
               capitalizeFirstChar(fieldName));
 
       // Add validation for mandatory fields
-      if (isMandatoryField(method)) {
+      // For builders with builderExtendsModelRoot=true, NonNull fields are also mandatory
+      // Exclude Lists/Maps of Models (they can be empty collections)
+      boolean isMandatory =
+          isMandatoryField(method)
+              || (isBuilder
+                  && modelRoot != null
+                  && modelRoot.builderExtendsModelRoot()
+                  && !typeSupportsAbsentValues(method)
+                  && !(fieldModelRootInfo.isPresent()
+                      && fieldModelRootInfo.get().containerType().isContainer()));
+      if (isMandatory) {
         getterBuilder
             .addCode(protoPresenceCheck)
             .addCode(
@@ -595,7 +612,10 @@ return _serializedPayload;
               }
               """,
                 MandatoryFieldMissingException.class,
-                util.getImmutClassName(codeGenContext.modelRootType(), PROTOBUF_3).simpleName(),
+                immutableProtoTypeName != null
+                    ? immutableProtoTypeName.simpleName()
+                    : util.getImmutClassName(codeGenContext.modelRootType(), PROTOBUF_3)
+                        .simpleName(),
                 fieldName);
       } else if (isOptionalReturnType) {
         getterBuilder
@@ -710,7 +730,8 @@ return _serializedPayload;
       Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType());
       if (modelRoot.builderExtendsModelRoot()
           || (fieldModelRoot.isPresent() && fieldModelRoot.get().containerType().isContainer())) {
-        builderClassBuilder.addMethod(getterMethod(method, dataType, true).build());
+        builderClassBuilder.addMethod(
+            getterMethod(method, dataType, true, modelRoot, immutableProtoType).build());
       }
       // Add setter method
       MethodSpec.Builder setterBuilder =
@@ -884,5 +905,15 @@ return _serializedPayload;
    */
   private boolean isMandatoryField(ExecutableElement method) {
     return util.getIfAbsent(method).value() == IfAbsentThen.FAIL;
+  }
+
+  /**
+   * Checks if a type supports absent/null values. Returns true if the type is Optional or annotated
+   * with @Nullable.
+   */
+  private boolean typeSupportsAbsentValues(ExecutableElement method) {
+    TypeMirror returnType = method.getReturnType();
+    return !returnType.getKind().isPrimitive()
+        && (util.isOptional(returnType) || util.isAnyNullable(returnType, method));
   }
 }

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
@@ -589,7 +589,10 @@ public final class JavaModelsGen implements CodeGenerator {
     // Create getter methods for the POJO class
     List<MethodSpec> methods = new ArrayList<>();
     for (ExecutableElement method : modelMethods) {
-      methods.add(getterMethod(method, false, null, util).addAnnotation(Override.class).build());
+      methods.add(
+          getterMethod(method, false, null, util, null, false)
+              .addAnnotation(Override.class)
+              .build());
     }
 
     MethodSpec.Builder asBuilderMethodBuilder = asBuilder(modelMethods, builderType);
@@ -758,7 +761,9 @@ this.$L = $L == null
       ExecutableElement method,
       boolean isBuilder,
       @Nullable ModelProtocol modelProtocol,
-      CodeGenUtility util) {
+      CodeGenUtility util,
+      @Nullable TypeName modelTypeName,
+      boolean builderExtendsModelRoot) {
     TypeMirror specifiedReturnType = method.getReturnType();
     ModelFieldTypeInfo modelFieldType = util.getModelFieldType(method, true, null);
     Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(specifiedReturnType);
@@ -832,6 +837,23 @@ this.$L = $L == null
                   .formatted(specifiedReturnType),
               method);
         }
+      }
+      // For builders with builderExtendsModelRoot=true, check if field is NonNull
+      // If so, throw MandatoryFieldMissingException instead of returning null
+      // Exclude Lists/Maps of Models (they can be empty collections)
+      if (isBuilder
+          && builderExtendsModelRoot
+          && !typeSupportsAbsentValues(method, util)
+          && !(fieldModelRootInfo.isPresent()
+              && fieldModelRootInfo.get().containerType().isContainer())
+          && modelTypeName != null) {
+        methodBuilder.beginControlFlow("if ($N == null)", fieldName);
+        methodBuilder.addStatement(
+            "throw new $T($S, $S)",
+            MandatoryFieldMissingException.class,
+            modelTypeName.toString(),
+            fieldName);
+        methodBuilder.endControlFlow();
       }
       methodBuilder.addStatement(
           "return $L", getFieldAccessorExpression(isBuilder, fieldName, specifiedReturnType, util));
@@ -909,7 +931,8 @@ this.$L = $L == null
     MethodSpec noArgConstructor = MethodSpec.constructorBuilder().addModifiers(PRIVATE).build();
 
     List<MethodSpec> dataAccessMethods =
-        builderGettersAndSetters(modelMethods, builderType, modelRoot, null, util);
+        builderGettersAndSetters(
+            modelMethods, builderType, modelRoot, null, util, immutableModelName);
 
     MethodSpec.Builder buildMethodBuilder =
         buildForBuilder(modelMethods, immutableModelName, immutablePojoName, util);
@@ -1060,7 +1083,8 @@ this.$L = $L == null
       TypeName builderType,
       ModelRoot modelRoot,
       @Nullable ModelProtocol modelProtocol,
-      CodeGenUtility util) {
+      CodeGenUtility util,
+      @Nullable TypeName modelTypeName) {
     // Create setter methods
     List<MethodSpec> dataAccessMethods = new ArrayList<>();
     for (ExecutableElement method : modelMethods) {
@@ -1118,10 +1142,15 @@ this.$L = $L == null
 
       if (modelRoot.builderExtendsModelRoot()
           || (fieldModelRoot.isPresent() && fieldModelRoot.get().containerType().isContainer())) {
-        MethodSpec.Builder getterMethod = getterMethod(method, true, modelProtocol, util);
-        if (modelRoot.builderExtendsModelRoot()) {
-          getterMethod.addAnnotation(Override.class);
-        }
+        MethodSpec.Builder getterMethod =
+            getterMethod(
+                    method,
+                    true,
+                    modelProtocol,
+                    util,
+                    modelTypeName,
+                    modelRoot.builderExtendsModelRoot())
+                .addAnnotation(Override.class);
         dataAccessMethods.add(getterMethod.build());
       }
     }
@@ -1166,7 +1195,7 @@ this.$L = $L == null
   }
 
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-  private static boolean typeSupportsAbsentValues(ExecutableElement method, CodeGenUtility util) {
+  public static boolean typeSupportsAbsentValues(ExecutableElement method, CodeGenUtility util) {
     TypeMirror returnType = method.getReturnType();
     return !returnType.getKind().isPrimitive()
         && (util.isOptional(returnType) || util.isAnyNullable(returnType, method));


### PR DESCRIPTION
When a Model interface (extends Model and has @ModelRoot.java annotation) with builderExtendsModelRoot=true has a NonNull field, then all the Builders must throw a @MandatoryFieldMissingException.java instead of returning a null value (since the builder can be partially built) - this breaches the @NonNull contract of the model root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of required fields in generated builder classes; mandatory field access now properly throws exceptions when fields remain unset.
  * Improved detection and handling of optional and nullable field types during code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->