### PR TITLE
Add validation to prevent nested collection patterns

### DIFF
--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -324,14 +324,18 @@ public class CodeGenUtility {
     }
 
     // Validate no nested collections (List<List>, List<Map>, Map<K, List>, Map<K, Map>)
-    TypeMirror typeToCheck = returnType;
-    if (isOptional(typeToCheck)) {
-      typeToCheck = getOptionalInnerType(typeToCheck);
-    }
-    validateNoNestedCollections(method, typeToCheck);
+    validateNoNestedCollections(method, returnType);
   }
 
   private void validateNoNestedCollections(ExecutableElement method, TypeMirror type) {
+    if (isOptional(type)) {
+      type = getOptionalInnerType(type);
+      if (isOptional(type)) {
+        error(
+            "Optional of Optional (Optional<Optional<..>>) is not supported by Krystal Modelling framework",
+            method);
+      }
+    }
     if (isListType(type)) {
       TypeMirror elementType = getContentType(type);
       if (isListType(elementType)) {
@@ -370,10 +374,24 @@ public class CodeGenUtility {
                 + "Field '%s' has type Map<..., Optional<...>>.".formatted(method.getSimpleName()),
             method);
       }
+      if (isMapType(keyType)) {
+        error(
+            "Nested collections are not allowed in Krystal models. "
+                + "Field '%s' has type Map<Map<...>, ...>. Use a @ModelRoot model to wrap the inner Map."
+                    .formatted(method.getSimpleName()),
+            method);
+      }
       if (isMapType(valueType)) {
         error(
             "Nested collections are not allowed in Krystal models. "
                 + "Field '%s' has type Map<..., Map<...>>. Use a @ModelRoot model to wrap the inner Map."
+                    .formatted(method.getSimpleName()),
+            method);
+      }
+      if (isListType(keyType)) {
+        error(
+            "Nested collections are not allowed in Krystal models. "
+                + "Field '%s' has type Map<List<...>, ...>. Use a @ModelRoot model to wrap the inner List."
                     .formatted(method.getSimpleName()),
             method);
       }
@@ -1071,7 +1089,7 @@ public class CodeGenUtility {
     }
     TypeName finalTypeName;
     TypeName elementType = typeName;
-    Optional<ModelRootInfo> fieldModelRootInfo = asModelRoot(inferredType);
+    Optional<ModelRootInfo> fieldModelRootInfo = asModelRoot(inferredType, method);
     ContainerType containerType = getContainerType(inferredType);
 
     finalTypeName =
@@ -1300,8 +1318,8 @@ public class CodeGenUtility {
     return null;
   }
 
-  public boolean isModelRoot(TypeMirror javaModelType) {
-    return asModelRoot(javaModelType).isPresent();
+  public boolean isModelRoot(TypeMirror javaModelType, Element... elements) {
+    return asModelRoot(javaModelType, elements).isPresent();
   }
 
   public ContainerType getContainerType(TypeMirror javaModelType) {
@@ -1315,14 +1333,17 @@ public class CodeGenUtility {
         : isMapType(javaModelType) ? ContainerType.MAP : ContainerType.NO_CONTAINER;
   }
 
-  public Optional<ModelRootInfo> asModelRoot(TypeMirror javaModelType) {
+  public Optional<ModelRootInfo> asModelRoot(TypeMirror javaModelType, Element... elements) {
+    if (elements.length == 0) {
+      elements = new Element[] {typeUtils.asElement(javaModelType)};
+    }
     ContainerType containerType = ContainerType.NO_CONTAINER;
     if (isOptional(javaModelType)) {
       javaModelType = getOptionalInnerType(javaModelType);
       if (isOptional(javaModelType)) {
         error(
-            "Optional of Optional (Optional<Optional<..>>) is not supported by Krystal Modelling protocol",
-            typeUtils.asElement(javaModelType));
+            "Optional of Optional (Optional<Optional<..>>) is not supported by Krystal Modelling framework",
+            elements);
       }
     }
     if (isListType(javaModelType)) {
@@ -1330,7 +1351,7 @@ public class CodeGenUtility {
       if (isListType(javaModelType)) {
         error(
             "List of Lists (List<List<..>>) is not supported by Krystal Modelling protocol",
-            typeUtils.asElement(javaModelType));
+            elements);
       }
       containerType = ContainerType.LIST;
     } else if (isMapType(javaModelType)) {
@@ -1338,7 +1359,7 @@ public class CodeGenUtility {
       if (isMapType(javaModelType)) {
         error(
             "Map of Maps (Map<K, Map<..>>) is not supported by Krystal Modelling protocol",
-            typeUtils.asElement(javaModelType));
+            elements);
       }
       containerType = ContainerType.MAP;
     }

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -348,9 +348,28 @@ public class CodeGenUtility {
                     .formatted(method.getSimpleName()),
             method);
       }
+      if (isOptional(elementType)) {
+        error(
+            "Optional is not allowed as a List element type in Krystal models. "
+                + "Field '%s' has type List<Optional<...>>.".formatted(method.getSimpleName()),
+            method);
+      }
     }
     if (isMapType(type)) {
+      TypeMirror keyType = getMapKeyType(type);
       TypeMirror valueType = getMapValueType(type);
+      if (isOptional(keyType)) {
+        error(
+            "Optional is not allowed as a Map key type in Krystal models. "
+                + "Field '%s' has type Map<Optional<...>, ...>.".formatted(method.getSimpleName()),
+            method);
+      }
+      if (isOptional(valueType)) {
+        error(
+            "Optional is not allowed as a Map value type in Krystal models. "
+                + "Field '%s' has type Map<..., Optional<...>>.".formatted(method.getSimpleName()),
+            method);
+      }
       if (isMapType(valueType)) {
         error(
             "Nested collections are not allowed in Krystal models. "

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -322,6 +322,50 @@ public class CodeGenUtility {
     if (returnType.getKind() == TypeKind.ARRAY) {
       error("Model root methods must not return arrays. Use List instead.", method);
     }
+
+    // Validate no nested collections (List<List>, List<Map>, Map<K, List>, Map<K, Map>)
+    TypeMirror typeToCheck = returnType;
+    if (isOptional(typeToCheck)) {
+      typeToCheck = getOptionalInnerType(typeToCheck);
+    }
+    validateNoNestedCollections(method, typeToCheck);
+  }
+
+  private void validateNoNestedCollections(ExecutableElement method, TypeMirror type) {
+    if (isListType(type)) {
+      TypeMirror elementType = getContentType(type);
+      if (isListType(elementType)) {
+        error(
+            "Nested collections are not allowed in Krystal models. "
+                + "Field '%s' has type List<List<...>>. Use a @ModelRoot model to wrap the inner List."
+                    .formatted(method.getSimpleName()),
+            method);
+      }
+      if (isMapType(elementType)) {
+        error(
+            "Nested collections are not allowed in Krystal models. "
+                + "Field '%s' has type List<Map<...>>. Use a @ModelRoot model to wrap the inner Map."
+                    .formatted(method.getSimpleName()),
+            method);
+      }
+    }
+    if (isMapType(type)) {
+      TypeMirror valueType = getMapValueType(type);
+      if (isMapType(valueType)) {
+        error(
+            "Nested collections are not allowed in Krystal models. "
+                + "Field '%s' has type Map<..., Map<...>>. Use a @ModelRoot model to wrap the inner Map."
+                    .formatted(method.getSimpleName()),
+            method);
+      }
+      if (isListType(valueType)) {
+        error(
+            "Nested collections are not allowed in Krystal models. "
+                + "Field '%s' has type Map<..., List<...>>. Use a @ModelRoot model to wrap the inner List."
+                    .formatted(method.getSimpleName()),
+            method);
+      }
+    }
   }
 
   public boolean isAnyNullable(TypeMirror type, Element elementToCheck) {

--- a/krystal-common/Krystal-models.md
+++ b/krystal-common/Krystal-models.md
@@ -284,6 +284,40 @@ Map fields have the following key-type restrictions:
 - **Protobuf3 specifically:** Only integral types and `String` are valid map keys (a proto3
   limitation).
 
+### Nested Collection Restrictions
+
+Nested collections are **not allowed** in Krystal models. The following patterns are rejected at
+compile time:
+
+- `List<List<...>>`
+- `List<Map<...>>`
+- `Map<K, Map<...>>`
+- `Map<K, List<...>>`
+
+This applies to **all** models regardless of purity or serde protocol. To model nested collections,
+wrap the inner collection in a `@ModelRoot` model:
+
+```java
+// ✗ Compile error: nested collection
+@ModelRoot
+public interface MyModel extends Model {
+  List<List<String>> nestedList();       // ERROR
+  Map<String, Map<String, Integer>> nestedMap(); // ERROR
+}
+
+// ✓ Correct: wrap inner collection in a model
+@ModelRoot
+public interface StringList extends Model {
+  List<String> values();
+}
+
+@ModelRoot
+public interface MyModel extends Model {
+  List<StringList> nestedList();          // OK
+  Map<String, StringList> nestedMap();    // OK
+}
+```
+
 ### Summary of Generated Artifacts
 
 For a model root `MyModel`:

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQlRespJsonModelGen.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQlRespJsonModelGen.java
@@ -192,7 +192,7 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
         TypeMirror elementType = getListElementType(returnType);
         if (elementType != null) {
           TypeName elementTypeName;
-          if (util.isModelRoot(elementType) && !isEntityIdType(elementType, util)) {
+          if (util.isModelRoot(elementType, method) && !isEntityIdType(elementType, util)) {
             // For custom model types (but NOT entity IDs), use _Immut suffix
             TypeElement elementTypeElement =
                 (TypeElement) util.processingEnv().getTypeUtils().asElement(elementType);
@@ -476,7 +476,7 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
     asBuilderMethodBuilder.addCode("return new $T()", builderType);
     for (ExecutableElement method : modelMethods) {
       String fieldName = method.getSimpleName().toString();
-      Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType(), method);
       if (fieldModelRoot.isPresent()) {
         asBuilderMethodBuilder.addCode(
             switch (fieldModelRoot.get().containerType()) {
@@ -529,7 +529,7 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
 
         // Determine the actual type stored in the field (with _Immut for custom models)
         TypeName fieldElementTypeName;
-        if (util.isModelRoot(elementType) && !isEntityIdType(elementType, util)) {
+        if (util.isModelRoot(elementType, method) && !isEntityIdType(elementType, util)) {
           // For custom model types (but NOT entity IDs), field uses _Immut suffix
           TypeElement elementTypeElement =
               (TypeElement) util.processingEnv().getTypeUtils().asElement(elementType);
@@ -563,7 +563,7 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
             ParameterizedTypeName.get(
                 ClassName.get(Errable.class), WildcardTypeName.subtypeOf(fieldElementTypeName)));
         // Only cast for custom model types (from _Immut to interface), not for standard types
-        if (util.isModelRoot(elementType) && !isEntityIdType(elementType, util)) {
+        if (util.isModelRoot(elementType, method) && !isEntityIdType(elementType, util)) {
           getter.addStatement("result.add(($T) e.valueOpt().orElse(null))", elementTypeName);
         } else {
           getter.addStatement("result.add(e.valueOpt().orElse(null))");
@@ -927,7 +927,8 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
 
     if (isListType) {
       TypeMirror elementType = getListElementType(returnType);
-      isListOfEntities = util.isModelRoot(elementType) && !isEntityIdType(elementType, util);
+      isListOfEntities =
+          util.isModelRoot(elementType, method) && !isEntityIdType(elementType, util);
     }
 
     // Determine the correct Errable field type for the second overload
@@ -964,7 +965,7 @@ final class GraphQlRespJsonModelGen implements CodeGenerator {
             .addAnnotation(Override.class)
             .addModifiers(PUBLIC)
             .returns(builderType);
-    Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(returnType);
+    Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(returnType, method);
     if (isListType) {
       // For ALL lists (entities OR standard types), use complex wrapping logic
       directSetterBuilder.addParameter(fieldType, fieldName);

--- a/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
+++ b/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
@@ -171,7 +171,7 @@ return _serializedPayload;
     List<MethodSpec> methods = new ArrayList<>();
 
     for (ExecutableElement method : modelMethods) {
-      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
       MethodSpec pojoGetterMethod =
           getterMethod(method, false, JSON, util, immutableJsonModelName, modelRoot)
               .addAnnotation(Override.class)
@@ -266,7 +266,7 @@ return _serializedPayload;
 
   private CodeBlock setterCode(ExecutableElement method) {
     String fieldName = method.getSimpleName().toString();
-    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
 
     return switch (util.getContainerType(method.getReturnType())) {
       case NO_CONTAINER -> {
@@ -379,7 +379,7 @@ this.$L = $L == null
       }
       FieldSpec.Builder fieldBuilder =
           FieldSpec.builder(fieldType, method.getSimpleName().toString(), PRIVATE);
-      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
       if (isBuilder
           && fieldModelRootInfo.isPresent()
           && !util.isEnumModel(fieldModelRootInfo.get().element())) {

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen/src/main/java/com/flipkart/krystal/vajram/protobuf3/codegen/Proto3ModelsGen.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen/src/main/java/com/flipkart/krystal/vajram/protobuf3/codegen/Proto3ModelsGen.java
@@ -414,7 +414,7 @@ return _serializedPayload;
                   boolean isOptional = util.isOptional(method.getReturnType());
                   boolean isNullable = method.getReturnType().getAnnotation(Nullable.class) != null;
                   String methodName = method.getSimpleName().toString();
-                  Optional<ModelRootInfo> modelRoot = util.asModelRoot(method.getReturnType());
+                  Optional<ModelRootInfo> modelRoot = util.asModelRoot(method.getReturnType(), method);
                   CodeBlock accessor;
                   if (modelRoot.isPresent() && !util.isEnumModel(modelRoot.get().element())) {
                     if (isOptional) {
@@ -463,7 +463,7 @@ return _serializedPayload;
     MethodSpec.Builder getterBuilder =
         methodBuilder(methodName).addAnnotation(Override.class).addModifiers(PUBLIC);
 
-    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(specifiedType);
+    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(specifiedType, method);
     if (isBuilder
         && fieldModelRootInfo.isPresent()
         && !util.isEnumModel(fieldModelRootInfo.get().element())) {
@@ -509,7 +509,7 @@ return _serializedPayload;
       @Nullable ModelRoot modelRoot,
       @Nullable ClassName immutableProtoTypeName) {
 
-    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
     if (isProtoTypeRepeated(dataType)) {
       if (fieldModelRootInfo.isPresent() && !util.isEnumModel(fieldModelRootInfo.get().element())) {
         ClassName immutProtoClass =
@@ -827,7 +827,7 @@ return _serializedPayload;
       TypeMirror returnType = method.getReturnType();
       CodeGenType dataType = new DeclaredTypeVisitor(util, method).visit(returnType);
 
-      Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType(), method);
       if (modelRoot.builderExtendsModelRoot()
           || (fieldModelRoot.isPresent()
               && !util.isEnumModel(fieldModelRoot.get().element())

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
@@ -897,7 +897,7 @@ public final class JavaModelsGen implements CodeGenerator {
       }
       methods.add(setter.build());
 
-      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
       if (fieldModelRootInfo.isPresent()
           && !fieldModelRootInfo.get().annotation().builderExtendsModelRoot()
           && !util.isEnumModel(fieldModelRootInfo.get().element())
@@ -1066,7 +1066,7 @@ public final class JavaModelsGen implements CodeGenerator {
       constructorBuilder.addParameter(
           ParameterSpec.builder(util.getVariableType(method, false), fieldName).build());
       ContainerType containerType = util.getContainerType(method.getReturnType());
-      Optional<ModelRootInfo> modelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> modelRootInfo = util.asModelRoot(method.getReturnType(), method);
       switch (containerType) {
         case NO_CONTAINER -> {
           if (modelRootInfo.isPresent()) {
@@ -1173,7 +1173,7 @@ this.$L = $L == null
       ModelRoot modelRoot) {
     TypeMirror specifiedReturnType = method.getReturnType();
     ModelFieldTypeInfo modelFieldType = util.getModelFieldType(method, true, null);
-    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(specifiedReturnType);
+    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(specifiedReturnType, method);
     String fieldName = method.getSimpleName().toString();
     TypeName actualReturnType =
         isBuilder
@@ -1212,7 +1212,7 @@ this.$L = $L == null
       methodBuilder.addStatement(
           "return $T.ofNullable($L)",
           Optional.class,
-          getFieldAccessorExpression(isBuilder, fieldName, specifiedReturnType, util));
+          getFieldAccessorExpression(isBuilder, fieldName, specifiedReturnType, method, util));
     } else {
       if (util.getIfAbsent(method, modelRoot).value().usePlatformDefault()
           && !specifiedReturnType.getKind().isPrimitive()) {
@@ -1279,16 +1279,21 @@ this.$L = $L == null
                 .build());
       }
       methodBuilder.addStatement(
-          "return $L", getFieldAccessorExpression(isBuilder, fieldName, specifiedReturnType, util));
+          "return $L",
+          getFieldAccessorExpression(isBuilder, fieldName, specifiedReturnType, method, util));
     }
     return methodBuilder;
   }
 
   private static CodeBlock getFieldAccessorExpression(
-      boolean isBuilder, String fieldName, TypeMirror returnType, CodeGenUtility util) {
+      boolean isBuilder,
+      String fieldName,
+      TypeMirror returnType,
+      ExecutableElement method,
+      CodeGenUtility util) {
     CodeBlock fieldAccessorCode = CodeBlock.of("$L", fieldName);
 
-    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(returnType);
+    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(returnType, method);
     if (isBuilder
         && fieldModelRootInfo.isPresent()
         && !util.isEnumModel(fieldModelRootInfo.get().element())) {
@@ -1340,7 +1345,7 @@ this.$L = $L == null
       String fieldName = method.getSimpleName().toString();
       TypeName fieldType = util.getModelFieldType(method, true, null).fieldType();
       FieldSpec.Builder fieldBuilder = FieldSpec.builder(fieldType, fieldName, PRIVATE);
-      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
       if (fieldModelRootInfo.isPresent() && !util.isEnumModel(fieldModelRootInfo.get().element())) {
         if (LIST.equals(fieldModelRootInfo.get().containerType())) {
           fieldBuilder.initializer("$T.empty()", ModelsListBuilder.class);
@@ -1416,10 +1421,11 @@ this.$L = $L == null
       ModelRoot modelRoot) {
     String fieldName = modelMethod.getSimpleName().toString();
     CodeBlock fieldAccessorExpr =
-        getFieldAccessorExpression(true, fieldName, modelMethod.getReturnType(), util);
+        getFieldAccessorExpression(true, fieldName, modelMethod.getReturnType(), modelMethod, util);
 
     IfAbsentThen ifAbsentThen = util.getIfAbsent(modelMethod, modelRoot).value();
-    Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(modelMethod.getReturnType());
+    Optional<ModelRootInfo> fieldModelRootInfo =
+        util.asModelRoot(modelMethod.getReturnType(), modelMethod);
     boolean isModelContainer =
         fieldModelRootInfo.map(info -> info.containerType().isContainer()).orElse(false);
 
@@ -1466,7 +1472,7 @@ this.$L = $L == null
     builderCopyMethodBuilder.addStatement("$T _copy = new $T()", builderType, builderType);
     for (ExecutableElement method : modelMethods) {
       String fieldName = method.getSimpleName().toString();
-      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
       if (fieldModelRootInfo.isPresent()
           && !fieldModelRootInfo.get().annotation().builderExtendsModelRoot()
           && !util.isEnumModel(fieldModelRootInfo.get().element())
@@ -1489,7 +1495,7 @@ this.$L = $L == null
         builderCopyMethodBuilder.addStatement(
             "_copy.$L(this.$L)",
             fieldName,
-            getFieldAccessorExpression(true, fieldName, method.getReturnType(), util));
+            getFieldAccessorExpression(true, fieldName, method.getReturnType(), method, util));
       }
     }
     builderCopyMethodBuilder.addStatement("return _copy");
@@ -1506,7 +1512,7 @@ this.$L = $L == null
     List<MethodSpec> dataAccessMethods = new ArrayList<>();
     for (ExecutableElement method : modelMethods) {
       String methodName = method.getSimpleName().toString();
-      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRootInfo = util.asModelRoot(method.getReturnType(), method);
       dataAccessMethods.add(
           MethodSpec.methodBuilder(methodName)
               .addModifiers(PUBLIC)
@@ -1541,7 +1547,7 @@ this.$L = $L == null
               .addStatement("return this")
               .build());
 
-      Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType());
+      Optional<ModelRootInfo> fieldModelRoot = util.asModelRoot(method.getReturnType(), method);
       if (fieldModelRoot.isPresent()
           && !fieldModelRoot.get().annotation().builderExtendsModelRoot()
           && !util.isEnumModel(fieldModelRoot.get().element())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added compile-time validation that rejects nested collection patterns in model definitions (e.g., collections/maps containing other collections or optionals), preventing invalid model shapes and surfacing clear error messages that identify the offending model getters.

* **Documentation**
  * Expanded model documentation to describe the new constraints and show recommended alternatives (encapsulating inner collections in their own model) with illustrative examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->