### PR TITLE
Add ability for vajrams to define their inputs outside the vajram

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,7 @@ configure(subprojects.findAll {
         api 'com.google.guava:guava'
         implementation 'org.slf4j:slf4j-api'
         implementation 'jakarta.inject:jakarta.inject-api'
+        compileOnly 'com.google.auto.service:auto-service-annotations'
         implementation 'com.google.auto.service:auto-service-annotations'
         annotationProcessor 'com.google.auto.service:auto-service'
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
     krystal_version = project['com.flipkart.krystal.currentVersion']
     lattice_version = project['com.flipkart.krystal.lattice.currentVersion']
 
-    protobuf_version = '4.34.1'
+    protobuf_version = '4.35.0'
     grpc_version = '1.81.0'
     fory_version = '0.17.0'
     quarkus_version = '3.35.3'

--- a/config/idea_method_contracts/com/google/common/collect/annotations.xml
+++ b/config/idea_method_contracts/com/google/common/collect/annotations.xml
@@ -1,7 +1,7 @@
 <root>
   <item name='com.google.common.collect.ImmutableMap V getOrDefault(java.lang.Object, V)'>
     <annotation name='org.jetbrains.annotations.Contract'>
-      <val name="value" val="&quot;_, !null -&gt; !null&quot;"/>
+      <val name="value" val="&quot;_,!null-&gt;!null&quot;"/>
       <val name="pure" val="true"/>
     </annotation>
   </item>

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/AbstractKrystalAnnoProcessor.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/AbstractKrystalAnnoProcessor.java
@@ -60,10 +60,10 @@ public abstract class AbstractKrystalAnnoProcessor extends AbstractProcessor {
   }
 
   private void validateAndInit() {
-    validateCodegenPhase();
+    validateAndInitCodegenPhase();
   }
 
-  private void validateCodegenPhase() {
+  private void validateAndInitCodegenPhase() {
     String currentPhaseString = processingEnv.getOptions().get(CODEGEN_PHASE_KEY);
     if (currentPhaseString == null) {
       return;

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -29,10 +29,12 @@ import com.flipkart.krystal.model.ModelProtocol;
 import com.flipkart.krystal.model.ModelRoot;
 import com.flipkart.krystal.model.ModelRoot.ModelType;
 import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.model.SupportedModelProtocolName;
 import com.flipkart.krystal.model.array.PrimitiveArray;
 import com.flipkart.krystal.model.list.ModelsListBuilder;
 import com.flipkart.krystal.model.map.ModelsMapBuilder;
 import com.flipkart.krystal.serial.DefaultSerdeProtocol;
+import com.flipkart.krystal.serial.DefaultSerdeProtocolName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
@@ -212,6 +214,27 @@ public class CodeGenUtility {
       return declaredType.getTypeArguments().get(0);
     }
     return objectType;
+  }
+
+  /**
+   * Returns the package in which code should be generated for the given model root element. By
+   * default, codegen happens in the same package as the modelRoot. But if the model root is shared,
+   * i.e: @ModelRoot(isShared = true), then codegen happens in a sub-package
+   */
+  public String getCodegenPackageName(Element element) {
+    ModelRoot modelRoot = element.getAnnotation(ModelRoot.class);
+    if (modelRoot == null) {
+      throw new IllegalArgumentException(
+          "Cannot fetch codegen package name for Type which does not have @ModelRoot annotation");
+    }
+    String modelRootPackageName =
+        requireNonNull(processingEnv().getElementUtils().getPackageOf(element))
+            .getQualifiedName()
+            .toString();
+    if (modelRoot.isShared()) {
+      return modelRootPackageName + "." + Constants.SHARED_MODELS_SUB_PACKAGE;
+    }
+    return modelRootPackageName;
   }
 
   public String getPackageName(Element element) {
@@ -1020,7 +1043,7 @@ public class CodeGenUtility {
     }
 
     String modelRootName = modelRootType.getSimpleName().toString();
-    String packageName = getPackageName(modelRootType);
+    String packageName = getCodegenPackageName(modelRootType);
     return ClassName.get(packageName, modelRootName + modelRoot.suffixSeparator() + IMMUT_SUFFIX);
   }
 
@@ -1254,10 +1277,14 @@ public class CodeGenUtility {
    */
   public List<TypeElement> getSupportedProtocolTypeElements(Element element) {
     SupportedModelProtocol[] protocols = element.getAnnotationsByType(SupportedModelProtocol.class);
-    if (protocols.length == 0) {
-      return List.of();
-    }
-    return stream(protocols).map(p -> getTypeElemFromAnnotationMember(p::value)).toList();
+    SupportedModelProtocolName[] protocolNames =
+        element.getAnnotationsByType(SupportedModelProtocolName.class);
+    return Stream.concat(
+            stream(protocols).map(p -> getTypeElemFromAnnotationMember(p::value)),
+            stream(protocolNames)
+                .map(p -> elementUtils.getTypeElement(p.value()))
+                .filter(Objects::nonNull))
+        .toList();
   }
 
   /**
@@ -1265,24 +1292,50 @@ public class CodeGenUtility {
    * {@code @SupportedModelProtocol} annotations on the given element (the one with {@code isDefault
    * = true}). Returns {@code null} if no default is declared.
    */
-  public @Nullable TypeElement getDefaultProtocolTypeElement(Element element) {
-    DefaultSerdeProtocol defaultSerdeProtocol = element.getAnnotation(DefaultSerdeProtocol.class);
-    if (defaultSerdeProtocol == null) {
+  public @Nullable TypeElement getDefaultProtocolTypeElement(TypeMirror modelType) {
+    AnnotationMirror defaultSerdeProtocolMirror =
+        getAnnotationMirror(modelType, DefaultSerdeProtocol.class);
+    if (defaultSerdeProtocolMirror != null) {
+      return elementUtils.getTypeElement(
+          (CharSequence)
+              defaultSerdeProtocolMirror.getElementValues().entrySet().stream()
+                  .filter(e -> e.getKey().getSimpleName().contentEquals("value"))
+                  .findFirst()
+                  .map(Entry::getValue)
+                  .orElseThrow(AssertionError::new)
+                  .getValue());
+    }
+    Element element = typeUtils.asElement(modelType);
+    if (element == null) {
       return null;
     }
-    return getTypeElemFromAnnotationMember(defaultSerdeProtocol::value);
+    DefaultSerdeProtocol defaultSerdeProtocol = element.getAnnotation(DefaultSerdeProtocol.class);
+    DefaultSerdeProtocolName defaultSerdeProtocolName =
+        element.getAnnotation(DefaultSerdeProtocolName.class);
+    if (defaultSerdeProtocol != null && defaultSerdeProtocolName != null) {
+      error(
+          "Only one of @DefaultSerdeProtocol or @DefaultSerdeProtocolName should be specified - since a type can only have one default",
+          element);
+    }
+    if (defaultSerdeProtocol != null) {
+      return getTypeElemFromAnnotationMember(defaultSerdeProtocol::value);
+    }
+    if (defaultSerdeProtocolName != null) {
+      TypeElement typeElement = elementUtils.getTypeElement(defaultSerdeProtocolName.value());
+      if (typeElement == null) {
+        note(
+            "Ignoring %s as DefaultSerdeProtocol since loading type element for protocol returned null - maybe its not in the classpath");
+      } else {
+        return typeElement;
+      }
+    }
+    return null;
   }
 
   /** Returns true if the model root type supports the given model protocol. */
   public boolean typeExplicitlySupportsProtocol(
       Element modelRootType, Class<? extends ModelProtocol> modelProtocol) {
-    SupportedModelProtocol[] protocols =
-        modelRootType.getAnnotationsByType(SupportedModelProtocol.class);
-    if (protocols.length == 0) {
-      return false;
-    }
-    return stream(protocols)
-        .map(p -> getTypeElemFromAnnotationMember(p::value))
+    return getSupportedProtocolTypeElements(modelRootType).stream()
         .map(element -> element.getQualifiedName().toString())
         .anyMatch(s -> Objects.equals(s, modelProtocol.getCanonicalName()));
   }
@@ -1292,9 +1345,9 @@ public class CodeGenUtility {
    * the given element. Only protocols that extend SerdeProtocol are included.
    */
   public List<ModelProtocol> getModelProtocols(Element modelRootType) {
-    SupportedModelProtocol[] protocols =
-        modelRootType.getAnnotationsByType(SupportedModelProtocol.class);
-    if (protocols.length == 0) {
+    List<TypeElement> supportedProtocolTypeElements =
+        getSupportedProtocolTypeElements(modelRootType);
+    if (supportedProtocolTypeElements.isEmpty()) {
       return List.of();
     }
     Map<String, ModelProtocol> availableModelProtocols =
@@ -1306,8 +1359,7 @@ public class CodeGenUtility {
             .collect(
                 toMap(c -> requireNonNull(c.getClass().getCanonicalName()), Function.identity()));
 
-    return stream(protocols)
-        .map(p -> getTypeElemFromAnnotationMember(p::value))
+    return supportedProtocolTypeElements.stream()
         .map(element -> element.getQualifiedName().toString())
         .map(availableModelProtocols::get)
         .filter(Objects::nonNull)

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -1283,7 +1283,8 @@ public class CodeGenUtility {
             stream(protocols).map(p -> getTypeElemFromAnnotationMember(p::value)),
             stream(protocolNames)
                 .map(p -> elementUtils.getTypeElement(p.value()))
-                .filter(Objects::nonNull))
+                .filter(Objects::nonNull)
+                .map(Objects::requireNonNull))
         .toList();
   }
 
@@ -1324,7 +1325,8 @@ public class CodeGenUtility {
       TypeElement typeElement = elementUtils.getTypeElement(defaultSerdeProtocolName.value());
       if (typeElement == null) {
         note(
-            "Ignoring %s as DefaultSerdeProtocol since loading type element for protocol returned null - maybe its not in the classpath");
+            "Ignoring %s as DefaultSerdeProtocol since loading type element for protocol returned null - maybe its not in the classpath"
+                .formatted(defaultSerdeProtocolName.value()));
       } else {
         return typeElement;
       }

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/Constants.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/Constants.java
@@ -13,6 +13,7 @@ public final class Constants {
   public static final String IMMUT_POJO_SUFFIX = "_" + IMMUT_SUFFIX + POJO.modelClassesSuffix();
 
   public static final CodeBlock EMPTY_CODE_BLOCK = CodeBlock.builder().build();
+  public static final String SHARED_MODELS_SUB_PACKAGE = "shared_models";
 
   private Constants() {}
 }

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/Constants.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/Constants.java
@@ -13,7 +13,7 @@ public final class Constants {
   public static final String IMMUT_POJO_SUFFIX = "_" + IMMUT_SUFFIX + POJO.modelClassesSuffix();
 
   public static final CodeBlock EMPTY_CODE_BLOCK = CodeBlock.builder().build();
-  public static final String SHARED_MODELS_SUB_PACKAGE = "shared_models";
+  public static final String SHARED_MODELS_SUB_PACKAGE = "gen";
 
   private Constants() {}
 }

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/spi/ModelsCodeGenContext.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/spi/ModelsCodeGenContext.java
@@ -4,5 +4,10 @@ import com.flipkart.krystal.codegen.common.models.CodeGenUtility;
 import com.flipkart.krystal.codegen.common.models.CodegenPhase;
 import javax.lang.model.element.TypeElement;
 
+/**
+ * @param modelRootType for which to generate model subtypes
+ * @param codegenPhase the current executing codegen phase
+ * @param util {@link CodeGenUtility}
+ */
 public record ModelsCodeGenContext(
-    TypeElement modelRootType, CodeGenUtility util, CodegenPhase codegenPhase) {}
+    TypeElement modelRootType, CodegenPhase codegenPhase, CodeGenUtility util) {}

--- a/krystal-common/Krystal-models.md
+++ b/krystal-common/Krystal-models.md
@@ -404,3 +404,60 @@ public interface Task extends Model {
 When used in protobuf messages, the enum field is generated as the corresponding proto enum type,
 and getter/setter code in the generated `_ImmutProto` wrapper delegates to the shared
 `<EnumName>_ProtoUtils` class for conversion.
+
+## Shared Models (External Inputs)
+
+Normally, a Vajram's inputs are defined inside its class via the `_Inputs` nested interface. Shared
+Models allow inputs to be defined **externally** in a standalone interface annotated with
+`@InputsForVajram`. This is useful when:
+
+- Multiple Vajrams share the same input contract.
+- The inputs interface lives in a different module from the Vajram implementation.
+- You want to generate the request interface (`_Req`) separately from the Vajram codegen.
+
+### Defining External Inputs
+
+Create an interface that extends `VajramInputs<T>` (where `T` is the response type) and annotate it
+with `@InputsForVajram`:
+
+```java
+@InputsForVajram(parentPackage = "com.example.vajrams", vajramId = "GetOrder")
+public interface GetOrderInputs extends VajramInputs<OrderResponse> {
+
+  String orderId();
+
+  @Nullable
+  String customerId();
+}
+```
+
+**Key attributes of `@InputsForVajram`:**
+
+| Attribute       | Description                                                                                                            |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| `parentPackage` | The parent package for the generated request interface. The request is generated in `parentPackage + ".shared_models"`. |
+| `vajramId`      | The ID of the Vajram that uses this interface as its inputs definition.                                                 |
+
+### How It Works
+
+1. The `SharedModelsGenProcessor` (an annotation processor) discovers interfaces annotated with
+   `@InputsForVajram`.
+2. It extracts the response type from the `VajramInputs<T>` type parameter.
+3. It builds `DefaultFacetModel` instances from the interface's methods (each method becomes an
+   input facet).
+4. It delegates to `VajramCodeGenerator.generateVajramRequest()` to generate the request interface
+   (`_Req`) in the `parentPackage.shared_models` package.
+
+### Repeatable Annotation
+
+`@InputsForVajram` is repeatable — a single inputs interface can define inputs for multiple Vajrams:
+
+```java
+@InputsForVajram(parentPackage = "com.example.vajrams.getorder", vajramId = "GetOrder")
+@InputsForVajram(parentPackage = "com.example.vajrams.getorderv2", vajramId = "GetOrderV2")
+public interface GetOrderInputs extends VajramInputs<OrderResponse> {
+  String orderId();
+}
+```
+
+This generates separate `_Req` interfaces for each Vajram in their respective packages.

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/AbstractFacet.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/AbstractFacet.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public abstract class AbstractFacet implements Facet {
-  private final int id;
   private final String name;
   private final VajramID ofVajramID;
   private final FacetType facetType;

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/BasicFacetInfo.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/BasicFacetInfo.java
@@ -6,8 +6,6 @@ import com.flipkart.krystal.core.VajramID;
 import com.flipkart.krystal.tags.ElementTags;
 
 public interface BasicFacetInfo {
-  int id();
-
   String name();
 
   String documentation();

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/ImportVajramInputs.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/ImportVajramInputs.java
@@ -1,0 +1,9 @@
+package com.flipkart.krystal.facets;
+
+/**
+ * This annotation is used to import vajram inputs from another module/project into the current
+ * module/project to enable code generation for those.
+ */
+public @interface ImportVajramInputs {
+  String[] fromPackages();
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/InputsForVajram.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/InputsForVajram.java
@@ -11,15 +11,15 @@ import java.lang.annotation.Target;
 @Repeatable(InputsForVajrams.class)
 public @interface InputsForVajram {
 
-  /**
-   * The parent package of the all the auto generated models - the models are generated in {@code
-   * parentPackage() + ".shared_models"} or one of its sub-packages. Ideally should be same as the
-   * package of the vajram class
-   */
-  String parentPackage();
-
   /** The id of the vajram which uses this interface as inputs definition. */
   String vajramId();
+
+  /**
+   * The parent package of the all the auto generated models - the models are generated in {@code
+   * parentPackage() + ".models"} or one of its sub-packages. Ideally should be same as the package
+   * of the vajram class
+   */
+  String parentPackage();
 
   @Target(TYPE)
   @interface InputsForVajrams {

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/InputsForVajram.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/InputsForVajram.java
@@ -1,0 +1,28 @@
+package com.flipkart.krystal.facets;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import com.flipkart.krystal.facets.InputsForVajram.InputsForVajrams;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Target;
+
+/** Declares that an interface defines the inputs of a Vajram. */
+@Target(TYPE)
+@Repeatable(InputsForVajrams.class)
+public @interface InputsForVajram {
+
+  /**
+   * The parent package of the all the auto generated models - the models are generated in
+   * `parentPackage() +".shared_models` or one of its sub-packages. Ideally should be same as the
+   * package of the vajram class
+   */
+  String parentPackage();
+
+  /** The id of the vajram which used this interface as inputs definition. */
+  String vajramId();
+
+  @Target(TYPE)
+  @interface InputsForVajrams {
+    InputsForVajram[] value();
+  }
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/InputsForVajram.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/InputsForVajram.java
@@ -12,13 +12,13 @@ import java.lang.annotation.Target;
 public @interface InputsForVajram {
 
   /**
-   * The parent package of the all the auto generated models - the models are generated in
-   * `parentPackage() +".shared_models` or one of its sub-packages. Ideally should be same as the
+   * The parent package of the all the auto generated models - the models are generated in {@code
+   * parentPackage() + ".shared_models"} or one of its sub-packages. Ideally should be same as the
    * package of the vajram class
    */
   String parentPackage();
 
-  /** The id of the vajram which used this interface as inputs definition. */
+  /** The id of the vajram which uses this interface as inputs definition. */
   String vajramId();
 
   @Target(TYPE)

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/VajramInputs.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/VajramInputs.java
@@ -1,8 +1,9 @@
 package com.flipkart.krystal.facets;
 
 /**
- * Marker interface for Vajram or Trait inputs. Classes extending this interface must have @{@link
- * InputsForVajram} to participate in code generation.
+ * Marker interface for Vajram or Trait inputs defined outside the vajram class. Classes extending
+ * this interface must have the {@link InputsForVajram} annotation to participate in code
+ * generation.
  *
  * @param <T> The response type of the vajram or trait
  */

--- a/krystal-common/src/main/java/com/flipkart/krystal/facets/VajramInputs.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/facets/VajramInputs.java
@@ -1,0 +1,9 @@
+package com.flipkart.krystal.facets;
+
+/**
+ * Marker interface for Vajram or Trait inputs. Classes extending this interface must have @{@link
+ * InputsForVajram} to participate in code generation.
+ *
+ * @param <T> The response type of the vajram or trait
+ */
+public interface VajramInputs<T> {}

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/ImportSharedModels.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/ImportSharedModels.java
@@ -1,0 +1,15 @@
+package com.flipkart.krystal.model;
+
+/**
+ * This annotation is used to import shared models from another module/project into the current
+ * module/project to enable code generation for those models.
+ */
+public @interface ImportSharedModels {
+  /**
+   * The models to import. These models must be annotated with @ModelRoot and have isShared() set to
+   * true.
+   */
+  Class<? extends Model>[] value() default {};
+
+  String[] fromPackages() default {};
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/ModelRoot.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/ModelRoot.java
@@ -23,6 +23,14 @@ public @interface ModelRoot {
    */
   boolean pure() default true;
 
+  /**
+   * true if this model root is intended to be shared across other client modules/projects. Those
+   * modules may choose to generate code bases on this model. The general implication of this for
+   * code generation is that clients will need the ability to generate the code in a subpackage
+   * instead of the same package as the model root to avoid split package issues across modules.
+   */
+  boolean isShared() default false;
+
   enum ModelType {
     /** This model is designed to be used as part of requests */
     REQUEST,

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/SupportedModelProtocol.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/SupportedModelProtocol.java
@@ -1,13 +1,13 @@
 package com.flipkart.krystal.model;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.ElementType.TYPE_USE;
 
+import com.flipkart.krystal.model.SupportedModelProtocol.SupportedModelProtocols;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
-@Repeatable(SupportedModelProtocol.SupportedModelProtocols.class)
-@Target({TYPE, TYPE_USE})
+@Repeatable(SupportedModelProtocols.class)
+@Target(TYPE)
 public @interface SupportedModelProtocol {
   Class<? extends ModelProtocol> value();
 

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/SupportedModelProtocolName.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/SupportedModelProtocolName.java
@@ -8,13 +8,15 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation is used to specify the name of the model protocol supported by a type. This is
- * preferred over @{@link SupportedModelProtocol} in cases where we want to avoid users of the jar
+ * preferred over {@link SupportedModelProtocol} in cases where we want to avoid users of the jar
  * produced by this project from unnecessarily having to add protocol libraries to their classpath
  * which they don't need.
  */
 @Repeatable(SupportedModelProtocolNames.class)
 @Target(TYPE)
 public @interface SupportedModelProtocolName {
+
+  /** THe fully qualified "canonical" class name of the protocol class. */
   String value();
 
   @Target(TYPE)

--- a/krystal-common/src/main/java/com/flipkart/krystal/model/SupportedModelProtocolName.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/model/SupportedModelProtocolName.java
@@ -1,0 +1,24 @@
+package com.flipkart.krystal.model;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import com.flipkart.krystal.model.SupportedModelProtocolName.SupportedModelProtocolNames;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to specify the name of the model protocol supported by a type. This is
+ * preferred over @{@link SupportedModelProtocol} in cases where we want to avoid users of the jar
+ * produced by this project from unnecessarily having to add protocol libraries to their classpath
+ * which they don't need.
+ */
+@Repeatable(SupportedModelProtocolNames.class)
+@Target(TYPE)
+public @interface SupportedModelProtocolName {
+  String value();
+
+  @Target(TYPE)
+  @interface SupportedModelProtocolNames {
+    SupportedModelProtocolName[] value();
+  }
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/serial/DefaultSerdeProtocol.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/serial/DefaultSerdeProtocol.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.serial;
 
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_USE;
 
 import com.flipkart.krystal.model.ModelRoot;
 import java.lang.annotation.Target;
@@ -15,7 +16,7 @@ import java.lang.annotation.Target;
  * since client who were receiving data in one format will suddenly start receiving data in a
  * different format. So such a change should be done with extreme caution.
  */
-@Target(TYPE)
+@Target({TYPE, TYPE_USE})
 public @interface DefaultSerdeProtocol {
   Class<? extends SerdeProtocol> value();
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/serial/DefaultSerdeProtocolName.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/serial/DefaultSerdeProtocolName.java
@@ -1,0 +1,16 @@
+package com.flipkart.krystal.serial;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import java.lang.annotation.Target;
+
+/**
+ * Similar to {@link DefaultSerdeProtocol} but preferred in scenarios where we want to avoid adding
+ * the protocol classes to client systems' classpath - for example when the type is part of a shared
+ * library.
+ */
+@Target({TYPE, TYPE_USE})
+public @interface DefaultSerdeProtocolName {
+  String value();
+}

--- a/krystal-common/src/main/java/com/flipkart/krystal/serial/SerdeConfig.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/serial/SerdeConfig.java
@@ -1,12 +1,13 @@
 package com.flipkart.krystal.serial;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 
 import com.flipkart.krystal.serial.SerdeConfig.SerdeConfigs;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
-@Target(METHOD)
+@Target({METHOD, TYPE})
 @Repeatable(SerdeConfigs.class)
 public @interface SerdeConfig {
   Class<? extends SerdeProtocol> protocol();

--- a/krystal-common/src/main/java/com/flipkart/krystal/serial/SerialId.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/serial/SerialId.java
@@ -2,11 +2,9 @@ package com.flipkart.krystal.serial;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import com.flipkart.krystal.annos.ApplicableToElements;
 import com.flipkart.krystal.core.KrystalElement.Facet;
-import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
@@ -15,7 +13,6 @@ import java.lang.annotation.Target;
  */
 @ApplicableToElements(Facet.class)
 @Target({FIELD, METHOD})
-@Retention(SOURCE)
 public @interface SerialId {
   int value();
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/traits/SimpleStaticDispatchPolicy.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/traits/SimpleStaticDispatchPolicy.java
@@ -1,0 +1,65 @@
+package com.flipkart.krystal.traits;
+
+import com.flipkart.krystal.core.VajramID;
+import com.flipkart.krystal.data.Request;
+import com.flipkart.krystal.facets.Dependency;
+import com.google.common.collect.ImmutableSet;
+import java.lang.annotation.Annotation;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class SimpleStaticDispatchPolicy extends StaticDispatchPolicy {
+
+  private final VajramID traitId;
+  private final VajramID dispatchTarget;
+  private final Class<? extends Request<?>> dispatchTargetReq;
+
+  public SimpleStaticDispatchPolicy(
+      VajramID traitId, VajramID dispatchTarget, Class<? extends Request<?>> dispatchTargetReq) {
+    this.traitId = traitId;
+    this.dispatchTarget = dispatchTarget;
+    this.dispatchTargetReq = dispatchTargetReq;
+  }
+
+  @Override
+  public VajramID getDispatchTargetID(Dependency dependency) {
+    return dispatchTarget;
+  }
+
+  @Override
+  public Class<? extends Request<?>> getDispatchTarget(Dependency dependency) {
+    return dispatchTargetReq;
+  }
+
+  @Override
+  public VajramID getDispatchTargetID(@Nullable Annotation qualifier) {
+    if (qualifier == null) {
+      return dispatchTarget;
+    } else {
+      throw new IllegalArgumentException("Qualifier not supported");
+    }
+  }
+
+  @Override
+  public Class<? extends Request<?>> getDispatchTarget(@Nullable Annotation qualifier) {
+    if (qualifier == null) {
+      return dispatchTargetReq;
+    } else {
+      throw new IllegalArgumentException("Qualifier not supported");
+    }
+  }
+
+  @Override
+  public VajramID traitID() {
+    return traitId;
+  }
+
+  @Override
+  public ImmutableSet<VajramID> dispatchTargetIDs() {
+    return ImmutableSet.of(dispatchTarget);
+  }
+
+  @Override
+  public ImmutableSet<Class<? extends Request<?>>> dispatchTargetReqs() {
+    return ImmutableSet.of(dispatchTargetReq);
+  }
+}

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinition.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinition.java
@@ -6,12 +6,9 @@ import com.flipkart.krystal.facets.FacetType;
 import com.flipkart.krystal.krystex.LogicDefinition;
 import com.flipkart.krystal.krystex.resolution.CreateNewRequest;
 import com.flipkart.krystal.tags.ElementTags;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public sealed interface KryonDefinition permits VajramKryonDefinition, TraitKryonDefinition {
-
-  ImmutableMap<Integer, Facet> facetsById();
 
   ImmutableSet<Facet> facetsByType(FacetType facetType);
 

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinitionView.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinitionView.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * Useful data views over {@link VajramKryonDefinition}'s data
@@ -34,7 +33,6 @@ import java.util.function.Function;
  * @param dependenciesWithNoResolvers Set of dependency names which have no resolvers.
  */
 record KryonDefinitionView(
-    ImmutableMap<Integer, Facet> facetsById,
     ImmutableMap<FacetType, ImmutableSet<Facet>> facetsByType,
     ImmutableSet<Facet> givenFacets,
     ImmutableSet<Dependency> dependencies,
@@ -73,7 +71,6 @@ record KryonDefinitionView(
     ImmutableMap<Optional<Facet>, ImmutableSet<ResolverDefinition>> resolverDefinitionsByFacets =
         createResolverDefinitionsByFacets(resolversByDefinition.keySet());
     return new KryonDefinitionView(
-        allFacets.stream().collect(toImmutableMap(Facet::id, Function.identity())),
         facetsByType.entrySet().stream()
             .collect(toImmutableMap(Entry::getKey, e -> ImmutableSet.copyOf(e.getValue()))),
         allFacets.stream().filter(FacetUtils::isGiven).collect(toImmutableSet()),

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/TraitKryonDefinition.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/TraitKryonDefinition.java
@@ -35,11 +35,6 @@ public record TraitKryonDefinition(
   }
 
   @Override
-  public ImmutableMap<Integer, Facet> facetsById() {
-    return view.facetsById();
-  }
-
-  @Override
   public ImmutableSet<Facet> facetsByType(FacetType facetType) {
     return view.facetsByType().getOrDefault(facetType, ImmutableSet.of());
   }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/VajramKryonDefinition.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/VajramKryonDefinition.java
@@ -80,11 +80,6 @@ public record VajramKryonDefinition(
   }
 
   @Override
-  public ImmutableMap<Integer, Facet> facetsById() {
-    return view.facetsById();
-  }
-
-  @Override
   public ImmutableSet<Facet> facetsByType(FacetType facetType) {
     return view.facetsByType().getOrDefault(facetType, ImmutableSet.of());
   }

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/kryon/KryonExecutorTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/kryon/KryonExecutorTest.java
@@ -205,7 +205,7 @@ class KryonExecutorTest {
   @Test
   void requestExecution_unboundInputs_success() {
     VajramID kryonName = vajramID("requestExecution_noDependencies_success_nodeName");
-    ImmutableSet<SimpleFacet> inputDefs = ImmutableSet.of(input(1), input(2), input(3));
+    ImmutableSet<SimpleFacet> inputDefs = ImmutableSet.of(input(), input(), input());
     VajramID vajramID =
         kryonDefinitionRegistry
             .newVajramKryonDefinition(
@@ -213,14 +213,18 @@ class KryonExecutorTest {
                 inputDefs,
                 newComputeLogic(
                         kryonName,
-                        Set.of(input(1), input(2), input(3)),
+                        Set.of(input(), input(), input()),
                         facets ->
                             "computed_values: a=%s;b=%s;c=%s"
                                 .formatted(
-                                    ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow(),
-                                    ((FacetValuesMap) facets)._getOne2OneResponse(2).valueOrThrow(),
                                     ((FacetValuesMap) facets)
-                                        ._getOne2OneResponse(3)
+                                        ._getOne2OneResponse("facet1")
+                                        .valueOrThrow(),
+                                    ((FacetValuesMap) facets)
+                                        ._getOne2OneResponse("facet2")
+                                        .valueOrThrow(),
+                                    ((FacetValuesMap) facets)
+                                        ._getOne2OneResponse("facet3")
                                         .valueOrThrow()))
                     .kryonLogicId(),
                 ImmutableMap.of(),
@@ -233,7 +237,8 @@ class KryonExecutorTest {
         kryonExecutor.executeKryon(
             new SimpleRequestBuilder<>(
                     inputDefs,
-                    ImmutableMap.of(1, withValue(1), 2, withValue(2), 3, withValue("3")),
+                    ImmutableMap.of(
+                        "facet1", withValue(1), "facet2", withValue(2), "facet3", withValue("3")),
                     vajramID)
                 ._build(),
             KryonExecutionConfig.builder().executionId("r").build());
@@ -255,7 +260,7 @@ class KryonExecutorTest {
         emptyTags());
 
     VajramID n2ID = vajramID("n2");
-    SimpleDep n1DependsOnN1 = dependency(1, n2ID, n1ID);
+    SimpleDep n1DependsOnN1 = dependency("facet1", n2ID, n1ID);
     Set<SimpleDep> allFacets = Set.of(n1DependsOnN1);
     VajramKryonDefinition n2 =
         kryonDefinitionRegistry.newVajramKryonDefinition(
@@ -265,7 +270,7 @@ class KryonExecutorTest {
                     n2ID,
                     allFacets,
                     facets ->
-                        ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow()
+                        ((FacetValuesMap) facets)._getOne2OneResponse("facet1").valueOrThrow()
                             + ":computed_value")
                 .kryonLogicId(),
             ImmutableMap.of(),
@@ -285,7 +290,7 @@ class KryonExecutorTest {
                         (o, throwable) ->
                             ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                                 ._set(
-                                    n1DependsOnN1.id(),
+                                    n1DependsOnN1.name(),
                                     new RequestResponse(n1Req, errableFrom(o, throwable)))));
               }
               CompletableFuture.allOf(list.toArray(CompletableFuture[]::new))
@@ -317,7 +322,7 @@ class KryonExecutorTest {
         emptyTags());
 
     VajramID l2Dep = vajramID("requestExecution_multiLevelDependencies_level2");
-    Dependency l2DependsOnL1 = dependency(1, l2Dep, l1Dep);
+    Dependency l2DependsOnL1 = dependency("facet1", l2Dep, l1Dep);
     Set<Dependency> l2Facets = Set.of(l2DependsOnL1);
     kryonDefinitionRegistry.newVajramKryonDefinition(
         l2Dep,
@@ -325,7 +330,8 @@ class KryonExecutorTest {
         newComputeLogic(
                 l2Dep,
                 l2Facets,
-                facets -> ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow() + ":l2")
+                facets ->
+                    ((FacetValuesMap) facets)._getOne2OneResponse("facet1").valueOrThrow() + ":l2")
             .kryonLogicId(),
         ImmutableMap.of(),
         newCreateNewRequestLogic(l2Dep, emptySet()),
@@ -344,7 +350,7 @@ class KryonExecutorTest {
                     (result, throwable) ->
                         ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                             ._set(
-                                l2DependsOnL1.id(),
+                                l2DependsOnL1.name(),
                                 new RequestResponse(
                                     l1Req, Errable.errableFrom(result, throwable)))));
           }
@@ -355,7 +361,7 @@ class KryonExecutorTest {
         emptyTags());
 
     VajramID l3Dep = vajramID("requestExecution_multiLevelDependencies_level3");
-    Dependency l3DependsOnL2 = dependency(1, l3Dep, l2Dep);
+    Dependency l3DependsOnL2 = dependency("facet1", l3Dep, l2Dep);
     Set<Dependency> l3Facets = Set.of(l3DependsOnL2);
 
     kryonDefinitionRegistry.newVajramKryonDefinition(
@@ -364,7 +370,8 @@ class KryonExecutorTest {
         newComputeLogic(
                 l3Dep,
                 l3Facets,
-                facets -> ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow() + ":l3")
+                facets ->
+                    ((FacetValuesMap) facets)._getOne2OneResponse("facet1").valueOrThrow() + ":l3")
             .kryonLogicId(),
         ImmutableMap.of(),
         newCreateNewRequestLogic(l3Dep, emptySet()),
@@ -383,7 +390,8 @@ class KryonExecutorTest {
                     (o, throwable) ->
                         ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                             ._set(
-                                1, new RequestResponse(l2Req, Errable.errableFrom(o, throwable)))));
+                                "facet1",
+                                new RequestResponse(l2Req, Errable.errableFrom(o, throwable)))));
           }
           CompletableFuture.allOf(list.toArray(CompletableFuture[]::new))
               .whenComplete(
@@ -392,7 +400,7 @@ class KryonExecutorTest {
         emptyTags());
 
     VajramID l4Dep = vajramID("requestExecution_multiLevelDependencies_level4");
-    Dependency l4DepOnL3 = dependency(1, l4Dep, l3Dep);
+    Dependency l4DepOnL3 = dependency("facet1", l4Dep, l3Dep);
     Set<Facet> l4Facets = Set.of(l4DepOnL3);
     kryonDefinitionRegistry.newVajramKryonDefinition(
         l4Dep,
@@ -400,7 +408,8 @@ class KryonExecutorTest {
         newComputeLogic(
                 l4Dep,
                 l4Facets,
-                facets -> ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow() + ":l4")
+                facets ->
+                    ((FacetValuesMap) facets)._getOne2OneResponse("facet1").valueOrThrow() + ":l4")
             .kryonLogicId(),
         ImmutableMap.of(),
         newCreateNewRequestLogic(l4Dep, emptySet()),
@@ -419,7 +428,7 @@ class KryonExecutorTest {
                     (o, throwable) ->
                         ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                             ._set(
-                                l4DepOnL3.id(),
+                                l4DepOnL3.name(),
                                 new RequestResponse(l3Req, errableFrom(o, throwable)))));
           }
           CompletableFuture.allOf(list.toArray(CompletableFuture[]::new))
@@ -429,7 +438,7 @@ class KryonExecutorTest {
         ElementTags.of(List.of(InvocableOutsideGraph.Creator.create())));
 
     VajramID finalKryon = vajramID("requestExecution_multiLevelDependencies_final");
-    Dependency finalDepOnL4 = dependency(1, finalKryon, l4Dep);
+    Dependency finalDepOnL4 = dependency("facet1", finalKryon, l4Dep);
     Set<Facet> finalFacets = Set.of(finalDepOnL4);
     kryonDefinitionRegistry.newVajramKryonDefinition(
         finalKryon,
@@ -438,7 +447,8 @@ class KryonExecutorTest {
                 finalKryon,
                 finalFacets,
                 facets ->
-                    ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow() + ":final")
+                    ((FacetValuesMap) facets)._getOne2OneResponse("facet1").valueOrThrow()
+                        + ":final")
             .kryonLogicId(),
         ImmutableMap.of(),
         newCreateNewRequestLogic(finalKryon, emptySet()),
@@ -457,7 +467,7 @@ class KryonExecutorTest {
                     (o, throwable) ->
                         ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                             ._set(
-                                finalDepOnL4.id(),
+                                finalDepOnL4.name(),
                                 new RequestResponse(l4Req, errableFrom(o, throwable)))));
           }
           CompletableFuture.allOf(list.toArray(CompletableFuture[]::new))
@@ -522,8 +532,8 @@ class KryonExecutorTest {
     VajramID kryonName =
         vajramID(
             "executeKryon_dependenciesWithReturnInstantly_executeComputeExecutedExactlyOnce_final");
-    Dependency dep1 = dependency(1, kryonName, dep1ID);
-    Dependency dep2 = dependency(2, kryonName, dep2ID);
+    Dependency dep1 = dependency("facet1", kryonName, dep1ID);
+    Dependency dep2 = dependency("facet2", kryonName, dep2ID);
     Set<Facet> allFacets = Set.of(dep1, dep2);
     VajramID vajramID =
         kryonDefinitionRegistry
@@ -535,9 +545,13 @@ class KryonExecutorTest {
                         allFacets,
                         facets -> {
                           numberOfExecutions.increment();
-                          return ((FacetValuesMap) facets)._getOne2OneResponse(1).valueOrThrow()
+                          return ((FacetValuesMap) facets)
+                                  ._getOne2OneResponse("facet1")
+                                  .valueOrThrow()
                               + ":"
-                              + ((FacetValuesMap) facets)._getOne2OneResponse(2).valueOrThrow()
+                              + ((FacetValuesMap) facets)
+                                  ._getOne2OneResponse("facet2")
+                                  .valueOrThrow()
                               + ":final";
                         })
                     .kryonLogicId(),
@@ -557,13 +571,13 @@ class KryonExecutorTest {
                         (o, throwable) ->
                             ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                                 ._set(
-                                    dep1.id(),
+                                    dep1.name(),
                                     new RequestResponse(dep1Req, errableFrom(o, throwable))));
                     dep2Future.whenComplete(
                         (o, throwable) ->
                             ((FacetValuesMapBuilder) executionItem.facetValues()._asBuilder())
                                 ._set(
-                                    dep2.id(),
+                                    dep2.name(),
                                     new RequestResponse(dep2Req, errableFrom(o, throwable))));
                     _graphExecData
                         .communicationFacade()
@@ -587,11 +601,11 @@ class KryonExecutorTest {
                                       (FacetValuesMapBuilder)
                                           executionItem.facetValues()._asBuilder();
                                   f._set(
-                                      dep1.id(),
+                                      dep1.name(),
                                       new RequestResponse(
                                           dep1Req, errableFrom(dep1Future.join(), throwable)));
                                   f._set(
-                                      dep2.id(),
+                                      dep2.name(),
                                       new RequestResponse(
                                           dep2Req, errableFrom(dep2Future.join(), throwable)));
                                 }));
@@ -641,7 +655,7 @@ class KryonExecutorTest {
 
     CountDownLatch countDownLatch = new CountDownLatch(1);
     VajramID n2Id = vajramID("n2");
-    SimpleDep n2DepOnN1 = dependency(1, n2Id, n1ID);
+    SimpleDep n2DepOnN1 = dependency("facet1", n2Id, n1ID);
     Set<SimpleDep> allFacets = Set.of(n2DepOnN1);
     VajramKryonDefinition n2 =
         kryonDefinitionRegistry.newVajramKryonDefinition(
@@ -665,7 +679,7 @@ class KryonExecutorTest {
                             .handle(
                                 (unused, throwable) ->
                                     ((FacetValuesMap) facets)
-                                            ._getOne2OneResponse(1)
+                                            ._getOne2OneResponse("facet1")
                                             .valueOpt()
                                             .orElseThrow()
                                         + ":computed_value"))

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/kryon/KryonExecutorTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/kryon/KryonExecutorTest.java
@@ -205,7 +205,8 @@ class KryonExecutorTest {
   @Test
   void requestExecution_unboundInputs_success() {
     VajramID kryonName = vajramID("requestExecution_noDependencies_success_nodeName");
-    ImmutableSet<SimpleFacet> inputDefs = ImmutableSet.of(input(), input(), input());
+    ImmutableSet<SimpleFacet> inputDefs =
+        ImmutableSet.of(input("facet1"), input("facet2"), input("facet3"));
     VajramID vajramID =
         kryonDefinitionRegistry
             .newVajramKryonDefinition(
@@ -213,7 +214,7 @@ class KryonExecutorTest {
                 inputDefs,
                 newComputeLogic(
                         kryonName,
-                        Set.of(input(), input(), input()),
+                        Set.of(input("facet1"), input("facet2"), input("facet3")),
                         facets ->
                             "computed_values: a=%s;b=%s;c=%s"
                                 .formatted(

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/logicdecorators/observability/DefaultKryonExecutionReportTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/logicdecorators/observability/DefaultKryonExecutionReportTest.java
@@ -45,7 +45,7 @@ class DefaultKryonExecutionReportTest {
   void reportStartAndEnd_success() {
     VajramID vajramID = new VajramID("kryon_1");
     KryonLogicId kryonLogicId = new KryonLogicId(vajramID, "kryon_1__logic_1");
-    Set<SimpleFacet> allInputs = Set.of(input(1));
+    Set<SimpleFacet> allInputs = Set.of(input());
     ImmutableList<ExecutionItem> facetValuesList =
         ImmutableList.of(
             new ExecutionItem(
@@ -101,16 +101,16 @@ class DefaultKryonExecutionReportTest {
     assertThat(derefedMap)
         .isEqualTo(
             ImmutableMap.of(
-                ImmutableMap.of(input(1), "v1"), "r1", ImmutableMap.of(input(1), "v2"), "r1"));
+                ImmutableMap.of(input(), "v1"), "r1", ImmutableMap.of(input(), "v2"), "r1"));
 
     ImmutableList<ImmutableMap<Facet, String>> inputsList = logicExecInfo.inputsList();
 
-    List<Map<Integer, String>> dereffedInputList = new ArrayList<>();
+    List<Map<String, String>> dereffedInputList = new ArrayList<>();
     for (ImmutableMap<Facet, String> inputs : inputsList) {
-      Map<Integer, String> map = new LinkedHashMap<>();
+      Map<String, String> map = new LinkedHashMap<>();
       inputs.forEach(
           (inputName, valueRef) ->
-              map.put(inputName.id(), (String) kryonExecutionReport.dataMap().get(valueRef)));
+              map.put(inputName.name(), (String) kryonExecutionReport.dataMap().get(valueRef)));
       dereffedInputList.add(map);
     }
     assertThat(dereffedInputList)
@@ -126,15 +126,15 @@ class DefaultKryonExecutionReportTest {
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input(1)), ImmutableMap.of(1, withValue("v1")), vajramID),
-                    Set.of(input(1)),
+                        Set.of(input()), ImmutableMap.of(1, withValue("v1")), vajramID),
+                    Set.of(input()),
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input(2)), ImmutableMap.of(2, withValue("v2")), vajramID),
-                    Set.of(input(2)),
+                        Set.of(input()), ImmutableMap.of(2, withValue("v2")), vajramID),
+                    Set.of(input()),
                     vajramID),
                 new CompletableFuture<>()));
 
@@ -161,15 +161,15 @@ class DefaultKryonExecutionReportTest {
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input(1)), ImmutableMap.of(1, withValue("v1")), vajramID),
-                    Set.of(input(1)),
+                        Set.of(input()), ImmutableMap.of(1, withValue("v1")), vajramID),
+                    Set.of(input()),
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input(2)), ImmutableMap.of(2, withValue("v2")), vajramID),
-                    Set.of(input(2)),
+                        Set.of(input()), ImmutableMap.of(2, withValue("v2")), vajramID),
+                    Set.of(input()),
                     vajramID),
                 new CompletableFuture<>()));
 
@@ -214,13 +214,13 @@ class DefaultKryonExecutionReportTest {
         ImmutableList.of(
             new ImmutableFacetValuesMap(
                 new SimpleRequestBuilder<>(
-                    Set.of(input(1)), ImmutableMap.of(1, withValue("v1")), vajramID),
-                Set.of(input(1)),
+                    Set.of(input()), ImmutableMap.of(1, withValue("v1")), vajramID),
+                Set.of(input()),
                 vajramID),
             new ImmutableFacetValuesMap(
                 new SimpleRequestBuilder<>(
-                    Set.of(input(2)), ImmutableMap.of(2, withValue("v2")), vajramID),
-                Set.of(input(2)),
+                    Set.of(input()), ImmutableMap.of(2, withValue("v2")), vajramID),
+                Set.of(input()),
                 vajramID));
 
     clock.setInstant(END_TIME);

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/logicdecorators/observability/DefaultKryonExecutionReportTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/logicdecorators/observability/DefaultKryonExecutionReportTest.java
@@ -117,7 +117,8 @@ class DefaultKryonExecutionReportTest {
       dereffedInputList.add(map);
     }
     assertThat(dereffedInputList)
-        .isEqualTo(ImmutableList.of(ImmutableMap.of(1, "v1"), ImmutableMap.of(1, "v2")));
+        .isEqualTo(
+            ImmutableList.of(ImmutableMap.of("facet1", "v1"), ImmutableMap.of("facet1", "v2")));
   }
 
   @Test
@@ -129,14 +130,18 @@ class DefaultKryonExecutionReportTest {
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input("facet1")), ImmutableMap.of("facet1", withValue("v1")), vajramID),
+                        Set.of(input("facet1")),
+                        ImmutableMap.of("facet1", withValue("v1")),
+                        vajramID),
                     Set.of(input("facet1")),
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input("facet2")), ImmutableMap.of("facet2", withValue("v2")), vajramID),
+                        Set.of(input("facet2")),
+                        ImmutableMap.of("facet2", withValue("v2")),
+                        vajramID),
                     Set.of(input("facet2")),
                     vajramID),
                 new CompletableFuture<>()));
@@ -164,14 +169,18 @@ class DefaultKryonExecutionReportTest {
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input("facet1")), ImmutableMap.of("facet1", withValue("v1")), vajramID),
+                        Set.of(input("facet1")),
+                        ImmutableMap.of("facet1", withValue("v1")),
+                        vajramID),
                     Set.of(input("facet1")),
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input("facet2")), ImmutableMap.of("facet2", withValue("v2")), vajramID),
+                        Set.of(input("facet2")),
+                        ImmutableMap.of("facet2", withValue("v2")),
+                        vajramID),
                     Set.of(input("facet2")),
                     vajramID),
                 new CompletableFuture<>()));

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/logicdecorators/observability/DefaultKryonExecutionReportTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/logicdecorators/observability/DefaultKryonExecutionReportTest.java
@@ -45,20 +45,20 @@ class DefaultKryonExecutionReportTest {
   void reportStartAndEnd_success() {
     VajramID vajramID = new VajramID("kryon_1");
     KryonLogicId kryonLogicId = new KryonLogicId(vajramID, "kryon_1__logic_1");
-    Set<SimpleFacet> allInputs = Set.of(input());
+    Set<SimpleFacet> allInputs = Set.of(input("facet1"));
     ImmutableList<ExecutionItem> facetValuesList =
         ImmutableList.of(
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        allInputs, ImmutableMap.of(1, withValue("v1")), vajramID),
+                        allInputs, ImmutableMap.of("facet1", withValue("v1")), vajramID),
                     allInputs,
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        allInputs, ImmutableMap.of(1, withValue("v2")), vajramID),
+                        allInputs, ImmutableMap.of("facet1", withValue("v2")), vajramID),
                     allInputs,
                     vajramID),
                 new CompletableFuture<>()));
@@ -101,7 +101,10 @@ class DefaultKryonExecutionReportTest {
     assertThat(derefedMap)
         .isEqualTo(
             ImmutableMap.of(
-                ImmutableMap.of(input(), "v1"), "r1", ImmutableMap.of(input(), "v2"), "r1"));
+                ImmutableMap.of(input("facet1"), "v1"),
+                "r1",
+                ImmutableMap.of(input("facet1"), "v2"),
+                "r1"));
 
     ImmutableList<ImmutableMap<Facet, String>> inputsList = logicExecInfo.inputsList();
 
@@ -126,15 +129,15 @@ class DefaultKryonExecutionReportTest {
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input()), ImmutableMap.of(1, withValue("v1")), vajramID),
-                    Set.of(input()),
+                        Set.of(input("facet1")), ImmutableMap.of("facet1", withValue("v1")), vajramID),
+                    Set.of(input("facet1")),
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input()), ImmutableMap.of(2, withValue("v2")), vajramID),
-                    Set.of(input()),
+                        Set.of(input("facet2")), ImmutableMap.of("facet2", withValue("v2")), vajramID),
+                    Set.of(input("facet2")),
                     vajramID),
                 new CompletableFuture<>()));
 
@@ -161,15 +164,15 @@ class DefaultKryonExecutionReportTest {
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input()), ImmutableMap.of(1, withValue("v1")), vajramID),
-                    Set.of(input()),
+                        Set.of(input("facet1")), ImmutableMap.of("facet1", withValue("v1")), vajramID),
+                    Set.of(input("facet1")),
                     vajramID),
                 new CompletableFuture<>()),
             new ExecutionItem(
                 new FacetValuesMapBuilder(
                     new SimpleRequestBuilder<>(
-                        Set.of(input()), ImmutableMap.of(2, withValue("v2")), vajramID),
-                    Set.of(input()),
+                        Set.of(input("facet2")), ImmutableMap.of("facet2", withValue("v2")), vajramID),
+                    Set.of(input("facet2")),
                     vajramID),
                 new CompletableFuture<>()));
 
@@ -214,13 +217,13 @@ class DefaultKryonExecutionReportTest {
         ImmutableList.of(
             new ImmutableFacetValuesMap(
                 new SimpleRequestBuilder<>(
-                    Set.of(input()), ImmutableMap.of(1, withValue("v1")), vajramID),
-                Set.of(input()),
+                    Set.of(input("facet1")), ImmutableMap.of("facet1", withValue("v1")), vajramID),
+                Set.of(input("facet1")),
                 vajramID),
             new ImmutableFacetValuesMap(
                 new SimpleRequestBuilder<>(
-                    Set.of(input()), ImmutableMap.of(2, withValue("v2")), vajramID),
-                Set.of(input()),
+                    Set.of(input("facet2")), ImmutableMap.of("facet1", withValue("v2")), vajramID),
+                Set.of(input("facet2")),
                 vajramID));
 
     clock.setInstant(END_TIME);

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/FacetValuesMap.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/FacetValuesMap.java
@@ -9,10 +9,10 @@ import com.google.common.collect.ImmutableMap;
 public sealed interface FacetValuesMap extends FacetValues
     permits FacetValuesMapBuilder, ImmutableFacetValuesMap {
 
-  Errable<?> _getOne2OneResponse(int facetId);
+  Errable<?> _getOne2OneResponse(String facetId);
 
   @SuppressWarnings("unchecked")
-  FanoutDepResponses<?, ?> _getDepResponses(int facetId);
+  FanoutDepResponses<?, ?> _getDepResponses(String facetId);
 
-  ImmutableMap<Integer, FacetValue> _asMap();
+  ImmutableMap<String, FacetValue> _asMap();
 }

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/FacetValuesMapBuilder.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/FacetValuesMapBuilder.java
@@ -21,7 +21,7 @@ public final class FacetValuesMapBuilder implements FacetValuesMap, FacetValuesB
 
   private final SimpleRequestBuilder<Object> _request;
   private final ImmutableSet<? extends Facet> _facets;
-  private final Map<Integer, FacetValue> otherFacetValues;
+  private final Map<String, FacetValue> otherFacetValues;
   private final VajramID _vajramID;
 
   public FacetValuesMapBuilder(
@@ -32,7 +32,7 @@ public final class FacetValuesMapBuilder implements FacetValuesMap, FacetValuesB
   FacetValuesMapBuilder(
       SimpleRequestBuilder<Object> _request,
       Set<? extends Facet> _facets,
-      Map<Integer, ? extends FacetValue> otherFacetValues,
+      Map<String, ? extends FacetValue> otherFacetValues,
       VajramID vajramID) {
     this._request = _request._asBuilder();
     this._facets = ImmutableSet.copyOf(_facets);
@@ -40,20 +40,20 @@ public final class FacetValuesMapBuilder implements FacetValuesMap, FacetValuesB
     this._vajramID = vajramID;
   }
 
-  public FacetValue _get(int facetId) {
+  public FacetValue _get(String facetId) {
     if (_request._hasValue(facetId)) {
       ErrableFacetValue<Object> v = _request._get(facetId);
       if (v != null) {
         return v;
       } else {
-        throw new AssertionError("This should not be possible sinve _hasValue is true");
+        throw new AssertionError("This should not be possible since _hasValue is true");
       }
     }
     return otherFacetValues.getOrDefault(facetId, ErrableFacetValue.nil());
   }
 
   @Override
-  public Errable<?> _getOne2OneResponse(int facetId) {
+  public Errable<?> _getOne2OneResponse(String facetId) {
     if (_request._hasValue(facetId)) {
       return _request._get(facetId).asErrable();
     } else {
@@ -70,7 +70,7 @@ public final class FacetValuesMapBuilder implements FacetValuesMap, FacetValuesB
 
   @Override
   @SuppressWarnings("unchecked")
-  public FanoutDepResponses _getDepResponses(int facetId) {
+  public FanoutDepResponses _getDepResponses(String facetId) {
     FacetValue datum = otherFacetValues.getOrDefault(facetId, ErrableFacetValue.nil());
     if (datum instanceof FanoutDepResponses fanoutDepResponses) {
       return fanoutDepResponses;
@@ -80,14 +80,14 @@ public final class FacetValuesMapBuilder implements FacetValuesMap, FacetValuesB
   }
 
   @Override
-  public ImmutableMap<Integer, FacetValue> _asMap() {
-    return ImmutableMap.<Integer, FacetValue>builder()
+  public ImmutableMap<String, FacetValue> _asMap() {
+    return ImmutableMap.<String, FacetValue>builder()
         .putAll(_request._asMap())
         .putAll(otherFacetValues)
         .build();
   }
 
-  public boolean _hasValue(int facetId) {
+  public boolean _hasValue(String facetId) {
     return _request._hasValue(facetId) || otherFacetValues.containsKey(facetId);
   }
 
@@ -103,7 +103,7 @@ public final class FacetValuesMapBuilder implements FacetValuesMap, FacetValuesB
         _request, _facets, new LinkedHashMap<>(otherFacetValues), _vajramID);
   }
 
-  public FacetValuesMapBuilder _set(int facetId, FacetValue value) {
+  public FacetValuesMapBuilder _set(String facetId, FacetValue value) {
     if (this._hasValue(facetId)) {
       throw new IllegalModificationException();
     }

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/ImmutableFacetValuesMap.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/ImmutableFacetValuesMap.java
@@ -20,7 +20,7 @@ public final class ImmutableFacetValuesMap implements FacetValuesMap, ImmutableF
   private final VajramID _vajramID;
 
   private final SimpleImmutRequest<Object> _request;
-  private final ImmutableMap<Integer, FacetValue> otherFacetValues;
+  private final ImmutableMap<String, FacetValue> otherFacetValues;
 
   public ImmutableFacetValuesMap(
       SimpleRequestBuilder<Object> _request, Set<? extends Facet> _facets, VajramID vajramID) {
@@ -30,7 +30,7 @@ public final class ImmutableFacetValuesMap implements FacetValuesMap, ImmutableF
   public ImmutableFacetValuesMap(
       SimpleRequestBuilder<Object> _request,
       Set<? extends Facet> _facets,
-      ImmutableMap<Integer, FacetValue> otherFacetValues,
+      ImmutableMap<String, FacetValue> otherFacetValues,
       VajramID vajramID) {
     this._request = _request._build();
     this._facets = ImmutableSet.copyOf(_facets);
@@ -38,7 +38,7 @@ public final class ImmutableFacetValuesMap implements FacetValuesMap, ImmutableF
     this._vajramID = vajramID;
   }
 
-  public FacetValue _get(int facetId) {
+  public FacetValue _get(String facetId) {
     if (_request._hasValue(facetId)) {
       ErrableFacetValue<Object> v = _request._get(facetId);
       if (v != null) {
@@ -51,7 +51,7 @@ public final class ImmutableFacetValuesMap implements FacetValuesMap, ImmutableF
   }
 
   @Override
-  public Errable<?> _getOne2OneResponse(int facetId) {
+  public Errable<?> _getOne2OneResponse(String facetId) {
     if (_request._hasValue(facetId)) {
       return _request._get(facetId).asErrable();
     } else {
@@ -68,7 +68,7 @@ public final class ImmutableFacetValuesMap implements FacetValuesMap, ImmutableF
 
   @SuppressWarnings("unchecked")
   @Override
-  public FanoutDepResponses _getDepResponses(int facetId) {
+  public FanoutDepResponses _getDepResponses(String facetId) {
     FacetValue datum = otherFacetValues.getOrDefault(facetId, ErrableFacetValue.nil());
     if (datum instanceof FanoutDepResponses errable) {
       return errable;
@@ -79,14 +79,14 @@ public final class ImmutableFacetValuesMap implements FacetValuesMap, ImmutableF
   }
 
   @Override
-  public ImmutableMap<Integer, FacetValue> _asMap() {
-    return ImmutableMap.<Integer, FacetValue>builder()
+  public ImmutableMap<String, FacetValue> _asMap() {
+    return ImmutableMap.<String, FacetValue>builder()
         .putAll(_request._asMap())
         .putAll(otherFacetValues)
         .build();
   }
 
-  public boolean _hasValue(int facetId) {
+  public boolean _hasValue(String facetId) {
     return _request._hasValue(facetId) || otherFacetValues.containsKey(facetId);
   }
 

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleDep.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleDep.java
@@ -13,8 +13,8 @@ public final class SimpleDep extends SimpleFacet implements Dependency {
   private final VajramID ofVajramID;
   private final VajramID onVajramID;
 
-  SimpleDep(int id, String name, VajramID ofVajramID, VajramID onVajramID) {
-    super(id, name, DEPENDENCY);
+  SimpleDep(String name, VajramID ofVajramID, VajramID onVajramID) {
+    super(name, DEPENDENCY);
     this.ofVajramID = ofVajramID;
     this.onVajramID = onVajramID;
   }
@@ -30,7 +30,7 @@ public final class SimpleDep extends SimpleFacet implements Dependency {
   }
 
   public void setToFacets(FacetValues facetValues, DepResponse value) {
-    ((FacetValuesMapBuilder) facetValues._asBuilder())._set(id(), value);
+    ((FacetValuesMapBuilder) facetValues._asBuilder())._set(name(), value);
   }
 
   @Override
@@ -42,11 +42,11 @@ public final class SimpleDep extends SimpleFacet implements Dependency {
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     SimpleDep that = (SimpleDep) o;
-    return id() == that.id() && facetType() == that.facetType();
+    return name().equals(that.name()) && facetType() == that.facetType();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id(), facetType());
+    return Objects.hash(name(), facetType());
   }
 }

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleFacet.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleFacet.java
@@ -21,23 +21,21 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public sealed class SimpleFacet implements Facet, InputMirror permits SimpleDep {
 
-  public static SimpleFacet input(int facetId) {
-    return new SimpleFacet(facetId, "input" + count++, INPUT);
+  public static SimpleFacet input() {
+    return new SimpleFacet("input" + count++, INPUT);
   }
 
-  public static SimpleDep dependency(int facetId, VajramID ofVajramID, VajramID onVajramID) {
-    return new SimpleDep(facetId, "dep" + count++, ofVajramID, onVajramID);
+  public static SimpleDep dependency(String name, VajramID ofVajramID, VajramID onVajramID) {
+    return new SimpleDep(name, ofVajramID, onVajramID);
   }
 
   private static int count;
 
-  private final int id;
   private final String name;
 
   private final FacetType facetType;
 
-  public SimpleFacet(int id, String name, FacetType facetType) {
-    this.id = id;
+  public SimpleFacet(String name, FacetType facetType) {
     this.name = name;
     this.facetType = facetType;
   }
@@ -47,23 +45,18 @@ public sealed class SimpleFacet implements Facet, InputMirror permits SimpleDep 
   }
 
   @Override
-  public int id() {
-    return id;
-  }
-
-  @Override
   public String name() {
     return name;
   }
 
   @Override
   public @Nullable FacetValue getFacetValue(FacetValues facetValues) {
-    return ((FacetValuesMap) facetValues)._asMap().get(id());
+    return ((FacetValuesMap) facetValues)._asMap().get(name());
   }
 
   @Override
   public void setFacetValue(FacetValuesBuilder facets, FacetValue value) {
-    ((FacetValuesMapBuilder) facets)._set(id(), value);
+    ((FacetValuesMapBuilder) facets)._set(name(), value);
   }
 
   @Override
@@ -73,7 +66,7 @@ public sealed class SimpleFacet implements Facet, InputMirror permits SimpleDep 
 
   @Override
   public @Nullable Object getFromRequest(Request request) {
-    return ((SimpleRequest) request)._asMap().get(id());
+    return ((SimpleRequest) request)._asMap().get(name());
   }
 
   @SuppressWarnings("unchecked")
@@ -81,7 +74,7 @@ public sealed class SimpleFacet implements Facet, InputMirror permits SimpleDep 
   public void setToRequest(Builder request, @Nullable Object value) {
     ((SimpleRequestBuilder<Object>) request)
         ._asMap()
-        .put(id(), new ErrableFacetValue<>(Errable.withValue(value)));
+        .put(name(), new ErrableFacetValue<>(Errable.withValue(value)));
   }
 
   @Override
@@ -98,11 +91,11 @@ public sealed class SimpleFacet implements Facet, InputMirror permits SimpleDep 
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     SimpleFacet that = (SimpleFacet) o;
-    return id == that.id && facetType == that.facetType;
+    return name().equals(that.name()) && facetType == that.facetType;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, facetType);
+    return Objects.hash(name, facetType);
   }
 }

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleFacet.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleFacet.java
@@ -21,15 +21,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public sealed class SimpleFacet implements Facet, InputMirror permits SimpleDep {
 
-  public static SimpleFacet input() {
-    return new SimpleFacet("input" + count++, INPUT);
+  public static SimpleFacet input(String name) {
+    return new SimpleFacet(name, INPUT);
   }
 
   public static SimpleDep dependency(String name, VajramID ofVajramID, VajramID onVajramID) {
     return new SimpleDep(name, ofVajramID, onVajramID);
   }
-
-  private static int count;
 
   private final String name;
 

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleImmutRequest.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleImmutRequest.java
@@ -14,19 +14,19 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class SimpleImmutRequest<T> implements SimpleRequest<T>, ImmutableRequest<T> {
-  private final Map<Integer, ErrableFacetValue<Object>> _data;
+  private final Map<String, ErrableFacetValue<Object>> _data;
   private final VajramID _vajramID;
 
   public static <T> SimpleImmutRequest<T> empty(VajramID vajramID) {
     return new SimpleImmutRequest<>(ImmutableMap.of(), vajramID);
   }
 
-  SimpleImmutRequest(Map<Integer, ErrableFacetValue<Object>> data, VajramID vajramID) {
+  SimpleImmutRequest(Map<String, ErrableFacetValue<Object>> data, VajramID vajramID) {
     this._data = ImmutableMap.copyOf(data);
     this._vajramID = vajramID;
   }
 
-  public ErrableFacetValue<Object> _get(int facetId) {
+  public ErrableFacetValue<Object> _get(String facetId) {
     return _data.getOrDefault(facetId, ErrableFacetValue.nil());
   }
 
@@ -41,7 +41,7 @@ public final class SimpleImmutRequest<T> implements SimpleRequest<T>, ImmutableR
   }
 
   @Override
-  public Map<Integer, ErrableFacetValue<Object>> _asMap() {
+  public Map<String, ErrableFacetValue<Object>> _asMap() {
     return _data;
   }
 
@@ -50,7 +50,7 @@ public final class SimpleImmutRequest<T> implements SimpleRequest<T>, ImmutableR
     return ImmutableSet.of();
   }
 
-  public boolean _hasValue(int facetId) {
+  public boolean _hasValue(String facetId) {
     return _data.containsKey(facetId);
   }
 
@@ -77,7 +77,7 @@ public final class SimpleImmutRequest<T> implements SimpleRequest<T>, ImmutableR
     return Objects.hash(_data, _vajramID);
   }
 
-  public Map<Integer, ErrableFacetValue<Object>> _data() {
+  public Map<String, ErrableFacetValue<Object>> _data() {
     return _data;
   }
 

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleRequest.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleRequest.java
@@ -5,7 +5,7 @@ import com.flipkart.krystal.data.Request;
 import java.util.Map;
 
 public interface SimpleRequest<T> extends Request<T> {
-  Map<Integer, ErrableFacetValue<Object>> _asMap();
+  Map<String, ErrableFacetValue<Object>> _asMap();
 
   @Override
   SimpleRequestBuilder<T> _asBuilder();

--- a/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleRequestBuilder.java
+++ b/krystex/src/testFixtures/java/com/flipkart/krystal/krystex/testfixtures/SimpleRequestBuilder.java
@@ -19,7 +19,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class SimpleRequestBuilder<T> implements ImmutableRequest.Builder<T> {
 
   private final ImmutableSet<? extends InputMirror> _facets;
-  private final Map<Integer, ErrableFacetValue<Object>> _data;
+  private final Map<String, ErrableFacetValue<Object>> _data;
   private final VajramID _vajramID;
 
   public SimpleRequestBuilder(Set<? extends InputMirror> _facets, VajramID vajramID) {
@@ -27,7 +27,7 @@ public final class SimpleRequestBuilder<T> implements ImmutableRequest.Builder<T
   }
 
   public SimpleRequestBuilder(
-      Set<? extends InputMirror> _facets, Map<Integer, Errable<Object>> data, VajramID vajramID) {
+      Set<? extends InputMirror> _facets, Map<String, Errable<Object>> data, VajramID vajramID) {
     this._facets = ImmutableSet.copyOf(_facets);
     this._data =
         data.entrySet().stream()
@@ -35,11 +35,11 @@ public final class SimpleRequestBuilder<T> implements ImmutableRequest.Builder<T
     this._vajramID = vajramID;
   }
 
-  public ErrableFacetValue<Object> _get(int facetId) {
+  public ErrableFacetValue<Object> _get(String facetId) {
     return _data.getOrDefault(facetId, ErrableFacetValue.nil());
   }
 
-  public Map<Integer, ErrableFacetValue<Object>> _asMap() {
+  public Map<String, ErrableFacetValue<Object>> _asMap() {
     return _data;
   }
 
@@ -48,7 +48,7 @@ public final class SimpleRequestBuilder<T> implements ImmutableRequest.Builder<T
     return _facets;
   }
 
-  public boolean _hasValue(int facetId) {
+  public boolean _hasValue(String facetId) {
     return _data.containsKey(facetId);
   }
 
@@ -58,7 +58,7 @@ public final class SimpleRequestBuilder<T> implements ImmutableRequest.Builder<T
   }
 
   @SuppressWarnings("unchecked")
-  public SimpleRequestBuilder<T> _set(int facetId, FacetValue value) {
+  public SimpleRequestBuilder<T> _set(String facetId, FacetValue value) {
     if (!(value instanceof ErrableFacetValue<?> errableFacetValue)) {
       throw new IllegalArgumentException(
           "Expected Errable but found %s".formatted(value.getClass()));

--- a/lattice/extensions/a2a/lattice-a2a-codegen/src/main/java/com/flipkart/krystal/lattice/ext/a2a/codegen/QuarkusA2ACodegenProvider.java
+++ b/lattice/extensions/a2a/lattice-a2a-codegen/src/main/java/com/flipkart/krystal/lattice/ext/a2a/codegen/QuarkusA2ACodegenProvider.java
@@ -277,9 +277,7 @@ public class QuarkusA2ACodegenProvider implements LatticeCodeGeneratorProvider {
     }
 
     VajramInfo vajramInfo = ctx.codeGenUtility().computeVajramInfo(cancellerVajram);
-    ClassName requestClass =
-        ClassName.get(
-            vajramInfo.packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX);
+    ClassName requestClass = vajramInfo.lite().reqImmutPojoClassName();
 
     CodeBlock requestBuilder = buildRequestFromContext(vajramInfo, requestClass, true);
 

--- a/lattice/extensions/a2a/lattice-a2a-codegen/src/main/java/com/flipkart/krystal/lattice/ext/a2a/codegen/QuarkusA2ACodegenProvider.java
+++ b/lattice/extensions/a2a/lattice-a2a-codegen/src/main/java/com/flipkart/krystal/lattice/ext/a2a/codegen/QuarkusA2ACodegenProvider.java
@@ -233,7 +233,7 @@ public class QuarkusA2ACodegenProvider implements LatticeCodeGeneratorProvider {
     VajramInfo vajramInfo = ctx.codeGenUtility().computeVajramInfo(executorType);
     ClassName requestClass =
         ClassName.get(
-            vajramInfo.lite().packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX);
+            vajramInfo.packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX);
 
     CodeBlock requestBuilder = buildRequestFromContext(vajramInfo, requestClass, false);
 
@@ -279,7 +279,7 @@ public class QuarkusA2ACodegenProvider implements LatticeCodeGeneratorProvider {
     VajramInfo vajramInfo = ctx.codeGenUtility().computeVajramInfo(cancellerVajram);
     ClassName requestClass =
         ClassName.get(
-            vajramInfo.lite().packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX);
+            vajramInfo.packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX);
 
     CodeBlock requestBuilder = buildRequestFromContext(vajramInfo, requestClass, true);
 

--- a/lattice/extensions/grpc/lattice-grpc-codegen/src/main/java/com/flipkart/krystal/lattice/ext/grpc/codegen/ProtoServiceSchemaGen.java
+++ b/lattice/extensions/grpc/lattice-grpc-codegen/src/main/java/com/flipkart/krystal/lattice/ext/grpc/codegen/ProtoServiceSchemaGen.java
@@ -254,7 +254,7 @@ class ProtoServiceSchemaGen implements CodeGenerator {
                       getSimpleClassName(vajramInfo.responseType().canonicalClassName());
                   // Add imports for the request and response messages
                   imports.add(
-                      vajramInfo.packageName().replace('.', '/')
+                      vajramInfo.inputsInfo().requestPackageName().replace('.', '/')
                           + "/"
                           + vajramInfo.vajramId().id()
                           + reqProtoFileSuffix);

--- a/lattice/extensions/mcp/quarkus/lattice-mcp-quarkus-codegen/src/main/java/com/flipkart/krystal/lattice/ext/mcp/quarkus/codegen/QuarkusMcpCodegenProvider.java
+++ b/lattice/extensions/mcp/quarkus/lattice-mcp-quarkus-codegen/src/main/java/com/flipkart/krystal/lattice/ext/mcp/quarkus/codegen/QuarkusMcpCodegenProvider.java
@@ -117,7 +117,7 @@ public class QuarkusMcpCodegenProvider implements LatticeCodeGeneratorProvider {
               .add(
                   "$T._builder()",
                   ClassName.get(
-                      vajramInfo.lite().packageName(),
+                      vajramInfo.packageName(),
                       vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX));
 
       for (FacetGenModel facet : vajramInfo.facetStream().toList()) {
@@ -230,7 +230,7 @@ return $T.createFrom()
 """,
           Uni.class,
           ClassName.get(
-              vajramInfo.lite().packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX),
+              vajramInfo.packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX),
           vajramInfo
               .facetStream()
               .filter(fd -> fd.facetType() == FacetType.INPUT)
@@ -288,8 +288,7 @@ return $T.createFrom()
 """,
           Uni.class,
           ClassName.get(
-              vajramInfo.lite().packageName(),
-              vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX));
+              vajramInfo.packageName(), vajramInfo.vajramName() + IMMUT_REQUEST_POJO_SUFFIX));
       mcpResourcesClassBuilder.addMethod(methodBuilder.build());
     }
 

--- a/lattice/extensions/rest/lattice-rest-codegen/src/main/java/com/flipkart/krystal/lattice/ext/rest/codegen/JakartaRestServiceCodegenProvider.java
+++ b/lattice/extensions/rest/lattice-rest-codegen/src/main/java/com/flipkart/krystal/lattice/ext/rest/codegen/JakartaRestServiceCodegenProvider.java
@@ -115,7 +115,8 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
 
     private void jakartaResources(TypeElement latticeAppElem) {
       RestService restService = latticeAppElem.getAnnotation(RestService.class);
-      String pathPrefix = restService.pathPrefix().isEmpty() ? "" : "/" + restService.pathPrefix();
+      String pathPrefix = restService.pathPrefix();
+      pathPrefix = (pathPrefix.isEmpty() ? "" : "/") + pathPrefix;
       for (TypeElement vajramElem : getRestResourceVajramElems(latticeAppElem, util)) {
         VajramInfo vajramInfo = context.codeGenUtility().computeVajramInfo(vajramElem);
         var resourceMethods = resourceMethods(vajramElem, vajramInfo);
@@ -129,6 +130,12 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
         } else {
           pathValue = path.value();
         }
+        if (pathValue.startsWith("/")) {
+          pathValue = pathValue.substring(1);
+        }
+        if (pathValue.startsWith("/")) {
+          pathValue = pathValue.substring(0, pathValue.length() - 1);
+        }
         ClassName jaxRsResourceName = getJaxRsResourceName(vajramInfo, vajramElem);
         TypeSpec.Builder resourceClassBuilder =
             util.classBuilder(
@@ -138,7 +145,7 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
             .addField(RestServiceDopant.class, "_restServiceDopant", PRIVATE, FINAL)
             .addAnnotation(
                 AnnotationSpec.builder(jakarta.ws.rs.Path.class)
-                    .addMember("value", "$S", pathPrefix + pathValue)
+                    .addMember("value", "$S", pathPrefix + "/" + pathValue)
                     .build())
             .addMethod(
                 MethodSpec.constructorBuilder()
@@ -349,31 +356,30 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
           // body into the vajram request object
           !explicitPath) {
 
-        Element protocolSource;
+        TypeElement inputsSource = vajramInfo.inputsSource();
+        Element supportedProtocolSource = inputsSource != null ? inputsSource : vajramElem;
         Map<Element, SerdeConfig> serdeConfigsMap = new HashMap<>();
+        TypeMirror defaultProtocolSource;
         if (bodyFacet != null) {
           Map<@NonNull Element, SerdeConfig> collect =
               Arrays.stream(bodyFacet.facetElement().getAnnotationsByType(SerdeConfig.class))
                   .collect(toMap(s -> util.getTypeElemFromAnnotationMember(s::protocol), s -> s));
           serdeConfigsMap.putAll(collect);
-          protocolSource =
-              requireNonNull(
-                  util.processingEnv()
-                      .getTypeUtils()
-                      .asElement(bodyFacet.dataType().typeMirror(util.processingEnv())));
-          for (SerdeConfig serdeConfig : protocolSource.getAnnotationsByType(SerdeConfig.class)) {
-            serdeConfigsMap.putIfAbsent(
-                util.getTypeElemFromAnnotationMember(serdeConfig::protocol), serdeConfig);
+          TypeMirror bodyFacetType = bodyFacet.dataType().typeMirror(util.processingEnv());
+          defaultProtocolSource = bodyFacetType;
+          supportedProtocolSource = util.processingEnv().getTypeUtils().asElement(bodyFacetType);
+          if (supportedProtocolSource == null) {
+            throw util.errorAndThrow(
+                "Could not retrieve type element for body facet type", bodyFacet.facetElement());
           }
         } else {
-          protocolSource =
-              vajramInfo.inputsElement() != null ? vajramInfo.inputsElement() : vajramElem;
-          Map<@NonNull Element, SerdeConfig> collect =
-              Arrays.stream(protocolSource.getAnnotationsByType(SerdeConfig.class))
-                  .collect(toMap(s -> util.getTypeElemFromAnnotationMember(s::protocol), s -> s));
-          serdeConfigsMap.putAll(collect);
+          serdeConfigsMap.putAll(
+              Arrays.stream(supportedProtocolSource.getAnnotationsByType(SerdeConfig.class))
+                  .collect(toMap(s -> util.getTypeElemFromAnnotationMember(s::protocol), s -> s)));
+          defaultProtocolSource = supportedProtocolSource.asType();
         }
-        List<TypeElement> allProtocolElems = util.getSupportedProtocolTypeElements(protocolSource);
+        List<TypeElement> allProtocolElems =
+            util.getSupportedProtocolTypeElements(supportedProtocolSource);
         ImmutableList<TypeElement> requestSerdeProtocols = ImmutableList.of();
         if (allProtocolElems.isEmpty()) {
           util.error(
@@ -402,7 +408,8 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
                 bodyFacet.facetElement());
           }
         }
-        TypeElement defaultProtocolTypeElement = util.getDefaultProtocolTypeElement(protocolSource);
+        TypeElement defaultProtocolTypeElement =
+            util.getDefaultProtocolTypeElement(defaultProtocolSource);
         for (TypeElement serdeProtocolType : requestSerdeProtocols) {
           boolean isDefaultProtocol =
               defaultProtocolTypeElement != null

--- a/lattice/extensions/rest/lattice-rest-codegen/src/main/java/com/flipkart/krystal/lattice/ext/rest/codegen/JakartaRestServiceCodegenProvider.java
+++ b/lattice/extensions/rest/lattice-rest-codegen/src/main/java/com/flipkart/krystal/lattice/ext/rest/codegen/JakartaRestServiceCodegenProvider.java
@@ -133,7 +133,7 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
         if (pathValue.startsWith("/")) {
           pathValue = pathValue.substring(1);
         }
-        if (pathValue.startsWith("/")) {
+        if (pathValue.endsWith("/")) {
           pathValue = pathValue.substring(0, pathValue.length() - 1);
         }
         ClassName jaxRsResourceName = getJaxRsResourceName(vajramInfo, vajramElem);

--- a/lattice/extensions/rest/lattice-rest-codegen/src/main/java/com/flipkart/krystal/lattice/ext/rest/codegen/JakartaRestServiceCodegenProvider.java
+++ b/lattice/extensions/rest/lattice-rest-codegen/src/main/java/com/flipkart/krystal/lattice/ext/rest/codegen/JakartaRestServiceCodegenProvider.java
@@ -552,7 +552,6 @@ public class JakartaRestServiceCodegenProvider implements LatticeCodeGeneratorPr
 
   public static ClassName getJaxRsResourceName(VajramInfo vajramInfo, TypeElement vajramElem) {
     return ClassName.get(
-        vajramInfo.lite().packageName(),
-        vajramElem.getSimpleName().toString() + "_JakartaRestResource");
+        vajramInfo.packageName(), vajramElem.getSimpleName().toString() + "_JakartaRestResource");
   }
 }

--- a/lattice/extensions/rest/lattice-rest/src/main/java/com/flipkart/krystal/lattice/ext/rest/RestServiceDopant.java
+++ b/lattice/extensions/rest/lattice-rest/src/main/java/com/flipkart/krystal/lattice/ext/rest/RestServiceDopant.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Flow.Publisher;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 @Slf4j
 @DopantType(RestServiceDopant.REST_SERVICE_DOPANT_TYPE)
@@ -116,8 +117,11 @@ public abstract class RestServiceDopant implements Dopant<RestService, RestServi
 
   @Produces(inScope = RequestScoped.class)
   @Named(StandardHeaderNames.ACCEPT)
-  public Header getAcceptHeader(HttpHeaders httpHeaders) {
+  public @Nullable Header getAcceptHeader(HttpHeaders httpHeaders) {
     List<String> requestHeaderValues = httpHeaders.getRequestHeader(StandardHeaderNames.ACCEPT);
+    if (requestHeaderValues == null) {
+      return null;
+    }
     List<String> splitHeaderValues = new ArrayList<>();
     for (String requestHeaderValue : requestHeaderValues) {
       Splitter.on(',').trimResults().split(requestHeaderValue).forEach(splitHeaderValues::add);

--- a/lattice/extensions/rest/lattice-rest/src/main/java/com/flipkart/krystal/lattice/ext/rest/RestServiceDopant.java
+++ b/lattice/extensions/rest/lattice-rest/src/main/java/com/flipkart/krystal/lattice/ext/rest/RestServiceDopant.java
@@ -24,6 +24,7 @@ import com.flipkart.krystal.lattice.vajram.VajramRequestExecutionContext.VajramR
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
 import com.flipkart.krystal.serial.SerializableModel;
 import com.flipkart.krystal.tags.Names;
+import com.google.common.base.Splitter;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -32,6 +33,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletionStage;
@@ -115,8 +117,12 @@ public abstract class RestServiceDopant implements Dopant<RestService, RestServi
   @Produces(inScope = RequestScoped.class)
   @Named(StandardHeaderNames.ACCEPT)
   public Header getAcceptHeader(HttpHeaders httpHeaders) {
-    return Header.of(
-        StandardHeaderNames.ACCEPT, httpHeaders.getRequestHeader(StandardHeaderNames.ACCEPT));
+    List<String> requestHeaderValues = httpHeaders.getRequestHeader(StandardHeaderNames.ACCEPT);
+    List<String> splitHeaderValues = new ArrayList<>();
+    for (String requestHeaderValue : requestHeaderValues) {
+      Splitter.on(',').trimResults().split(requestHeaderValue).forEach(splitHeaderValues::add);
+    }
+    return Header.of(StandardHeaderNames.ACCEPT, splitHeaderValues);
   }
 
   private static Bindings getRequestScopeSeeds(HttpHeaders headers, UriInfo uriInfo) {

--- a/lattice/lattice-codegen/src/main/java/com/flipkart/krystal/lattice/codegen/SerdeProtocolBindingsProvider.java
+++ b/lattice/lattice-codegen/src/main/java/com/flipkart/krystal/lattice/codegen/SerdeProtocolBindingsProvider.java
@@ -2,7 +2,6 @@ package com.flipkart.krystal.lattice.codegen;
 
 import static java.util.Objects.requireNonNull;
 
-import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
 import com.flipkart.krystal.codegen.common.spi.ModelProtocolConfigProvider;
 import com.flipkart.krystal.codegen.common.spi.ModelProtocolConfigProvider.ModelProtocolConfig;
 import com.flipkart.krystal.lattice.codegen.spi.LatticeAppCodeGenAttrsProvider;
@@ -59,12 +58,11 @@ public final class SerdeProtocolBindingsProvider implements BindingsProvider {
                         requireNonNull(
                             cp.getConfig().modelProtocol().getClass().getCanonicalName()),
                     ModelProtocolConfigProvider::getConfig));
-    Map<String, TypeElement> responseTypeElems = new LinkedHashMap<>();
+    Map<String, TypeMirror> responseTypeElems = new LinkedHashMap<>();
     Map<String, List<String>> responseToVajramsMapping = new LinkedHashMap<>();
     for (TypeElement vajram : remotelyInvocableVajrams) {
       VajramInfoLite vajramInfoLite = util.computeVajramInfoLiteWithUpperBoundTypeArgs(vajram);
-      CodeGenType responseType = vajramInfoLite.responseType();
-      TypeMirror responseMirror = responseType.typeMirror(util.processingEnv());
+      TypeMirror responseMirror = vajramInfoLite.responseType().typeMirror(util.processingEnv());
       if (!util.codegenUtil().isRawAssignable(responseMirror, Model.class)) {
         continue;
       }
@@ -73,15 +71,19 @@ public final class SerdeProtocolBindingsProvider implements BindingsProvider {
               requireNonNull(
                   util.codegenUtil().processingEnv().getTypeUtils().asElement(responseMirror));
       String responseCanonicalName = responseTypeElem.getQualifiedName().toString();
-      responseTypeElems.put(responseCanonicalName, responseTypeElem);
+      responseTypeElems.put(responseCanonicalName, responseMirror);
       responseToVajramsMapping
           .computeIfAbsent(responseCanonicalName, s -> new ArrayList<>())
           .add(vajramInfoLite.vajramId().id());
     }
     List<Binding> bindings = new ArrayList<>();
-    for (Entry<String, TypeElement> entry : responseTypeElems.entrySet()) {
+    for (Entry<String, TypeMirror> entry : responseTypeElems.entrySet()) {
       String responseCanonicalName = entry.getKey();
-      TypeElement responseElement = entry.getValue();
+      TypeMirror responseType = entry.getValue();
+      TypeElement responseElement =
+          (TypeElement)
+              requireNonNull(
+                  util.codegenUtil().processingEnv().getTypeUtils().asElement(responseType));
       List<TypeElement> supportedModelProtocolElems =
           util.codegenUtil().getSupportedProtocolTypeElements(responseElement).stream()
               .filter(te -> util.codegenUtil().isRawAssignable(te.asType(), SerdeProtocol.class))
@@ -93,13 +95,13 @@ public final class SerdeProtocolBindingsProvider implements BindingsProvider {
       ClassName immutBuilderClassName =
           ClassName.get(immutClassName.packageName(), immutClassName.simpleName(), "Builder");
       TypeElement defaultSerializationProtocol =
-          util.codegenUtil().getDefaultProtocolTypeElement(responseElement);
+          util.codegenUtil().getDefaultProtocolTypeElement(responseType);
       List<CodeBlock> providingLogicBlocks = new ArrayList<>();
       if (defaultSerializationProtocol == null) {
         util.codegenUtil()
             .note(
                 "Could not determine default Serialization protocol for response type "
-                    + responseElement
+                    + responseType
                     + ". Add isDefault=true to one of its @SupportedModelProtocol annotations if needed.",
                 responseElement);
         providingLogicBlocks.add(
@@ -114,7 +116,7 @@ public final class SerdeProtocolBindingsProvider implements BindingsProvider {
           throw util.codegenUtil()
               .errorAndThrow(
                   "Response type "
-                      + responseElement
+                      + responseType
                       + " of vajram(s): "
                       + responseToVajramsMapping.get(responseCanonicalName)
                       + " does not support the default serialization protocol "

--- a/lattice/samples/graphql-rest-json-lattice-sample/build.gradle
+++ b/lattice/samples/graphql-rest-json-lattice-sample/build.gradle
@@ -100,3 +100,7 @@ configurations {
         }
     }
 }
+
+checkerFramework {
+    excludeTests = true
+}

--- a/lattice/samples/rest/fory/quarkus/rest-fory-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/fory/quarkus/sampleForyService/models/ForyRequest.java
+++ b/lattice/samples/rest/fory/quarkus/rest-fory-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/fory/quarkus/sampleForyService/models/ForyRequest.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 @SupportedModelProtocol(Fory.class)
 @SupportedModelProtocol(PlainJavaObject.class)
-@ModelRoot(type = {REQUEST})
+@ModelRoot(type = REQUEST)
 public interface ForyRequest extends Model {
 
   @Nullable Integer optionalInput();

--- a/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/logic/RestGetMappingLatticeSample.java
+++ b/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/logic/RestGetMappingLatticeSample.java
@@ -32,17 +32,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @GET
 @Vajram
 public abstract class RestGetMappingLatticeSample extends ComputeVajramDef<JsonResponse> {
-  interface _Inputs {
-    @IfAbsent(FAIL)
-    @PathParam
-    String fullPath();
-
-    @QueryParam
-    String name();
-
-    @QueryParam
-    String age();
-  }
+  interface _Inputs extends RestGetMappingLatticeSample_Inputs {}
 
   interface _InternalFacets {
     @Inject

--- a/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/logic/RestGetMappingLatticeSample.java
+++ b/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/logic/RestGetMappingLatticeSample.java
@@ -7,8 +7,6 @@ import com.flipkart.krystal.annos.InvocableOutsideGraph;
 import com.flipkart.krystal.annos.InvocableOutsideProcess;
 import com.flipkart.krystal.lattice.core.di.ByContentType;
 import com.flipkart.krystal.lattice.ext.rest.api.Path;
-import com.flipkart.krystal.lattice.ext.rest.api.PathParam;
-import com.flipkart.krystal.lattice.ext.rest.api.QueryParam;
 import com.flipkart.krystal.lattice.ext.rest.api.methods.GET;
 import com.flipkart.krystal.lattice.samples.rest.json.quarkus.sampleRestService.models.JsonResponse;
 import com.flipkart.krystal.lattice.samples.rest.json.quarkus.sampleRestService.models.JsonResponse_Immut;

--- a/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/logic/RestGetMappingLatticeSample_Inputs.java
+++ b/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/logic/RestGetMappingLatticeSample_Inputs.java
@@ -1,0 +1,26 @@
+package com.flipkart.krystal.lattice.samples.rest.json.quarkus.sampleRestService.logic;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+
+import com.flipkart.krystal.facets.InputsForVajram;
+import com.flipkart.krystal.facets.VajramInputs;
+import com.flipkart.krystal.lattice.ext.rest.api.PathParam;
+import com.flipkart.krystal.lattice.ext.rest.api.QueryParam;
+import com.flipkart.krystal.lattice.samples.rest.json.quarkus.sampleRestService.models.JsonResponse;
+import com.flipkart.krystal.model.IfAbsent;
+
+@InputsForVajram(
+    parentPackage =
+        "com.flipkart.krystal.lattice.samples.rest.json.quarkus.sampleRestService.logic",
+    vajramId = "RestGetMappingLatticeSample")
+public interface RestGetMappingLatticeSample_Inputs extends VajramInputs<JsonResponse> {
+  @IfAbsent(FAIL)
+  @PathParam
+  String fullPath();
+
+  @QueryParam
+  String name();
+
+  @QueryParam
+  String age();
+}

--- a/vajram/extensions/guice/vajram-guice/src/main/java/com/flipkart/krystal/vajram/guice/traitbinding/GuiceyStaticDispatchPolicy.java
+++ b/vajram/extensions/guice/vajram-guice/src/main/java/com/flipkart/krystal/vajram/guice/traitbinding/GuiceyStaticDispatchPolicy.java
@@ -27,7 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @see TraitBinder
  */
-public class StaticDispatchPolicyImpl extends StaticDispatchPolicy {
+public class GuiceyStaticDispatchPolicy extends StaticDispatchPolicy {
 
   @Getter private final VajramID traitID;
   @Getter private final ImmutableSet<Class<? extends Request<?>>> dispatchTargetReqs;
@@ -39,7 +39,7 @@ public class StaticDispatchPolicyImpl extends StaticDispatchPolicy {
   private final Map<VajramID, Map<QualWrapper, Class<? extends Request<?>>>> bindingsByQualifier =
       new LinkedHashMap<>();
 
-  public StaticDispatchPolicyImpl(
+  public GuiceyStaticDispatchPolicy(
       VajramGraph vajramGraph, VajramID traitID, TraitBinder traitBinder) {
     this.vajramGraph = vajramGraph;
     this.traitID = traitID;

--- a/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
+++ b/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
@@ -510,17 +510,9 @@ this.$L = $L == null
       return false;
     }
 
-    TypeElement modelRootType = codeGenContext.modelRootType();
-    if (!util.getModelProtocols(modelRootType).contains(JSON)) {
-      util.note(
-          "Skipping json codegen for %s as model protocols doesn't contain JSON"
-              .formatted(modelRootType),
-          modelRootType);
-      return false;
-    }
     // Enum models don't need generated JSON wrapper classes -
     // Jackson handles them directly via the EnumModelModule
-    return !util.isEnumModel(modelRootType);
+    return !util.isEnumModel(codeGenContext.modelRootType());
   }
 
   /**

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/BaseProtoModelsGen.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/BaseProtoModelsGen.java
@@ -148,7 +148,7 @@ public abstract class BaseProtoModelsGen implements CodeGenerator {
    */
   private void generateEnumProtoUtils() {
     TypeElement enumElement = codeGenContext.modelRootType();
-    String packageName = processingEnv.getElementUtils().getPackageOf(enumElement).toString();
+    String packageName = util.getCodegenPackageName(enumElement);
     String utilsClassName = enumElement.getSimpleName().toString() + config.utilsSuffix();
 
     ClassName javaEnumType = ClassName.get(enumElement);
@@ -189,7 +189,7 @@ public abstract class BaseProtoModelsGen implements CodeGenerator {
 
   private ClassName getProtoUtilsClassName(TypeElement enumElement) {
     return ClassName.get(
-        processingEnv.getElementUtils().getPackageOf(enumElement).toString(),
+        util.getCodegenPackageName(enumElement),
         enumElement.getSimpleName().toString() + config.utilsSuffix());
   }
 

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/BaseProtoSchemaGen.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/BaseProtoSchemaGen.java
@@ -117,8 +117,7 @@ public abstract class BaseProtoSchemaGen implements CodeGenerator {
   private void generateProtobufSchema() {
     TypeElement modelRootType = codeGenContext.modelRootType();
     String modelRootName = modelRootType.getSimpleName().toString();
-    String packageName =
-        util.processingEnv().getElementUtils().getPackageOf(modelRootType).toString();
+    String packageName = util.getCodegenPackageName(modelRootType);
     String protoFileName = modelRootName + config.fileSuffix();
 
     try {

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/ProtoGenUtility.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/ProtoGenUtility.java
@@ -45,11 +45,8 @@ import com.flipkart.krystal.vajram.protobuf.util.ProtoByteArray;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
 import com.google.protobuf.ByteString;
-import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.TypeName;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -191,7 +188,7 @@ public final class ProtoGenUtility {
     }
 
     Element annotationSource =
-        vajramInfo.inputsElement() != null ? vajramInfo.inputsElement() : vajramClass;
+        vajramInfo.inputsSource() != null ? vajramInfo.inputsSource() : vajramClass;
     List<? extends TypeMirror> serializationProtocols =
         getSerializationProtocols(annotationSource, util);
     if (serializationProtocols.stream()
@@ -304,36 +301,33 @@ public final class ProtoGenUtility {
     } else if (dataType instanceof AnnotatedStandardJavaType annotatedStandardJavaType
         && JAVA_TO_PROTO_SCALAR_TYPES.containsKey(annotatedStandardJavaType.standardJavaType())) {
       return JAVA_TO_PROTO_SCALAR_TYPES.get(annotatedStandardJavaType.standardJavaType());
-    } else if (TypeName.get(dataType.typeMirror(util.processingEnv()))
-            instanceof ClassName modelRootName
+    } else if (util.processingEnv()
+                .getTypeUtils()
+                .asElement(dataType.typeMirror(util.processingEnv()))
+            instanceof TypeElement modelRootName
         && util.isEnumModelType(javaModelType)) {
       return new EnumFieldType(
-          modelRootName.packageName(),
+          util.getCodegenPackageName(modelRootName),
           // Strip underscores from the model name for the protobuf type reference - proto
           // messages and enums must be TitleCase. The file name keeps the original Java simple
           // name since the file path doesn't have to obey TitleCase.
-          toTitleCaseProtoName(modelRootName.simpleName()) + config.messageSuffix(),
-          modelRootName.simpleName(),
+          toTitleCaseProtoName(modelRootName.getSimpleName().toString()) + config.messageSuffix(),
+          modelRootName.getSimpleName().toString(),
           config.fileSuffix());
     } else {
       Element javaElement = util.processingEnv().getTypeUtils().asElement(javaModelType);
       if (javaElement != null
           && util.typeExplicitlySupportsProtocol(javaElement, config.protocolClass())
-          && TypeName.get(dataType.typeMirror(util.processingEnv()))
-              instanceof ClassName modelRootName) {
+          && util.processingEnv()
+                  .getTypeUtils()
+                  .asElement(dataType.typeMirror(util.processingEnv()))
+              instanceof TypeElement modelRootName) {
         String protoTypeName =
-            toTitleCaseProtoName(modelRootName.simpleName()) + config.messageSuffix();
-        if (util.isEnumModelType(javaModelType)) {
-          return new EnumFieldType(
-              modelRootName.packageName(),
-              protoTypeName,
-              modelRootName.simpleName(),
-              config.fileSuffix());
-        }
+            toTitleCaseProtoName(modelRootName.getSimpleName().toString()) + config.messageSuffix();
         return new MessageFieldType(
-            modelRootName.packageName(),
+            util.getCodegenPackageName(modelRootName),
             protoTypeName,
-            modelRootName.simpleName(),
+            modelRootName.getSimpleName().toString(),
             config.fileSuffix());
       }
       throw util.errorAndThrow(

--- a/vajram/extensions/resilience4j/vajram-resilience4j/src/test/java/com/flipkart/krystal/vajram/resilience4j/Resilience4JBulkheadTest.java
+++ b/vajram/extensions/resilience4j/vajram-resilience4j/src/test/java/com/flipkart/krystal/vajram/resilience4j/Resilience4JBulkheadTest.java
@@ -89,7 +89,7 @@ class Resilience4JBulkheadTest {
     OutputLogicDefinition<String> outputLogicDef =
         newIOLogic(
             "bulkhead_restrictsConcurrency",
-            ImmutableSet.of(input()),
+            ImmutableSet.of(input("facet1")),
             executionItem ->
                 runAsync(
                     () -> {
@@ -105,10 +105,10 @@ class Resilience4JBulkheadTest {
     VajramKryonDefinition kryonDefinition =
         kryonDefinitionRegistry.newVajramKryonDefinition(
             vajramID("kryon"),
-            Set.of(input()),
+            Set.of(input("facet1")),
             outputLogicDef.kryonLogicId(),
             ImmutableMap.of(),
-            newCreateNewRequestLogic(Set.of(input())),
+            newCreateNewRequestLogic(Set.of(input("facet1"))),
             newFacetsFromRequestLogic(),
             _graphExecData -> _graphExecData.communicationFacade().executeOutputLogic(),
             ElementTags.of(
@@ -138,7 +138,9 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> call1BeforeBulkheadExhaustion =
         executor1.executeKryon(
             new SimpleRequestBuilder<>(
-                    Set.of(input()), ImmutableMap.of(1, withValue(1)), kryonDefinition.vajramID())
+                    Set.of(input("facet1")),
+                    ImmutableMap.of("facet1", withValue(1)),
+                    kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_1").build());
     KryonExecutor executor2 =
@@ -152,7 +154,9 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> call2BeforeBulkheadExhaustion =
         executor2.executeKryon(
             new SimpleRequestBuilder<>(
-                    Set.of(input()), ImmutableMap.of(1, withValue(2)), kryonDefinition.vajramID())
+                    Set.of(input("facet1")),
+                    ImmutableMap.of("facet1", withValue(2)),
+                    kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_2").build());
     KryonExecutor executor3 =
@@ -166,7 +170,9 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> callAfterBulkheadExhaustion =
         executor3.executeKryon(
             new SimpleRequestBuilder<>(
-                    Set.of(input()), ImmutableMap.of(1, withValue(3)), kryonDefinition.vajramID())
+                    Set.of(input("facet1")),
+                    ImmutableMap.of("facet1", withValue(3)),
+                    kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_3").build());
     executor1.close();
@@ -187,7 +193,7 @@ class Resilience4JBulkheadTest {
   @Test
   void threadpoolBulkhead_restrictsConcurrency() {
     CountDownLatch countDownLatch = new CountDownLatch(1);
-    Set<SimpleFacet> inputs = Set.of(input());
+    Set<SimpleFacet> inputs = Set.of(input("facet1"));
     OutputLogicDefinition<String> outputLogic =
         newIOLogic(
             "threadpoolBulkhead_restrictsConcurrency",
@@ -238,7 +244,7 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> call1BeforeBulkheadExhaustion =
         executor1.executeKryon(
             new SimpleRequestBuilder<>(
-                    inputs, ImmutableMap.of(1, withValue(1)), kryonDefinition.vajramID())
+                    inputs, ImmutableMap.of("facet1", withValue(1)), kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_1").build());
     KryonExecutor executor2 =
@@ -252,7 +258,7 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> call2BeforeBulkheadExhaustion =
         executor2.executeKryon(
             new SimpleRequestBuilder<>(
-                    inputs, ImmutableMap.of(1, withValue(2)), kryonDefinition.vajramID())
+                    inputs, ImmutableMap.of("facet1", withValue(2)), kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_2").build());
     KryonExecutor executor3 =
@@ -266,7 +272,7 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> callAfterBulkheadExhaustion =
         executor3.executeKryon(
             new SimpleRequestBuilder<>(
-                    inputs, ImmutableMap.of(1, withValue(3)), kryonDefinition.vajramID())
+                    inputs, ImmutableMap.of("facet1", withValue(3)), kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_3").build());
     executor1.close();

--- a/vajram/extensions/resilience4j/vajram-resilience4j/src/test/java/com/flipkart/krystal/vajram/resilience4j/Resilience4JBulkheadTest.java
+++ b/vajram/extensions/resilience4j/vajram-resilience4j/src/test/java/com/flipkart/krystal/vajram/resilience4j/Resilience4JBulkheadTest.java
@@ -89,7 +89,7 @@ class Resilience4JBulkheadTest {
     OutputLogicDefinition<String> outputLogicDef =
         newIOLogic(
             "bulkhead_restrictsConcurrency",
-            ImmutableSet.of(input(1)),
+            ImmutableSet.of(input()),
             executionItem ->
                 runAsync(
                     () -> {
@@ -105,10 +105,10 @@ class Resilience4JBulkheadTest {
     VajramKryonDefinition kryonDefinition =
         kryonDefinitionRegistry.newVajramKryonDefinition(
             vajramID("kryon"),
-            Set.of(input(1)),
+            Set.of(input()),
             outputLogicDef.kryonLogicId(),
             ImmutableMap.of(),
-            newCreateNewRequestLogic(Set.of(input(1))),
+            newCreateNewRequestLogic(Set.of(input())),
             newFacetsFromRequestLogic(),
             _graphExecData -> _graphExecData.communicationFacade().executeOutputLogic(),
             ElementTags.of(
@@ -138,7 +138,7 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> call1BeforeBulkheadExhaustion =
         executor1.executeKryon(
             new SimpleRequestBuilder<>(
-                    Set.of(input(1)), ImmutableMap.of(1, withValue(1)), kryonDefinition.vajramID())
+                    Set.of(input()), ImmutableMap.of(1, withValue(1)), kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_1").build());
     KryonExecutor executor2 =
@@ -152,7 +152,7 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> call2BeforeBulkheadExhaustion =
         executor2.executeKryon(
             new SimpleRequestBuilder<>(
-                    Set.of(input(1)), ImmutableMap.of(1, withValue(2)), kryonDefinition.vajramID())
+                    Set.of(input()), ImmutableMap.of(1, withValue(2)), kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_2").build());
     KryonExecutor executor3 =
@@ -166,7 +166,7 @@ class Resilience4JBulkheadTest {
     CompletableFuture<Object> callAfterBulkheadExhaustion =
         executor3.executeKryon(
             new SimpleRequestBuilder<>(
-                    Set.of(input(1)), ImmutableMap.of(1, withValue(3)), kryonDefinition.vajramID())
+                    Set.of(input()), ImmutableMap.of(1, withValue(3)), kryonDefinition.vajramID())
                 ._build(),
             KryonExecutionConfig.builder().executionId("req_3").build());
     executor1.close();
@@ -187,7 +187,7 @@ class Resilience4JBulkheadTest {
   @Test
   void threadpoolBulkhead_restrictsConcurrency() {
     CountDownLatch countDownLatch = new CountDownLatch(1);
-    Set<SimpleFacet> inputs = Set.of(input(1));
+    Set<SimpleFacet> inputs = Set.of(input());
     OutputLogicDefinition<String> outputLogic =
         newIOLogic(
             "threadpoolBulkhead_restrictsConcurrency",

--- a/vajram/extensions/sql/vertx/vajram-sql-vertx-samples/src/test/java/com/flipkart/krystal/vajram/ext/sql/vertx/samples/users/statement/SqlTraitIntegrationTest.java
+++ b/vajram/extensions/sql/vertx/vajram-sql-vertx-samples/src/test/java/com/flipkart/krystal/vajram/ext/sql/vertx/samples/users/statement/SqlTraitIntegrationTest.java
@@ -33,7 +33,7 @@ import com.flipkart.krystal.vajram.ext.sql.vertx.samples.users.model.Order_Immut
 import com.flipkart.krystal.vajram.ext.sql.vertx.samples.users.model.User;
 import com.flipkart.krystal.vajram.ext.sql.vertx.samples.users.model.User_ImmutPojo;
 import com.flipkart.krystal.vajram.guice.injection.VajramGuiceInputInjector;
-import com.flipkart.krystal.vajram.guice.traitbinding.StaticDispatchPolicyImpl;
+import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.json.Json;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph;
@@ -1314,7 +1314,7 @@ class SqlTraitIntegrationTest {
                         GetUserWithAddressById_Req._VAJRAM_ID)
                     .map(
                         vajramID ->
-                            new StaticDispatchPolicyImpl(vajramGraph, vajramID, traitBinder))
+                            new GuiceyStaticDispatchPolicy(vajramGraph, vajramID, traitBinder))
                     .toList())
             .build());
     return kGraph

--- a/vajram/extensions/sql/vertx/vajram-sql-vertx/src/main/java/com/flipkart/krystal/vajram/ext/sql/vertx/ExecuteVertxSql.java
+++ b/vajram/extensions/sql/vertx/vajram-sql-vertx/src/main/java/com/flipkart/krystal/vajram/ext/sql/vertx/ExecuteVertxSql.java
@@ -11,6 +11,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * IO Vajram that executes a parameterized SQL query using the Vert.x SQL client.
@@ -21,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>The query is executed as a prepared statement to prevent SQL injection.
  */
+@Slf4j
 @Vajram
 public abstract class ExecuteVertxSql extends IOVajramDef<RowSet<Row>> {
 
@@ -40,6 +42,17 @@ public abstract class ExecuteVertxSql extends IOVajramDef<RowSet<Row>> {
 
   @Output
   static CompletableFuture<RowSet<Row>> execute(String sql, Tuple params, Pool pool) {
-    return pool.preparedQuery(sql).execute(params).toCompletionStage().toCompletableFuture();
+    CompletableFuture<RowSet<Row>> resultFuture =
+        pool.preparedQuery(sql)
+            .execute(params)
+            .toCompletionStage()
+            .toCompletableFuture()
+            .whenComplete(
+                (rows, throwable) -> {
+                  if (throwable != null) {
+                    log.error("Failed to execute SQL query", throwable);
+                  }
+                });
+    return resultFuture;
   }
 }

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/generators/JavaModelsGen.java
@@ -15,7 +15,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.DEFAULT;
-import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
@@ -81,6 +80,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -191,17 +191,19 @@ public final class JavaModelsGen implements CodeGenerator {
     if (!isApplicable()) {
       return;
     }
-
     TypeElement modelRootType = codeGenContext.modelRootType();
-
     // For enum models: validate only, no code generation needed
     if (util.isEnumModel(modelRootType)) {
       validateEnumModel(modelRootType);
       return;
     }
-
     validate();
+    interfaces();
+    impls();
+  }
 
+  private void interfaces() {
+    TypeElement modelRootType = codeGenContext.modelRootType();
     CodeGenUtility util = codeGenContext.util();
 
     // Extract and validate model methods
@@ -230,12 +232,18 @@ public final class JavaModelsGen implements CodeGenerator {
         generateImmutableInterface(modelRootType, modelMethods, immutModelNameRaw);
     // Write the immutable interface to a file
     util.writeJavaFile(packageName, immutableInterface, modelRootType);
+  }
 
+  private void impls() {
+    TypeElement modelRootType = codeGenContext.modelRootType();
+    CodeGenUtility util = codeGenContext.util();
+    String packageName = util.getCodegenPackageName(modelRootType);
     if (util.typeExplicitlySupportsProtocol(modelRootType, PlainJavaObject.class)
+        ||
         // If no SupportedModelProtocol annotation is present, then we assume PlainJavaObject as a
         // sane default
-        || modelRootType.getAnnotationsByType(SupportedModelProtocol.class).length == 0) {
-      // Generate the POJO class only if PlainJavaObject is explicitly supported
+        util.getSupportedProtocolTypeElements(modelRootType).isEmpty()) {
+      List<ExecutableElement> modelMethods = util.extractAndValidateModelMethods(modelRootType);
       util.writeJavaFile(
           packageName, generateImmutablePojo(modelRootType, modelMethods), modelRootType);
     }
@@ -965,7 +973,7 @@ public final class JavaModelsGen implements CodeGenerator {
                   util.getModelFieldType(method, false, null).fieldType(),
                   method.getSimpleName().toString(),
                   PRIVATE,
-                  FINAL)
+                  Modifier.FINAL)
               .build());
     }
 
@@ -1016,7 +1024,7 @@ public final class JavaModelsGen implements CodeGenerator {
         classBuilder);
     // Create the POJO class
     return classBuilder
-        .addModifiers(PUBLIC, FINAL)
+        .addModifiers(PUBLIC, Modifier.FINAL)
         .addSuperinterface(immutIfaceType)
         .addFields(fields)
         .addMethod(allArgCtor(modelMethods, util).build())
@@ -1374,7 +1382,7 @@ this.$L = $L == null
             "Builder",
             modelRootType.getTypeParameters().stream().map(TypeVariableName::get).toList(),
             modelRootType.getQualifiedName().toString())
-        .addModifiers(PUBLIC, STATIC, FINAL)
+        .addModifiers(PUBLIC, STATIC, Modifier.FINAL)
         .addSuperinterface(withTypeParams(builderClassName, modelRootType.getTypeParameters()))
         .addFields(fields)
         .addMethod(noArgConstructor)

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/DefaultFacetModel.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/DefaultFacetModel.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.vajram.codegen.common.models;
 
 import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
+import com.flipkart.krystal.core.VajramID;
 import com.flipkart.krystal.facets.FacetType;
 import com.google.common.collect.ImmutableSet;
 import java.util.EnumSet;
@@ -11,13 +12,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents any face which is "given" to the vajram from outside - like client provided inputs and
- * platform provided injections
+ * platform provided injections.
+ *
+ * @param vajramId the vajram that this facet belongs to
  */
 @Builder
 public record DefaultFacetModel(
     int id,
     @NonNull String name,
-    @NonNull VajramInfoLite vajramInfo,
+    @NonNull VajramID vajramId,
     @NonNull CodeGenType dataType,
     @Nullable String documentation,
     FacetType facetType,

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/DependencyModel.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/DependencyModel.java
@@ -4,6 +4,7 @@ import static com.flipkart.krystal.codegen.common.models.CodeGenUtility.asClassN
 import static com.flipkart.krystal.facets.FacetType.DEPENDENCY;
 
 import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
+import com.flipkart.krystal.core.VajramID;
 import com.flipkart.krystal.facets.FacetType;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
@@ -16,8 +17,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public record DependencyModel(
     int id,
     @NonNull String name,
-    @NonNull VajramInfoLite vajramInfo,
-    @NonNull VajramInfoLite depVajramInfo,
+    @NonNull VajramID vajramId,
+    @NonNull VajramInputsInfo depVajramInfo,
     @NonNull CodeGenType dataType,
     @NonNull TypeName depReqType,
     boolean canFanout,

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/FacetGenModel.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/FacetGenModel.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.vajram.codegen.common.models;
 
 import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
+import com.flipkart.krystal.core.VajramID;
 import com.flipkart.krystal.facets.FacetType;
 import com.flipkart.krystal.model.IfAbsent;
 import com.flipkart.krystal.vajram.batching.Batched;
@@ -16,7 +17,8 @@ public sealed interface FacetGenModel permits DefaultFacetModel, DependencyModel
 
   String name();
 
-  VajramInfoLite vajramInfo();
+  /** The vajram that this facet belongs to */
+  VajramID vajramId();
 
   Element facetElement();
 

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/FacetJavaType.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/FacetJavaType.java
@@ -102,7 +102,7 @@ public abstract sealed class FacetJavaType {
               FacetValidation.class,
               FACET_VALUES_VAR,
               facet.name(),
-              facet.vajramInfo().vajramId().id(),
+              facet.vajramId().id(),
               facet.name());
         } else {
           return CodeBlock.of("return this.$L.$L()", FACET_VALUES_VAR, facet.name());

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/ParsedVajramData.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/ParsedVajramData.java
@@ -34,7 +34,7 @@ public record ParsedVajramData(
   public static Optional<ParsedVajramData> fromVajramInfo(
       VajramInfo vajramInfo, VajramCodeGenUtility util) {
     validate(vajramInfo, util);
-    String packageName = vajramInfo.lite().packageName();
+    String packageName = vajramInfo.packageName();
     ImmutableList<ExecutableElement> allMethods = getAllMethods(vajramInfo.vajramClassElem());
     if (vajramInfo.lite().isTrait()) {
       if (!allMethods.isEmpty()) {

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramCodeGenUtility.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramCodeGenUtility.java
@@ -319,7 +319,7 @@ public class VajramCodeGenUtility {
    * fields. For interfaces, returns abstract methods. For classes with abstract methods (abstract
    * classes), returns both fields and abstract methods.
    */
-  private List<Element> extractFacetElements(@Nullable Element container) {
+  public List<Element> extractFacetElements(@Nullable Element container) {
     if (container == null) {
       return List.of();
     }
@@ -559,6 +559,7 @@ public class VajramCodeGenUtility {
       TypeElement inputsElement = getInputsClass(vajramOrReqClass).orElse(null);
       Element externalInputsElement = getExternalInputsElement(inputsElement);
       if (externalInputsElement != null) {
+        validateExternalInputsVajramId(externalInputsElement, vajramId, inputsElement);
         requestPackageName += "." + SHARED_MODELS_SUB_PACKAGE;
       }
 
@@ -787,6 +788,30 @@ public class VajramCodeGenUtility {
             .map(Entry::getValue)
             .orElseThrow(AssertionError::new)
             .getValue());
+  }
+
+  private void validateExternalInputsVajramId(
+      Element externalInputsElement, VajramID vajramId, TypeElement inputsElement) {
+    InputsForVajram[] annotations =
+        externalInputsElement.getAnnotationsByType(InputsForVajram.class);
+    boolean matchFound = false;
+    for (InputsForVajram annotation : annotations) {
+      if (annotation.vajramId().equals(vajramId.id())) {
+        matchFound = true;
+        break;
+      }
+    }
+    if (!matchFound) {
+      codegenUtil()
+          .error(
+              "The @InputsForVajram annotation on '%s' does not declare vajramId '%s'. Please add @InputsForVajram(vajramId = \"%s\", ...) to '%s'"
+                  .formatted(
+                      externalInputsElement.getSimpleName(),
+                      vajramId.id(),
+                      vajramId.id(),
+                      externalInputsElement.getSimpleName()),
+              inputsElement);
+    }
   }
 
   @Nullable

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramCodeGenUtility.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramCodeGenUtility.java
@@ -220,7 +220,6 @@ public class VajramCodeGenUtility {
               .getQualifiedName()
               .toString();
     }
-    Optional<TypeElement> inputsClass = getInputsClass(vajramClass);
     Optional<Element> internalFacetsClass = getInternalFacetsClass(vajramClass);
     BiMap<String, Integer> givenIdsByName = HashBiMap.create();
     Set<Integer> takenFacetIds = givenIdsByName.values();
@@ -271,7 +270,7 @@ public class VajramCodeGenUtility {
             vajramClass,
             conformsToTraitInfo,
             outputLogicDelegationMode,
-            inputsClass.orElse(null));
+            getInputsSource(vajramClass));
     codegenUtil().note("VajramInfo: %s".formatted(vajramInfo));
     validateVajramInfo(vajramInfo);
     return vajramInfo;
@@ -297,6 +296,18 @@ public class VajramCodeGenUtility {
         .filter(element -> element.getSimpleName().contentEquals(Constants._INPUTS_CLASS))
         .findFirst()
         .map(TypeElement.class::cast);
+  }
+
+  private @Nullable TypeElement getInputsSource(TypeElement vajramClass) {
+    TypeElement inputsClass = getInputsClass(vajramClass).orElse(null);
+    if (inputsClass == null) {
+      return null;
+    }
+    TypeElement externalInputsElement = getExternalInputsElement(inputsClass);
+    if (externalInputsElement == null) {
+      return inputsClass;
+    }
+    return externalInputsElement;
   }
 
   private void validateVajramInfo(VajramInfo vajramInfo) {
@@ -388,7 +399,10 @@ public class VajramCodeGenUtility {
   private @Nullable FacetType getFacetType(Element facetElement) {
     String facetName = facetElement.getSimpleName().toString();
     FacetType facetType = null;
-    boolean isInput = "_Inputs".contentEquals(facetElement.getEnclosingElement().getSimpleName());
+    Element enclosingElement = facetElement.getEnclosingElement();
+    boolean isInput =
+        "_Inputs".contentEquals(enclosingElement.getSimpleName())
+            || enclosingElement.getAnnotation(InputsForVajram.class) != null;
     if (isInput) {
       facetType = INPUT;
     }
@@ -559,12 +573,16 @@ public class VajramCodeGenUtility {
       TypeElement inputsElement = getInputsClass(vajramOrReqClass).orElse(null);
       Element externalInputsElement = getExternalInputsElement(inputsElement);
       if (externalInputsElement != null) {
-        validateExternalInputsVajramId(externalInputsElement, vajramId, inputsElement);
-        requestPackageName += "." + SHARED_MODELS_SUB_PACKAGE;
+        requestPackageName =
+            validateExternalInputsAndGetPackage(externalInputsElement, vajramId, inputsElement)
+                + "."
+                + SHARED_MODELS_SUB_PACKAGE;
       }
 
       inputs =
-          extractFacetElements(inputsElement).stream()
+          extractFacetElements(
+                  externalInputsElement != null ? externalInputsElement : inputsElement)
+              .stream()
               .map(facetElement -> toGivenFacetModel(facetElement, vajramId))
               .filter(Optional::isPresent)
               .map(Optional::get)
@@ -790,20 +808,20 @@ public class VajramCodeGenUtility {
             .getValue());
   }
 
-  private void validateExternalInputsVajramId(
+  private String validateExternalInputsAndGetPackage(
       Element externalInputsElement, VajramID vajramId, TypeElement inputsElement) {
     InputsForVajram[] annotations =
         externalInputsElement.getAnnotationsByType(InputsForVajram.class);
-    boolean matchFound = false;
+    InputsForVajram matchFound = null;
     for (InputsForVajram annotation : annotations) {
       if (annotation.vajramId().equals(vajramId.id())) {
-        matchFound = true;
+        matchFound = annotation;
         break;
       }
     }
-    if (!matchFound) {
-      codegenUtil()
-          .error(
+    if (matchFound == null) {
+      throw codegenUtil()
+          .errorAndThrow(
               "The @InputsForVajram annotation on '%s' does not declare vajramId '%s'. Please add @InputsForVajram(vajramId = \"%s\", ...) to '%s'"
                   .formatted(
                       externalInputsElement.getSimpleName(),
@@ -812,25 +830,30 @@ public class VajramCodeGenUtility {
                       externalInputsElement.getSimpleName()),
               inputsElement);
     }
+    if (!inputsElement.getEnclosedElements().isEmpty()) {
+      throw codegenUtil.errorAndThrow(
+          "_Inputs that extend @InputsForVajram interface should not have any fields",
+          inputsElement);
+    }
+    return matchFound.parentPackage();
   }
 
-  @Nullable
-  public Element getExternalInputsElement(TypeElement inputsElement) {
+  public @Nullable TypeElement getExternalInputsElement(@Nullable TypeElement inputsElement) {
     if (inputsElement == null) {
       return null;
     }
     List<? extends TypeMirror> interfaces = inputsElement.getInterfaces();
-    List<Element> externalInputsElements =
+    List<TypeElement> externalInputsElements =
         interfaces.stream()
             .map(typeUtils::asElement)
+            .filter(TypeElement.class::isInstance)
+            .map(TypeElement.class::cast)
             .filter(element -> element.getAnnotation(InputsForVajram.class) != null)
             .toList();
     if (externalInputsElements.size() > 1) {
       codegenUtil()
           .error("Multiple external inputs found for vajram. Max one allowed.", inputsElement);
     }
-    Element externalInputsElement =
-        externalInputsElements.isEmpty() ? null : externalInputsElements.get(0);
-    return externalInputsElement;
+    return externalInputsElements.isEmpty() ? null : externalInputsElements.get(0);
   }
 }

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramCodeGenUtility.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramCodeGenUtility.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.vajram.codegen.common.models;
 
 import static com.flipkart.krystal.codegen.common.models.CodeGenUtility.asTypeNameWithTypes;
+import static com.flipkart.krystal.codegen.common.models.Constants.SHARED_MODELS_SUB_PACKAGE;
 import static com.flipkart.krystal.core.VajramID.vajramID;
 import static com.flipkart.krystal.facets.FacetType.INJECTION;
 import static com.flipkart.krystal.facets.FacetType.INPUT;
@@ -31,6 +32,7 @@ import com.flipkart.krystal.data.ImmutableRequest;
 import com.flipkart.krystal.data.One2OneDepResponse;
 import com.flipkart.krystal.data.Request;
 import com.flipkart.krystal.facets.FacetType;
+import com.flipkart.krystal.facets.InputsForVajram;
 import com.flipkart.krystal.model.IfAbsent;
 import com.flipkart.krystal.vajram.ComputeVajramDef;
 import com.flipkart.krystal.vajram.IOVajramDef;
@@ -54,8 +56,8 @@ import com.flipkart.krystal.vajram.facets.specs.InputMirrorSpec;
 import com.google.common.base.Splitter;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
@@ -206,7 +208,8 @@ public class VajramCodeGenUtility {
   }
 
   public VajramInfo computeVajramInfo(TypeElement vajramClass) {
-    VajramInfoLite vajramInfoLite = computeVajramInfoLiteWithExactTypeArgs(vajramClass.asType());
+    VajramInfoLite vajramInfoLite = computeVajramInfoLite(vajramClass, List.of());
+    var vajramPackageName = elementUtils.getPackageOf(vajramClass).getQualifiedName().toString();
     VajramInfoLite conformsToTraitInfo = getConformToTraitInfoFromVajram(vajramClass);
     String parentClassName = null;
     if (vajramInfoLite.isVajram()) {
@@ -217,11 +220,10 @@ public class VajramCodeGenUtility {
               .getQualifiedName()
               .toString();
     }
-    Optional<Element> inputsClass = getInputsClass(vajramClass);
+    Optional<TypeElement> inputsClass = getInputsClass(vajramClass);
     Optional<Element> internalFacetsClass = getInternalFacetsClass(vajramClass);
     BiMap<String, Integer> givenIdsByName = HashBiMap.create();
     Set<Integer> takenFacetIds = givenIdsByName.values();
-    List<Element> inputFacetElements = extractFacetElements(inputsClass.orElse(null));
     List<Element> internalFacetElements = extractFacetElements(internalFacetsClass.orElse(null));
     List<Element> dependencyElements =
         internalFacetElements.stream()
@@ -240,21 +242,19 @@ public class VajramCodeGenUtility {
       throw codegenUtil.errorAndThrow(
           "Unknown vajram parent class " + parentClassName, vajramClass);
     }
+    ImmutableList<DefaultFacetModel> givenFacets =
+        Stream.concat(
+                vajramInfoLite.inputsInfo().inputs().stream(),
+                internalFacetElements.stream()
+                    .map(facetElement -> toGivenFacetModel(facetElement, vajramInfoLite.vajramId()))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get))
+            .collect(toImmutableList());
     VajramInfo vajramInfo =
         new VajramInfo(
             vajramInfoLite,
-            Streams.concat(inputFacetElements.stream(), internalFacetElements.stream())
-                .map(
-                    facetElement ->
-                        toGivenFacetModel(
-                            facetElement,
-                            givenIdsByName,
-                            takenFacetIds,
-                            nextFacetId,
-                            vajramInfoLite))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(toImmutableList()),
+            vajramPackageName,
+            givenFacets,
             dependencyElements.stream()
                 .map(
                     depElement ->
@@ -288,7 +288,7 @@ public class VajramCodeGenUtility {
         .map(element -> typeUtils.asElement(element.asType()));
   }
 
-  private Optional<Element> getInputsClass(TypeElement vajramClass) {
+  private Optional<TypeElement> getInputsClass(TypeElement vajramClass) {
     return vajramClass.getEnclosedElements().stream()
         .filter(
             element ->
@@ -296,7 +296,7 @@ public class VajramCodeGenUtility {
                     || element.getKind() == ElementKind.INTERFACE)
         .filter(element -> element.getSimpleName().contentEquals(Constants._INPUTS_CLASS))
         .findFirst()
-        .map(element -> typeUtils.asElement(element.asType()));
+        .map(TypeElement.class::cast);
   }
 
   private void validateVajramInfo(VajramInfo vajramInfo) {
@@ -335,12 +335,12 @@ public class VajramCodeGenUtility {
     for (ExecutableElement method : ElementFilter.methodsIn(enclosed)) {
       if (method.getModifiers().contains(ABSTRACT)
           && method.getParameters().isEmpty()
-          && method.getReturnType().getKind() != TypeKind.VOID) {
+          && method.getReturnType().getKind() != TypeKind.VOID
+          && !method.getSimpleName().toString().startsWith("_")) {
         result.add(method);
       } else {
-        codegenUtil.error(
-            "Facet methods must be abstract have a return a value and accept zero parameters",
-            method);
+        codegenUtil.note(
+            "Facet methods must be abstract have a return a value and accept zero parameters");
       }
     }
     return Collections.unmodifiableList(result);
@@ -357,25 +357,16 @@ public class VajramCodeGenUtility {
     return element.asType();
   }
 
-  private Optional<DefaultFacetModel> toGivenFacetModel(
-      Element facetElement,
-      BiMap<String, Integer> givenIdsByName,
-      Set<Integer> takenFacetIds,
-      AtomicInteger nextFacetId,
-      VajramInfoLite vajramInfoLite) {
+  private Optional<DefaultFacetModel> toGivenFacetModel(Element facetElement, VajramID vajramID) {
     DefaultFacetModelBuilder facetBuilder = DefaultFacetModel.builder().facetElement(facetElement);
     String facetName = facetElement.getSimpleName().toString();
-    facetBuilder.id(
-        requireNonNullElseGet(
-            givenIdsByName.get(facetName),
-            () -> getNextAvailableFacetId(takenFacetIds, nextFacetId)));
     facetBuilder.name(facetName);
     facetBuilder.documentation(elementUtils.getDocComment(facetElement));
     TypeMirror facetElementType = getFacetElementType(facetElement);
     if (TypeKind.ERROR.equals(facetElementType.getKind())) {
       throw new CodeGenShortCircuitException(
           "Vajram Id : "
-              + vajramInfoLite.vajramId()
+              + vajramID
               + " facet : "
               + facetName
               + " has an error type: "
@@ -390,9 +381,7 @@ public class VajramCodeGenUtility {
     if (facetType == null) {
       return Optional.empty();
     }
-    DefaultFacetModel facetModel =
-        facetBuilder.facetType(facetType).vajramInfo(vajramInfoLite).build();
-    givenIdsByName.putIfAbsent(facetName, facetModel.id());
+    DefaultFacetModel facetModel = facetBuilder.facetType(facetType).vajramId(vajramID).build();
     return Optional.of(facetModel);
   }
 
@@ -480,7 +469,7 @@ public class VajramCodeGenUtility {
       VajramInfoLite depVajramInfoLite =
           computeVajramInfoLiteWithUpperBoundTypeArgs(vajramOrReqElement);
       depBuilder
-          .depVajramInfo(depVajramInfoLite)
+          .depVajramInfo(depVajramInfoLite.inputsInfo())
           .depReqType(getVajramReqTypeName(vajramOrReqElement))
           .canFanout(dependency.canFanout());
       if (!processingEnv
@@ -495,7 +484,10 @@ public class VajramCodeGenUtility {
                 depField);
       }
       DependencyModel depModel =
-          depBuilder.dataType(declaredFieldDataType).vajramInfo(vajramInfo).build();
+          depBuilder
+              .dataType(declaredFieldDataType)
+              .vajramId(vajramInfo.inputsInfo().vajramId())
+              .build();
       givenIdsByName.putIfAbsent(facetName, depModel.id());
       return depModel;
     }
@@ -531,7 +523,9 @@ public class VajramCodeGenUtility {
     String vajramClassSimpleName = vajramOrReqClass.getSimpleName().toString();
     VajramID vajramId;
     CodeGenType responseType;
-    String packageName = elementUtils.getPackageOf(vajramOrReqClass).getQualifiedName().toString();
+    String requestPackageName =
+        elementUtils.getPackageOf(vajramOrReqClass).getQualifiedName().toString();
+    ImmutableList<DefaultFacetModel> inputs;
     if (codegenUtil().isRawAssignable(vajramOrReqClass.asType(), Request.class)) {
       TypeMirror responseTypeMirror = getVajramResponseType(vajramOrReqClass, Request.class);
       vajramId =
@@ -541,6 +535,12 @@ public class VajramCodeGenUtility {
       responseType =
           responseTypeMirror.accept(
               new DeclaredTypeVisitor(codegenUtil, vajramOrReqClass, DISALLOWED_FACET_TYPES), null);
+      inputs =
+          extractFacetElements(vajramOrReqClass).stream()
+              .map(facetElement -> toGivenFacetModel(facetElement, vajramId))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .collect(toImmutableList());
     } else if (codegenUtil().isRawAssignable(vajramOrReqClass.asType(), VajramDefRoot.class)) {
       Vajram vajram = vajramOrReqClass.getAnnotation(Vajram.class);
       Trait trait = vajramOrReqClass.getAnnotation(Trait.class);
@@ -556,17 +556,35 @@ public class VajramCodeGenUtility {
       responseType =
           responseTypeMirror.accept(
               new DeclaredTypeVisitor(codegenUtil, vajramOrReqClass, DISALLOWED_FACET_TYPES), null);
+      TypeElement inputsElement = getInputsClass(vajramOrReqClass).orElse(null);
+      Element externalInputsElement = getExternalInputsElement(inputsElement);
+      if (externalInputsElement != null) {
+        requestPackageName += "." + SHARED_MODELS_SUB_PACKAGE;
+      }
+
+      inputs =
+          extractFacetElements(inputsElement).stream()
+              .map(facetElement -> toGivenFacetModel(facetElement, vajramId))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .collect(toImmutableList());
     } else {
       throw new IllegalArgumentException(
           "Unknown class hierarchy of vajram class %s. Expected %s or %s"
               .formatted(vajramOrReqClass, VajramDef.class, ImmutableRequest.class));
     }
+    boolean isTrait = vajramOrReqClass.getAnnotation(Trait.class) != null;
+    VajramInputsInfo inputsInfo =
+        new VajramInputsInfo(
+            vajramId,
+            responseType,
+            requestPackageName,
+            inputs,
+            Collections.unmodifiableList(typeArguments),
+            isTrait);
     return new VajramInfoLite(
-        vajramId,
-        responseType,
-        packageName,
+        inputsInfo,
         vajramOrReqClass,
-        Collections.unmodifiableList(typeArguments),
         codegenUtil.processingEnv().getElementUtils().getDocComment(vajramOrReqClass),
         this);
   }
@@ -769,5 +787,25 @@ public class VajramCodeGenUtility {
             .map(Entry::getValue)
             .orElseThrow(AssertionError::new)
             .getValue());
+  }
+
+  @Nullable
+  public Element getExternalInputsElement(TypeElement inputsElement) {
+    if (inputsElement == null) {
+      return null;
+    }
+    List<? extends TypeMirror> interfaces = inputsElement.getInterfaces();
+    List<Element> externalInputsElements =
+        interfaces.stream()
+            .map(typeUtils::asElement)
+            .filter(element -> element.getAnnotation(InputsForVajram.class) != null)
+            .toList();
+    if (externalInputsElements.size() > 1) {
+      codegenUtil()
+          .error("Multiple external inputs found for vajram. Max one allowed.", inputsElement);
+    }
+    Element externalInputsElement =
+        externalInputsElements.isEmpty() ? null : externalInputsElements.get(0);
+    return externalInputsElement;
   }
 }

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInfo.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInfo.java
@@ -23,7 +23,7 @@ public record VajramInfo(
     TypeElement definitionElement,
     @Nullable VajramInfoLite conformsToTraitInfo,
     @Nullable ComputeDelegationMode vajramDelegationMode,
-    @Nullable TypeElement inputsElement) {
+    @Nullable TypeElement inputsSource) {
 
   public VajramInfo {
     if (lite.isTrait()) {

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInfo.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInfo.java
@@ -12,18 +12,18 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.util.List;
 import java.util.stream.Stream;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record VajramInfo(
     VajramInfoLite lite,
+    String packageName,
     ImmutableList<DefaultFacetModel> givenFacets,
     ImmutableList<DependencyModel> dependencies,
     TypeElement definitionElement,
     @Nullable VajramInfoLite conformsToTraitInfo,
     @Nullable ComputeDelegationMode vajramDelegationMode,
-    @Nullable Element inputsElement) {
+    @Nullable TypeElement inputsElement) {
 
   public VajramInfo {
     if (lite.isTrait()) {
@@ -93,11 +93,10 @@ public record VajramInfo(
   }
 
   public ClassName facetsInterfaceType() {
-    return ClassName.get(lite.packageName(), vajramName() + Constants.FACETS_CLASS_SUFFIX);
+    return ClassName.get(packageName(), vajramName() + Constants.FACETS_CLASS_SUFFIX);
   }
 
   public ClassName facetsImmutPojoType() {
-    return ClassName.get(
-        lite.packageName(), vajramName() + Constants.FACETS_IMMUT_POJO_CLASS_SUFFIX);
+    return ClassName.get(packageName(), vajramName() + Constants.FACETS_IMMUT_POJO_CLASS_SUFFIX);
   }
 }

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInfoLite.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInfoLite.java
@@ -1,15 +1,8 @@
 package com.flipkart.krystal.vajram.codegen.common.models;
 
-import static com.flipkart.krystal.codegen.common.models.CodeGenUtility.asTypeNameWithTypes;
-import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getImmutRequestInterfaceName;
-import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getImmutRequestPojoName;
-import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getRequestInterfaceName;
-
 import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
-import com.flipkart.krystal.codegen.common.datatypes.VariableCodeGenType;
 import com.flipkart.krystal.core.VajramID;
 import com.flipkart.krystal.facets.FacetType;
-import com.flipkart.krystal.vajram.Trait;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
 import java.util.List;
@@ -20,63 +13,66 @@ import lombok.SneakyThrows;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record VajramInfoLite(
-    VajramID vajramId,
-    CodeGenType responseType,
-    String packageName,
+    VajramInputsInfo inputsInfo,
     TypeElement vajramOrReqClass,
-    List<? extends TypeMirror> typeArguments,
     String docString,
     VajramCodeGenUtility util) {
 
+  public VajramID vajramId() {
+    return inputsInfo.vajramId();
+  }
+
+  public CodeGenType responseType() {
+    return inputsInfo.responseType();
+  }
+
+  public List<? extends TypeMirror> typeArguments() {
+    return inputsInfo.typeArguments();
+  }
+
+  public boolean isTrait() {
+    return inputsInfo.isTrait();
+  }
+
+  public boolean isVajram() {
+    return !isTrait();
+  }
+
   public ClassName requestInterfaceClassName() {
-    return ClassName.get(packageName(), getRequestInterfaceName(vajramId().id()));
+    return inputsInfo.requestInterfaceClassName();
   }
 
   public TypeName requestInterfaceTypeName() {
-    return asTypeNameWithTypes(requestInterfaceClassName(), typeArguments());
+    return inputsInfo.requestInterfaceTypeName();
   }
 
   public ClassName reqImmutInterfaceClassName() {
-    return ClassName.get(packageName(), getImmutRequestInterfaceName(vajramId().id()));
+    return inputsInfo.reqImmutInterfaceClassName();
   }
 
   public TypeName reqImmutInterfaceTypeName() {
-    return asTypeNameWithTypes(
-        ClassName.get(packageName(), getImmutRequestInterfaceName(vajramId().id())),
-        typeArguments());
+    return inputsInfo.reqImmutInterfaceTypeName();
   }
 
   public ClassName reqImmutPojoClassName() {
-    return ClassName.get(packageName(), getImmutRequestPojoName(vajramId().id()));
+    return inputsInfo.reqImmutPojoClassName();
   }
 
   public TypeName reqImmutPojoTypeName() {
-    return asTypeNameWithTypes(reqImmutPojoClassName(), typeArguments());
+    return inputsInfo.reqImmutPojoTypeName();
   }
 
   public TypeName reqBuilderInterfaceType() {
-    return asTypeNameWithTypes(
-        reqImmutInterfaceClassName().nestedClass("Builder"), typeArguments());
+    return inputsInfo.reqBuilderInterfaceType();
   }
 
   public CodeGenType responseTypeBounds() {
-    if (responseType instanceof VariableCodeGenType vct) {
-      return vct.upperBound();
-    }
-    return responseType;
+    return inputsInfo.responseTypeBounds();
   }
 
   @SneakyThrows
   public List<? extends AnnotationMirror> annotations() {
     return vajramOrReqClass.getAnnotationMirrors();
-  }
-
-  public boolean isTrait() {
-    return vajramOrReqClass.getAnnotation(Trait.class) != null;
-  }
-
-  public boolean isVajram() {
-    return !isTrait();
   }
 
   public record FacetDetail(

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInputsInfo.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/VajramInputsInfo.java
@@ -1,0 +1,70 @@
+package com.flipkart.krystal.vajram.codegen.common.models;
+
+import static com.flipkart.krystal.codegen.common.models.CodeGenUtility.asTypeNameWithTypes;
+import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getImmutRequestInterfaceName;
+import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getImmutRequestPojoName;
+import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getRequestInterfaceName;
+
+import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
+import com.flipkart.krystal.codegen.common.datatypes.VariableCodeGenType;
+import com.flipkart.krystal.core.VajramID;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Encapsulates the information about vajram inputs needed for request interface generation. This
+ * can be used both for vajrams that define inputs inside their class and for vajrams that define
+ * inputs externally via {@link com.flipkart.krystal.facets.InputsForVajram}.
+ */
+public record VajramInputsInfo(
+    VajramID vajramId,
+    CodeGenType responseType,
+    String requestPackageName,
+    List<DefaultFacetModel> inputs,
+    List<? extends TypeMirror> typeArguments,
+    boolean isTrait) {
+
+  public String vajramName() {
+    return vajramId.id();
+  }
+
+  public ClassName requestInterfaceClassName() {
+    return ClassName.get(requestPackageName(), getRequestInterfaceName(vajramId().id()));
+  }
+
+  public TypeName requestInterfaceTypeName() {
+    return asTypeNameWithTypes(requestInterfaceClassName(), typeArguments());
+  }
+
+  public ClassName reqImmutInterfaceClassName() {
+    return ClassName.get(requestPackageName(), getImmutRequestInterfaceName(vajramId().id()));
+  }
+
+  public TypeName reqImmutInterfaceTypeName() {
+    return asTypeNameWithTypes(
+        ClassName.get(requestPackageName(), getImmutRequestInterfaceName(vajramId().id())),
+        typeArguments());
+  }
+
+  public ClassName reqImmutPojoClassName() {
+    return ClassName.get(requestPackageName(), getImmutRequestPojoName(vajramId().id()));
+  }
+
+  public TypeName reqImmutPojoTypeName() {
+    return asTypeNameWithTypes(reqImmutPojoClassName(), typeArguments());
+  }
+
+  public TypeName reqBuilderInterfaceType() {
+    return asTypeNameWithTypes(
+        reqImmutInterfaceClassName().nestedClass("Builder"), typeArguments());
+  }
+
+  public CodeGenType responseTypeBounds() {
+    if (responseType instanceof VariableCodeGenType vct) {
+      return vct.upperBound();
+    }
+    return responseType;
+  }
+}

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/ModelGenProcessor.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/ModelGenProcessor.java
@@ -3,6 +3,7 @@ package com.flipkart.krystal.vajram.codegen.processor;
 import static com.flipkart.krystal.codegen.common.models.Constants.CODEGEN_PHASE_KEY;
 import static com.flipkart.krystal.codegen.common.models.Constants.MODULE_ROOT_PATH_KEY;
 import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.StreamSupport.stream;
@@ -11,6 +12,7 @@ import com.flipkart.krystal.codegen.common.models.AbstractKrystalAnnoProcessor;
 import com.flipkart.krystal.codegen.common.models.CodeGenUtility;
 import com.flipkart.krystal.codegen.common.spi.ModelsCodeGenContext;
 import com.flipkart.krystal.codegen.common.spi.ModelsCodeGeneratorProvider;
+import com.flipkart.krystal.model.ImportSharedModels;
 import com.flipkart.krystal.model.ModelProtocol;
 import com.flipkart.krystal.model.ModelRoot;
 import com.flipkart.krystal.model.PlainJavaObject;
@@ -18,6 +20,7 @@ import com.flipkart.krystal.model.SupportedModelProtocol;
 import com.flipkart.krystal.model.SupportedModelProtocolName;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Throwables;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -32,9 +35,14 @@ import javax.annotation.processing.SupportedOptions;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
 
-@SupportedAnnotationTypes("com.flipkart.krystal.model.ModelRoot")
+@SupportedAnnotationTypes({
+  "com.flipkart.krystal.model.ModelRoot",
+  "com.flipkart.krystal.model.ImportModels"
+})
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 @AutoService(Processor.class)
 @SupportedOptions({CODEGEN_PHASE_KEY, MODULE_ROOT_PATH_KEY})
@@ -42,15 +50,24 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
 
   @Override
   protected void processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
     CodeGenUtility util = codeGenUtil();
     List<TypeElement> modelRoots =
-        roundEnv.getElementsAnnotatedWith(ModelRoot.class).stream()
-            .filter(
-                element ->
-                    element.getKind() == ElementKind.INTERFACE
-                        || element.getKind() == ElementKind.ENUM)
+        new ArrayList<>(
+            roundEnv.getElementsAnnotatedWith(ModelRoot.class).stream()
+                .filter(
+                    element ->
+                        element.getKind() == ElementKind.INTERFACE
+                            || element.getKind() == ElementKind.ENUM)
+                .map(executableElement -> (TypeElement) executableElement)
+                .toList());
+    modelRoots.addAll(
+        roundEnv.getElementsAnnotatedWith(ImportSharedModels.class).stream()
             .map(executableElement -> (TypeElement) executableElement)
-            .toList();
+            .map(executableElement -> getImportedModelElements(executableElement, util))
+            .flatMap(List::stream)
+            .peek(e -> validateImportedModels(e, util))
+            .toList());
     util.note(
         "Model Roots received by %s: %s"
             .formatted(
@@ -68,7 +85,7 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
       Set<Class<? extends ModelProtocol>> supportedModelProtocols =
           getSupportedModelProtocols(modelRoot, util);
       ModelsCodeGenContext creationContext =
-          new ModelsCodeGenContext(modelRoot, util, codegenPhase());
+          new ModelsCodeGenContext(modelRoot, codegenPhase(), util);
       for (Class<? extends ModelProtocol> modelProtocol : supportedModelProtocols) {
         if (stream(codeGeneratorProviders.spliterator(), false)
             .noneMatch(
@@ -91,6 +108,37 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
       }
     }
     return;
+  }
+
+  private static List<TypeElement> getImportedModelElements(
+      TypeElement executableElement, CodeGenUtility util) {
+    ImportSharedModels importSharedModels =
+        requireNonNull(executableElement.getAnnotation(ImportSharedModels.class));
+    List<TypeElement> allSharedModels =
+        new ArrayList<>(util.getTypeElemsFromAnnotationMember(importSharedModels::value));
+    String[] packageNames = importSharedModels.fromPackages();
+    for (String importedPackage : packageNames) {
+      PackageElement packageElement =
+          util.processingEnv().getElementUtils().getPackageElement(importedPackage);
+      if (packageElement == null) {
+        throw util.errorAndThrow(
+            "Package %s not found".formatted(importedPackage), executableElement);
+      }
+      ElementFilter.typesIn(packageElement.getEnclosedElements()).stream()
+          .filter(e -> e.getAnnotation(ModelRoot.class) != null)
+          .forEach(allSharedModels::add);
+    }
+    return allSharedModels;
+  }
+
+  private void validateImportedModels(TypeElement modelRootElem, CodeGenUtility util) {
+    ModelRoot modelRootAnno = modelRootElem.getAnnotation(ModelRoot.class);
+    if (modelRootAnno == null || !modelRootAnno.isShared()) {
+      throw util.errorAndThrow(
+          "Imported model %s must be annotated with @ModelRoot(isShared=true)"
+              .formatted(modelRootElem),
+          modelRootElem);
+    }
   }
 
   private Set<Class<? extends ModelProtocol>> getSupportedModelProtocols(

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/ModelGenProcessor.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/ModelGenProcessor.java
@@ -99,19 +99,16 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
         modelRootType.getAnnotationsByType(SupportedModelProtocol.class);
     SupportedModelProtocolName[] protocolNames =
         modelRootType.getAnnotationsByType(SupportedModelProtocolName.class);
-    if (protocols.length == 0) {
-      return Set.of(PlainJavaObject.class);
-    }
     Set<Class<? extends ModelProtocol>> modelProtocolClasses =
         Arrays.stream(protocols)
             .map(p -> util.getTypeElemFromAnnotationMember(p::value))
             .map(element -> element.getQualifiedName().toString())
             .map(
-                s -> {
+                protocolName -> {
                   try {
                     //noinspection unchecked
                     return (Class<? extends ModelProtocol>)
-                        Class.forName(s, false, this.getClass().getClassLoader());
+                        Class.forName(protocolName, false, this.getClass().getClassLoader());
                   } catch (ClassNotFoundException e) {
                     util.error(Throwables.getStackTraceAsString(e), modelRootType);
                     return null;
@@ -124,20 +121,24 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
         Arrays.stream(protocolNames)
             .map(SupportedModelProtocolName::value)
             .map(
-                s -> {
+                protocolName -> {
                   try {
                     //noinspection unchecked
                     return (Class<? extends ModelProtocol>)
-                        Class.forName(s, false, this.getClass().getClassLoader());
+                        Class.forName(protocolName, false, this.getClass().getClassLoader());
                   } catch (ClassNotFoundException e) {
                     util.note(
-                        "Skipping processing of model protocol %s since it is not part of the class path.");
+                        "Skipping processing of model protocol %s since it is not part of the classpath."
+                            .formatted(protocolName));
                     return null;
                   }
                 })
             .filter(Objects::nonNull)
             .collect(toSet()));
 
+    if (modelProtocolClasses.isEmpty()) {
+      return Set.of(PlainJavaObject.class);
+    }
     return modelProtocolClasses;
   }
 }

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/ModelGenProcessor.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/ModelGenProcessor.java
@@ -15,12 +15,16 @@ import com.flipkart.krystal.model.ModelProtocol;
 import com.flipkart.krystal.model.ModelRoot;
 import com.flipkart.krystal.model.PlainJavaObject;
 import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.model.SupportedModelProtocolName;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Throwables;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -72,7 +76,7 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
                     customCodeGeneratorProvider
                         .getSupportedModelProtocols()
                         .contains(modelProtocol))) {
-          util.error(
+          util.note(
               "No model code generator found supporting model protocol %s for model root %s"
                   .formatted(modelProtocol, modelRoot),
               modelRoot);
@@ -93,24 +97,47 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
       TypeElement modelRootType, CodeGenUtility util) {
     SupportedModelProtocol[] protocols =
         modelRootType.getAnnotationsByType(SupportedModelProtocol.class);
+    SupportedModelProtocolName[] protocolNames =
+        modelRootType.getAnnotationsByType(SupportedModelProtocolName.class);
     if (protocols.length == 0) {
       return Set.of(PlainJavaObject.class);
     }
-    return java.util.Arrays.stream(protocols)
-        .map(p -> util.getTypeElemFromAnnotationMember(p::value))
-        .map(element -> element.getQualifiedName().toString())
-        .map(
-            s -> {
-              try {
-                //noinspection unchecked
-                return (Class<? extends ModelProtocol>)
-                    Class.forName(s, false, this.getClass().getClassLoader());
-              } catch (ClassNotFoundException e) {
-                util.error(Throwables.getStackTraceAsString(e), modelRootType);
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .collect(toSet());
+    Set<Class<? extends ModelProtocol>> modelProtocolClasses =
+        Arrays.stream(protocols)
+            .map(p -> util.getTypeElemFromAnnotationMember(p::value))
+            .map(element -> element.getQualifiedName().toString())
+            .map(
+                s -> {
+                  try {
+                    //noinspection unchecked
+                    return (Class<? extends ModelProtocol>)
+                        Class.forName(s, false, this.getClass().getClassLoader());
+                  } catch (ClassNotFoundException e) {
+                    util.error(Throwables.getStackTraceAsString(e), modelRootType);
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+    modelProtocolClasses.addAll(
+        Arrays.stream(protocolNames)
+            .map(SupportedModelProtocolName::value)
+            .map(
+                s -> {
+                  try {
+                    //noinspection unchecked
+                    return (Class<? extends ModelProtocol>)
+                        Class.forName(s, false, this.getClass().getClassLoader());
+                  } catch (ClassNotFoundException e) {
+                    util.note(
+                        "Skipping processing of model protocol %s since it is not part of the class path.");
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(toSet()));
+
+    return modelProtocolClasses;
   }
 }

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/SharedModelsGenProcessor.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/SharedModelsGenProcessor.java
@@ -42,7 +42,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.ElementFilter;
 import org.jetbrains.annotations.UnknownNullability;
 
 /**
@@ -59,8 +58,11 @@ import org.jetbrains.annotations.UnknownNullability;
 @RunOnlyWhenCodegenPhaseIs(MODELS)
 public final class SharedModelsGenProcessor extends AbstractKrystalAnnoProcessor {
 
+  private VajramCodeGenUtility vajramUtil;
+
   @Override
   protected void processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    this.vajramUtil = new VajramCodeGenUtility(codeGenUtil());
     Set<? extends Element> annotatedElements =
         roundEnv.getElementsAnnotatedWith(InputsForVajram.class);
 
@@ -162,7 +164,10 @@ public final class SharedModelsGenProcessor extends AbstractKrystalAnnoProcessor
     List<DefaultFacetModel> facets = new ArrayList<>();
 
     for (ExecutableElement method :
-        ElementFilter.methodsIn(inputsInterface.getEnclosedElements())) {
+        vajramUtil.extractFacetElements(inputsInterface).stream()
+            .filter(ExecutableElement.class::isInstance)
+            .map(ExecutableElement.class::cast)
+            .toList()) {
       String facetName = method.getSimpleName().toString();
       TypeMirror returnType = method.getReturnType();
       CodeGenType dataType =

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/SharedModelsGenProcessor.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/SharedModelsGenProcessor.java
@@ -1,0 +1,186 @@
+package com.flipkart.krystal.vajram.codegen.processor;
+
+import static com.flipkart.krystal.codegen.common.models.CodegenPhase.MODELS;
+import static com.flipkart.krystal.codegen.common.models.Constants.CODEGEN_PHASE_KEY;
+import static com.flipkart.krystal.codegen.common.models.Constants.MODULE_ROOT_PATH_KEY;
+import static com.flipkart.krystal.codegen.common.models.Constants.SHARED_MODELS_SUB_PACKAGE;
+import static com.flipkart.krystal.core.VajramID.vajramID;
+import static com.flipkart.krystal.facets.FacetType.INPUT;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static java.lang.System.lineSeparator;
+import static java.util.stream.Collectors.joining;
+
+import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
+import com.flipkart.krystal.codegen.common.models.AbstractKrystalAnnoProcessor;
+import com.flipkart.krystal.codegen.common.models.DeclaredTypeVisitor;
+import com.flipkart.krystal.codegen.common.models.RunOnlyWhenCodegenPhaseIs;
+import com.flipkart.krystal.codegen.common.models.TypeNameVisitor;
+import com.flipkart.krystal.core.VajramID;
+import com.flipkart.krystal.data.Request;
+import com.flipkart.krystal.facets.InputsForVajram;
+import com.flipkart.krystal.facets.VajramInputs;
+import com.flipkart.krystal.vajram.codegen.common.models.DefaultFacetModel;
+import com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility;
+import com.flipkart.krystal.vajram.codegen.common.models.VajramInputsInfo;
+import com.google.auto.service.AutoService;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import org.jetbrains.annotations.UnknownNullability;
+
+/**
+ * Annotation processor that generates request interfaces for Vajrams whose inputs are defined
+ * externally via {@link InputsForVajram} annotated interfaces that extend {@link VajramInputs}.
+ *
+ * <p>This processor runs during the MODELS codegen phase and generates the request interface in the
+ * {@code parentPackage.shared_models} package.
+ */
+@SupportedAnnotationTypes("com.flipkart.krystal.facets.InputsForVajram")
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@AutoService(Processor.class)
+@SupportedOptions({CODEGEN_PHASE_KEY, MODULE_ROOT_PATH_KEY})
+@RunOnlyWhenCodegenPhaseIs(MODELS)
+public final class SharedModelsGenProcessor extends AbstractKrystalAnnoProcessor {
+
+  @Override
+  protected void processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    Set<? extends Element> annotatedElements =
+        roundEnv.getElementsAnnotatedWith(InputsForVajram.class);
+
+    VajramCodeGenUtility vajramUtil = new VajramCodeGenUtility(codeGenUtil());
+
+    CharSequence message =
+        "SharedModelsGenProcessor found @InputsForVajram elements: %s"
+            .formatted(
+                annotatedElements.stream()
+                    .map(Objects::toString)
+                    .collect(
+                        joining(lineSeparator(), '[' + lineSeparator(), lineSeparator() + ']')));
+    codeGenUtil().note(message);
+
+    List<Failure> failures = new ArrayList<>();
+    for (Element element : annotatedElements) {
+      if (!(element instanceof TypeElement inputsInterface)) {
+        codeGenUtil().error("@InputsForVajram can only be applied to interfaces", element);
+        continue;
+      }
+      InputsForVajram[] inputsForVajrams =
+          inputsInterface.getAnnotationsByType(InputsForVajram.class);
+      for (InputsForVajram inputsForVajram : inputsForVajrams) {
+        try {
+          processInputsForVajram(vajramUtil, inputsInterface, inputsForVajram);
+        } catch (Exception e) {
+          failures.add(new Failure(inputsInterface, e));
+        }
+      }
+    }
+
+    for (Failure failure : failures) {
+      codeGenUtil()
+          .error(
+              "[SharedModels Codegen Exception] " + getStackTraceAsString(failure.throwable()),
+              failure.element());
+    }
+  }
+
+  private void processInputsForVajram(
+      @UnknownNullability VajramCodeGenUtility vajramUtil,
+      TypeElement inputsInterface,
+      InputsForVajram inputsForVajram) {
+    String parentPackage = inputsForVajram.parentPackage();
+    String requestPackage = parentPackage + "." + SHARED_MODELS_SUB_PACKAGE;
+
+    // Extract response type from VajramInputs<T>
+    CodeGenType responseType = extractResponseType(inputsInterface);
+
+    VajramID vajramId = vajramID(inputsForVajram.vajramId());
+    List<DefaultFacetModel> inputs = buildInputFacets(inputsInterface, vajramId);
+    VajramInputsInfo inputsInfo =
+        new VajramInputsInfo(
+            vajramId, responseType, requestPackage, inputs, Collections.emptyList(), false);
+    // Build input facet models from the interface methods
+
+    // Compute request super types (extends Request<ResponseType>)
+    TypeName responseTypeName =
+        new TypeNameVisitor(true).visit(responseType.typeMirror(codeGenUtil().processingEnv()));
+    Iterable<TypeName> requestSuperTypes =
+        List.of(ParameterizedTypeName.get(ClassName.get(Request.class), responseTypeName.box()));
+
+    VajramCodeGenerator generator = new VajramCodeGenerator(inputsInfo, vajramUtil);
+    generator.generateVajramRequest(
+        inputsInfo,
+        inputs,
+        requestSuperTypes,
+        inputsInterface.getQualifiedName().toString(),
+        inputsInterface,
+        inputsInterface,
+        inputsInfo);
+  }
+
+  private CodeGenType extractResponseType(TypeElement inputsInterface) {
+    // Find VajramInputs<T> in the interface's superinterfaces
+    for (TypeMirror superInterface : inputsInterface.getInterfaces()) {
+      if (superInterface instanceof DeclaredType declaredType) {
+        Element superElement = declaredType.asElement();
+        if (superElement instanceof TypeElement typeElement
+            && typeElement
+                .getQualifiedName()
+                .contentEquals(VajramInputs.class.getCanonicalName())) {
+          List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+          if (typeArgs.size() == 1) {
+            return typeArgs
+                .get(0)
+                .accept(new DeclaredTypeVisitor(codeGenUtil(), inputsInterface), null);
+          }
+        }
+      }
+    }
+    throw codeGenUtil()
+        .errorAndThrow(
+            "@InputsForVajram interface must extend VajramInputs<T> where T is the response type",
+            inputsInterface);
+  }
+
+  private List<DefaultFacetModel> buildInputFacets(TypeElement inputsInterface, VajramID vajramID) {
+    List<DefaultFacetModel> facets = new ArrayList<>();
+
+    for (ExecutableElement method :
+        ElementFilter.methodsIn(inputsInterface.getEnclosedElements())) {
+      String facetName = method.getSimpleName().toString();
+      TypeMirror returnType = method.getReturnType();
+      CodeGenType dataType =
+          returnType.accept(new DeclaredTypeVisitor(codeGenUtil(), method), null);
+
+      DefaultFacetModel facet =
+          DefaultFacetModel.builder()
+              .name(facetName)
+              .vajramId(vajramID)
+              .dataType(dataType)
+              .documentation(codeGenUtil().processingEnv().getElementUtils().getDocComment(method))
+              .facetType(INPUT)
+              .facetElement(method)
+              .build();
+      facets.add(facet);
+    }
+    return facets;
+  }
+
+  private record Failure(TypeElement element, Throwable throwable) {}
+}

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramCodeGenerator.java
@@ -28,7 +28,6 @@ import static com.flipkart.krystal.vajram.codegen.common.models.Constants._INPUT
 import static com.flipkart.krystal.vajram.codegen.common.models.Constants._INTERNAL_FACETS_CLASS;
 import static com.flipkart.krystal.vajram.codegen.common.models.ParsedVajramData.fromVajramInfo;
 import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getImmutFacetsClassName;
-import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getImmutRequestPojoName;
 import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getRequestInterfaceName;
 import static com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility.getVajramImplClassName;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -78,6 +77,7 @@ import com.flipkart.krystal.except.KrystalCompletionException;
 import com.flipkart.krystal.facets.Facet;
 import com.flipkart.krystal.facets.FacetType;
 import com.flipkart.krystal.facets.FacetUtils;
+import com.flipkart.krystal.facets.InputsForVajram;
 import com.flipkart.krystal.facets.resolution.ResolutionTarget;
 import com.flipkart.krystal.facets.resolution.ResolverCommand;
 import com.flipkart.krystal.facets.resolution.ResolverCommand.ExecuteDependency;
@@ -90,6 +90,8 @@ import com.flipkart.krystal.model.ModelRoot.ModelType;
 import com.flipkart.krystal.model.PlainJavaObject;
 import com.flipkart.krystal.model.SupportedModelProtocol;
 import com.flipkart.krystal.model.SupportedModelProtocol.SupportedModelProtocols;
+import com.flipkart.krystal.model.SupportedModelProtocolName;
+import com.flipkart.krystal.model.SupportedModelProtocolName.SupportedModelProtocolNames;
 import com.flipkart.krystal.serial.DefaultSerdeProtocol;
 import com.flipkart.krystal.serial.ReservedSerialIds;
 import com.flipkart.krystal.serial.SerialId;
@@ -212,6 +214,8 @@ public class VajramCodeGenerator implements CodeGenerator {
                   ReservedSerialIds.class,
                   SupportedModelProtocol.class,
                   SupportedModelProtocols.class,
+                  SupportedModelProtocolName.class,
+                  SupportedModelProtocolNames.class,
                   DefaultSerdeProtocol.class)
               .<@NonNull String>map(aClass -> requireNonNull(aClass.getCanonicalName()))
               .toList());
@@ -296,7 +300,11 @@ public class VajramCodeGenerator implements CodeGenerator {
   }
 
   private boolean areInputsExternal() {
-    return vajramUtil.getExternalInputsElement(currentVajramInfo().inputsElement()) != null;
+    TypeElement inputsElement = currentVajramInfo().inputsSource();
+    if (inputsElement == null) {
+      return false;
+    }
+    return inputsElement.getAnnotation(InputsForVajram.class) != null;
   }
 
   private void validate() {
@@ -318,7 +326,7 @@ public class VajramCodeGenerator implements CodeGenerator {
         currentVajramInfo().requestInterfaceSuperTypes(),
         currentVajramInfo().vajramClassElem().getQualifiedName().toString(),
         currentVajramInfo().vajramClassElem(),
-        currentVajramInfo().inputsElement(),
+        currentVajramInfo().inputsSource(),
         currentVajramInfo().conformsToTraitOrSelf().inputsInfo());
   }
 
@@ -496,8 +504,7 @@ public class VajramCodeGenerator implements CodeGenerator {
     wrapperConstructor(vajramWrapperClass);
 
     ClassName requestInterfaceType = getRequestInterfaceType();
-    ClassName immutRequestType =
-        ClassName.get(vajramPackageName(), getImmutRequestPojoName(vajramName));
+    ClassName immutRequestType = currentVajramInfo().lite().inputsInfo().reqImmutPojoClassName();
     ClassName immutFacetsType =
         ClassName.get(vajramPackageName(), getImmutFacetsClassName(vajramName));
 
@@ -1003,7 +1010,10 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     String facetName = parameter.getSimpleName().toString();
     FacetGenModel facetGenModel = facetModelsByName.get(facetName);
     if (facetGenModel == null) {
-      throw util.errorAndThrow("Unknown facet with name %s".formatted(facetName), parameter);
+      throw util.errorAndThrow(
+          "Unknown facet with name '%s'. Known facets: %s"
+              .formatted(facetName, facetModelsByName.keySet()),
+          parameter);
     }
     return facetGenModel;
   }
@@ -2288,7 +2298,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
    * compatibility reasons.
    */
   private void validateSerialIdReservations() {
-    Element inputsElement = currentVajramInfo().inputsElement();
+    Element inputsElement = currentVajramInfo().inputsSource();
     if (inputsElement == null) {
       return;
     }

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramCodeGenerator.java
@@ -117,7 +117,7 @@ import com.flipkart.krystal.vajram.codegen.common.models.LogicMethods.OutputLogi
 import com.flipkart.krystal.vajram.codegen.common.models.ParsedVajramData;
 import com.flipkart.krystal.vajram.codegen.common.models.VajramCodeGenUtility;
 import com.flipkart.krystal.vajram.codegen.common.models.VajramInfo;
-import com.flipkart.krystal.vajram.codegen.common.models.VajramInfoLite;
+import com.flipkart.krystal.vajram.codegen.common.models.VajramInputsInfo;
 import com.flipkart.krystal.vajram.codegen.common.spi.VajramCodeGenContext;
 import com.flipkart.krystal.vajram.exception.VajramDefinitionException;
 import com.flipkart.krystal.vajram.facets.DependencyCommand;
@@ -181,6 +181,7 @@ import java.util.stream.Stream;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.QualifiedNameable;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
@@ -215,40 +216,49 @@ public class VajramCodeGenerator implements CodeGenerator {
               .<@NonNull String>map(aClass -> requireNonNull(aClass.getCanonicalName()))
               .toList());
 
-  private final String packageName;
-  private final VajramInfo currentVajramInfo;
+  private final @Nullable String packageName;
+  private final String requestPackageName;
+  private final @Nullable VajramInfo currentVajramInfo;
 
-  private final Map<Integer, FacetGenModel> facetModels;
   private final Map<String, FacetGenModel> facetModelsByName;
   private final boolean needsBatching;
-  private final Map<Integer, Boolean> depFanoutMap;
-  private final CodegenPhase codegenPhase;
+  private final Map<String, Boolean> depFanoutMap;
+  private final @Nullable CodegenPhase codegenPhase;
   private final VajramCodeGenUtility vajramUtil;
   private final CodeGenUtility util;
-  private final String vajramName;
+  private final @Nullable String vajramName;
   private final Types typeUtils;
   private final Elements elementUtils;
 
   private @MonotonicNonNull ParsedVajramData parsedVajramData;
 
+  /**
+   * Constructor for request-only generation. Used by the shared models processor which does not
+   * have a full VajramInfo available.
+   */
+  public VajramCodeGenerator(VajramInputsInfo vajramInputsInfo, VajramCodeGenUtility vajramUtil) {
+    this.vajramUtil = vajramUtil;
+    this.util = vajramUtil.codegenUtil();
+    this.typeUtils = util.processingEnv().getTypeUtils();
+    this.elementUtils = util.processingEnv().getElementUtils();
+    this.currentVajramInfo = null;
+    this.requestPackageName = vajramInputsInfo.requestPackageName();
+    this.packageName = null;
+    this.facetModelsByName = Map.of();
+    this.needsBatching = false;
+    this.depFanoutMap = Map.of();
+    this.codegenPhase = CodegenPhase.MODELS;
+    this.vajramName = vajramInputsInfo.vajramName();
+  }
+
   public VajramCodeGenerator(VajramCodeGenContext creationContext) {
     this.currentVajramInfo = creationContext.vajramInfo();
-    this.packageName = creationContext.vajramInfo().lite().packageName();
+    this.packageName = creationContext.vajramInfo().packageName();
+    this.requestPackageName = creationContext.vajramInfo().lite().inputsInfo().requestPackageName();
     this.vajramUtil = creationContext.util();
     this.util = vajramUtil.codegenUtil();
     this.typeUtils = util.processingEnv().getTypeUtils();
     this.elementUtils = util.processingEnv().getElementUtils();
-    // noinspection Convert2MethodRef
-    this.facetModels =
-        creationContext
-            .vajramInfo()
-            .facetStream()
-            .collect(
-                toMap(
-                    FacetGenModel::id,
-                    Function.identity(),
-                    (o1, o2) -> o1,
-                    () -> new LinkedHashMap<>()));
     // noinspection Convert2MethodRef
     this.facetModelsByName =
         creationContext
@@ -264,23 +274,29 @@ public class VajramCodeGenerator implements CodeGenerator {
         creationContext.vajramInfo().givenFacets().stream().anyMatch(DefaultFacetModel::isBatched);
     this.depFanoutMap =
         creationContext.vajramInfo().dependencies().stream()
-            .collect(toMap(DependencyModel::id, DependencyModel::canFanout));
+            .collect(toMap(DependencyModel::name, DependencyModel::canFanout));
     this.codegenPhase = creationContext.codegenPhase();
-    this.vajramName = currentVajramInfo.vajramName();
+    this.vajramName = currentVajramInfo().vajramName();
   }
 
   @Override
   public void generate() {
     validate();
     if (CodegenPhase.MODELS.equals(codegenPhase)) {
-      vajramRequest();
+      if (!areInputsExternal()) {
+        vajramRequest();
+      }
       // Generate facets classes only for Vajrams and not for Traits
-      if (currentVajramInfo.vajramClassElem().getAnnotation(Vajram.class) != null) {
+      if (currentVajramInfo().vajramClassElem().getAnnotation(Vajram.class) != null) {
         vajramFacets();
       }
     } else if (CodegenPhase.FINAL.equals(codegenPhase)) {
       vajramWrapper();
     }
+  }
+
+  private boolean areInputsExternal() {
+    return vajramUtil.getExternalInputsElement(currentVajramInfo().inputsElement()) != null;
   }
 
   private void validate() {
@@ -294,38 +310,62 @@ public class VajramCodeGenerator implements CodeGenerator {
   }
 
   private void vajramRequest() {
-    ClassName requestInterfaceType = currentVajramInfo.lite().requestInterfaceClassName();
-    TypeMirror responseType =
-        currentVajramInfo.lite().responseType().typeMirror(util.processingEnv());
+    generateVajramRequest(
+        requireNonNull(currentVajramInfo()).lite().inputsInfo(),
+        currentVajramInfo().givenFacets().stream()
+            .filter(facetDef -> facetDef.facetType().equals(INPUT))
+            .toList(),
+        currentVajramInfo().requestInterfaceSuperTypes(),
+        currentVajramInfo().vajramClassElem().getQualifiedName().toString(),
+        currentVajramInfo().vajramClassElem(),
+        currentVajramInfo().inputsElement(),
+        currentVajramInfo().conformsToTraitOrSelf().inputsInfo());
+  }
+
+  /**
+   * Generates the vajram request interface. This method can be used both for vajrams that define
+   * inputs inside their class and for vajrams that define inputs externally via {@link
+   * com.flipkart.krystal.facets.InputsForVajram}.
+   *
+   * @param inputsInfo the inputs information for the vajram
+   * @param inputs the input facets
+   * @param requestSuperTypes the super types for the request interface
+   * @param originatingQualifiedName the qualified name of the originating element (for Javadoc)
+   * @param originatingElement the originating element (for source file generation)
+   * @param annotationsSource the element from which to extract model annotations (nullable)
+   * @param conformsToTraitInputsInfo the inputs info of the trait this vajram conforms to, or the
+   *     vajram's own inputs info if it doesn't conform to a trait
+   */
+  public void generateVajramRequest(
+      VajramInputsInfo inputsInfo,
+      List<DefaultFacetModel> inputs,
+      Iterable<TypeName> requestSuperTypes,
+      String originatingQualifiedName,
+      TypeElement originatingElement,
+      @Nullable Element annotationsSource,
+      VajramInputsInfo conformsToTraitInputsInfo) {
+    ClassName requestInterfaceType = inputsInfo.requestInterfaceClassName();
+    TypeMirror responseType = inputsInfo.responseType().typeMirror(util.processingEnv());
     TypeName responseTypeName = new TypeNameVisitor(true).visit(responseType);
     List<TypeVariableName> typeVariableNames = new ArrayList<>();
     if (responseTypeName instanceof TypeVariableName typeVariableName) {
       typeVariableNames = List.of(typeVariableName);
     }
-    List<DefaultFacetModel> inputs =
-        currentVajramInfo.givenFacets().stream()
-            .filter(facetDef -> facetDef.facetType().equals(INPUT))
-            .toList();
 
     TypeSpec.Builder requestInterface =
         util.interfaceBuilder(
-                requestInterfaceType.simpleName(),
-                typeVariableNames,
-                currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                requestInterfaceType.simpleName(), typeVariableNames, originatingQualifiedName)
             .addModifiers(PUBLIC)
-            .addAnnotation(
-                currentVajramInfo.lite().isTrait()
-                    ? TraitRequestRoot.class
-                    : VajramRequestRoot.class)
-            .addAnnotation(buildReqModelRootAnnotation())
-            .addAnnotations(getModelClassAnnotations())
-            .addSuperinterfaces(currentVajramInfo.requestInterfaceSuperTypes());
+            .addAnnotation(inputsInfo.isTrait() ? TraitRequestRoot.class : VajramRequestRoot.class)
+            .addAnnotation(buildReqModelRootAnnotation(annotationsSource))
+            .addAnnotations(getModelClassAnnotations(annotationsSource))
+            .addSuperinterfaces(requestSuperTypes);
 
     // Add VAJRAM_ID constant to the request interface
     FieldSpec vajramIdField =
         FieldSpec.builder(VajramID.class, VAJRAM_ID_CONSTANT_NAME)
             .addModifiers(PUBLIC, STATIC, FINAL)
-            .initializer("$T.vajramID($S)", VajramID.class, vajramName)
+            .initializer("$T.vajramID($S)", VajramID.class, inputsInfo.vajramName())
             .addJavadoc("The VajramID for this Vajram")
             .build();
     requestInterface.addField(vajramIdField);
@@ -342,24 +382,29 @@ public class VajramCodeGenerator implements CodeGenerator {
         MethodSpec.methodBuilder("_builder")
             .addModifiers(PUBLIC, STATIC)
             .addTypeVariables(
-                currentVajramInfo.lite().typeArguments().stream()
+                inputsInfo.typeArguments().stream()
                     .filter(TypeVariable.class::isInstance)
                     .map(TypeVariable.class::cast)
                     .map(TypeVariableName::get)
                     .toList())
-            .returns(currentVajramInfo.lite().reqBuilderInterfaceType())
+            .returns(inputsInfo.reqBuilderInterfaceType())
             .addStatement(
                 "return $T.$L_builder()",
-                currentVajramInfo.lite().reqImmutPojoClassName(),
-                currentVajramInfo.lite().typeArguments().isEmpty()
+                inputsInfo.reqImmutPojoClassName(),
+                inputsInfo.typeArguments().isEmpty()
                     ? EMPTY_CODE_BLOCK
-                    : currentVajramInfo.lite().typeArguments().stream()
+                    : inputsInfo.typeArguments().stream()
                         .map(new TypeNameVisitor(true)::visit)
                         .map(t -> CodeBlock.of("$T", t))
                         .collect(CodeBlock.joining(", ", "<", ">")))
             .build());
 
-    facetConstants(requestInterface, inputs, CodeGenParams.builder().isRequest(true).build());
+    facetConstants(
+        requestInterface,
+        inputs,
+        CodeGenParams.builder().isRequest(true).build(),
+        inputsInfo,
+        conformsToTraitInputsInfo);
     modelsClassMembers(
         requestInterface,
         requestInterfaceType,
@@ -369,23 +414,22 @@ public class VajramCodeGenerator implements CodeGenerator {
     util.generateSourceFile(
         requestInterfaceType.canonicalName(),
         JavaFile.builder(
-                packageName,
+                inputsInfo.requestPackageName(),
                 requestInterface
                     .addMethods(
                         facetContainerMethods(
                             inputs,
-                            currentVajramInfo.lite().requestInterfaceClassName(),
-                            currentVajramInfo.lite().reqImmutInterfaceTypeName(),
-                            currentVajramInfo.lite().reqBuilderInterfaceType(),
+                            inputsInfo.requestInterfaceClassName(),
+                            inputsInfo.reqImmutInterfaceTypeName(),
+                            inputsInfo.reqBuilderInterfaceType(),
                             CodeGenParams.builder().isRequest(true).build()))
                     .build())
             .build()
             .toString(),
-        currentVajramInfo.vajramClassElem());
+        originatingElement);
   }
 
-  private AnnotationSpec buildReqModelRootAnnotation() {
-    Element protocolSource = currentVajramInfo.inputsElement();
+  private AnnotationSpec buildReqModelRootAnnotation(@Nullable Element protocolSource) {
     return AnnotationSpec.builder(ModelRoot.class)
         .addMember("type", CodeBlock.of("{$T.$L}", ModelType.class, ModelType.REQUEST.name()))
         .addMember("suffixSeparator", CodeBlock.of("$S", ""))
@@ -403,8 +447,7 @@ public class VajramCodeGenerator implements CodeGenerator {
    * Returns the list of model class annotations (e.g. {@link ReservedSerialIds}) from the {@code
    * _Inputs} element.
    */
-  private List<AnnotationSpec> getModelClassAnnotations() {
-    Element source = currentVajramInfo.inputsElement();
+  private List<AnnotationSpec> getModelClassAnnotations(@Nullable Element source) {
     if (source == null) {
       return List.of();
     }
@@ -422,10 +465,14 @@ public class VajramCodeGenerator implements CodeGenerator {
   public void vajramFacets() {
     basicFacetsClasses();
     boolean doInputsNeedBatching =
-        currentVajramInfo.facetStream().anyMatch(FacetGenModel::isBatched);
+        currentVajramInfo().facetStream().anyMatch(FacetGenModel::isBatched);
     if (doInputsNeedBatching) {
       batchFacetsClasses();
     }
+  }
+
+  private VajramInfo currentVajramInfo() {
+    return requireNonNull(currentVajramInfo);
   }
 
   /**
@@ -437,22 +484,24 @@ public class VajramCodeGenerator implements CodeGenerator {
     final TypeSpec.Builder vajramWrapperClass =
         util.classBuilder(
                 getVajramImplClassName(vajramName),
-                currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                currentVajramInfo().vajramClassElem().getQualifiedName().toString())
             .addModifiers(PUBLIC, FINAL);
     List<MethodSpec> methodSpecs = new ArrayList<>();
     // Add superType
-    if (currentVajramInfo.lite().isTrait()) {
-      vajramWrapperClass.addSuperinterface(ClassName.get(currentVajramInfo.vajramClassElem()));
+    if (currentVajramInfo().lite().isTrait()) {
+      vajramWrapperClass.addSuperinterface(ClassName.get(currentVajramInfo().vajramClassElem()));
     } else {
-      vajramWrapperClass.superclass(ClassName.get(currentVajramInfo.vajramClassElem()));
+      vajramWrapperClass.superclass(ClassName.get(currentVajramInfo().vajramClassElem()));
     }
     wrapperConstructor(vajramWrapperClass);
 
     ClassName requestInterfaceType = getRequestInterfaceType();
-    ClassName immutRequestType = ClassName.get(packageName, getImmutRequestPojoName(vajramName));
-    ClassName immutFacetsType = ClassName.get(packageName, getImmutFacetsClassName(vajramName));
+    ClassName immutRequestType =
+        ClassName.get(vajramPackageName(), getImmutRequestPojoName(vajramName));
+    ClassName immutFacetsType =
+        ClassName.get(vajramPackageName(), getImmutFacetsClassName(vajramName));
 
-    if (currentVajramInfo.lite().isVajram()) {
+    if (currentVajramInfo().lite().isVajram()) {
 
       // Initialize few common attributes and data structures
       MethodSpec inputResolversMethod = createInputResolvers();
@@ -478,7 +527,7 @@ public class VajramCodeGenerator implements CodeGenerator {
               .addStatement(
                   "return new $T(($T)$L)",
                   immutFacetsType.nestedClass("Builder"),
-                  currentVajramInfo.conformsToTraitOrSelf().requestInterfaceClassName(),
+                  currentVajramInfo().conformsToTraitOrSelf().requestInterfaceClassName(),
                   "request")
               .build());
       vajramWrapperClass.addMethod(executeGraph());
@@ -487,7 +536,7 @@ public class VajramCodeGenerator implements CodeGenerator {
     StringWriter writer = new StringWriter();
     try {
       JavaFile.builder(
-              packageName,
+              vajramPackageName(),
               vajramWrapperClass
                   .addMethods(methodSpecs)
                   .addMethod(
@@ -511,26 +560,26 @@ public class VajramCodeGenerator implements CodeGenerator {
       throw new RuntimeException(e);
     }
     String className =
-        currentVajramInfo.lite().packageName()
+        currentVajramInfo().packageName()
             + '.'
-            + getVajramImplClassName(currentVajramInfo.lite().vajramId().id());
+            + getVajramImplClassName(currentVajramInfo().lite().vajramId().id());
 
     try {
-      util.generateSourceFile(className, writer.toString(), currentVajramInfo.vajramClassElem());
+      util.generateSourceFile(className, writer.toString(), currentVajramInfo().vajramClassElem());
     } catch (Exception e) {
       StringWriter exception = new StringWriter();
       e.printStackTrace(new PrintWriter(exception));
       util.error(
           "Error while generating file for class %s. Exception: %s".formatted(className, exception),
-          currentVajramInfo.vajramClassElem());
+          currentVajramInfo().vajramClassElem());
     }
   }
 
   private void wrapperConstructor(TypeSpec.Builder wrapperClassBuilder) {
     CodeBlock.Builder constructorBody = CodeBlock.builder();
-    if (currentVajramInfo.lite().isVajram()) {
+    if (currentVajramInfo().lite().isVajram()) {
       boolean simpleInputResolversMethodPresent =
-          currentVajramInfo.vajramClassElem().getEnclosedElements().stream()
+          currentVajramInfo().vajramClassElem().getEnclosedElements().stream()
               .filter(e -> e instanceof ExecutableElement)
               .anyMatch(e -> e.getSimpleName().contentEquals(GET_SIMPLE_INPUT_RESOLVERS));
 
@@ -539,7 +588,7 @@ public class VajramCodeGenerator implements CodeGenerator {
           "_inputResolvers",
           PRIVATE);
 
-      for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+      for (DependencyModel dependency : currentVajramInfo().dependencies()) {
         String fieldName = prependUnderscore(dependency.name() + "_reqBuilderSupplier");
         ParameterizedTypeName fieldType =
             ParameterizedTypeName.get(
@@ -555,12 +604,12 @@ public class VajramCodeGenerator implements CodeGenerator {
         """,
             fieldName,
             fieldType,
-            currentVajramInfo.facetsInterfaceType(),
+            currentVajramInfo().facetsInterfaceType(),
             dependency.name() + FACET_SPEC_SUFFIX,
             dependency.depVajramInfo().reqImmutPojoClassName());
       }
       List<CodeBlock> cases = new ArrayList<>();
-      for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+      for (DependencyModel dependency : currentVajramInfo().dependencies()) {
         if (dependency.canFanout()) {
           wrapperClassBuilder.addField(
               FanoutInputResolver.class,
@@ -573,7 +622,7 @@ public class VajramCodeGenerator implements CodeGenerator {
         constructorBody.addStatement("$T $L = new $T()", depFacetsType, fieldName, ArrayList.class);
       }
       if (simpleInputResolversMethodPresent) {
-        for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+        for (DependencyModel dependency : currentVajramInfo().dependencies()) {
           ParameterizedTypeName depFacetsType = ParameterizedTypeName.get(Set.class, Facet.class);
           @SuppressWarnings("SpellCheckingInspection")
           String depFacetsName = prependUnderscore(dependency.name() + "_depFacets");
@@ -582,7 +631,7 @@ public class VajramCodeGenerator implements CodeGenerator {
         }
       }
 
-      for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+      for (DependencyModel dependency : currentVajramInfo().dependencies()) {
         cases.add(
             CodeBlock.of(
 """
@@ -609,7 +658,7 @@ $L
                         \""");
 """,
                         VajramDefinitionException.class,
-                        currentVajramInfo.lite().vajramId().id(),
+                        currentVajramInfo().lite().vajramId().id(),
                         dependency.name()),
                 One2OneInputResolver.class,
                 dependency.name(),
@@ -635,7 +684,7 @@ $L
           cases.stream().collect(CodeBlock.joining("")));
     }
 
-    for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+    for (DependencyModel dependency : currentVajramInfo().dependencies()) {
       String fieldName = prependUnderscore(dependency.name() + "_one2oneInputResolvers");
       constructorBody.addStatement("this.$L = $L", fieldName, fieldName);
     }
@@ -658,7 +707,7 @@ $L
             util.getMethod(
                 () -> VajramDef.class.getMethod("executeGraph", GraphExecutionData.class)));
     boolean simpleInputResolversMethodPresent =
-        currentVajramInfo.vajramClassElem().getEnclosedElements().stream()
+        currentVajramInfo().vajramClassElem().getEnclosedElements().stream()
             .filter(e -> e instanceof ExecutableElement)
             .anyMatch(e -> e.getSimpleName().contentEquals(GET_SIMPLE_INPUT_RESOLVERS));
 
@@ -667,7 +716,7 @@ $L
     Map<String, List<ExecutableElement>> resolverMethodsByDependency =
         getResolverMethodsByDependency();
 
-    for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+    for (DependencyModel dependency : currentVajramInfo().dependencies()) {
       @SuppressWarnings("SpellCheckingInspection")
       Map<String, Object> commonNamesMap =
           Map.ofEntries(
@@ -678,9 +727,9 @@ $L
               entry("depReqIface", dependency.depVajramInfo().requestInterfaceTypeName()),
               entry("reqBuilder", dependency.depVajramInfo().reqBuilderInterfaceType()),
               entry("reqImmutType", dependency.depVajramInfo().reqImmutInterfaceTypeName()),
-              entry("facImmutPojo", currentVajramInfo.facetsImmutPojoType()),
-              entry("fac", currentVajramInfo.facetsInterfaceType()),
-              entry("reqType", currentVajramInfo.lite().requestInterfaceTypeName()),
+              entry("facImmutPojo", currentVajramInfo().facetsImmutPojoType()),
+              entry("fac", currentVajramInfo().facetsInterfaceType()),
+              entry("reqType", currentVajramInfo().lite().requestInterfaceTypeName()),
               entry(
                   "depType",
                   util.box(
@@ -929,12 +978,12 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
         CompletableFuture.class,
         Void.class,
         HashMap.class);
-    for (DependencyModel dependency : currentVajramInfo.dependencies()) {
+    for (DependencyModel dependency : currentVajramInfo().dependencies()) {
       executeGraph.addCode(
           "var _$L_ready = new $T<$T>();", dependency.name(), CompletableFuture.class, Void.class);
       executeGraph.addCode(
           "_futuresByFacet.put($T.$L_s, _$L_ready);",
-          currentVajramInfo.facetsInterfaceType(),
+          currentVajramInfo().facetsInterfaceType(),
           dependency.name(),
           dependency.name());
       executeGraph.addCode("\n");
@@ -980,7 +1029,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
         (depName, resolverMethods) -> {
           @SuppressWarnings("method.invocation")
           DependencyModel dep =
-              currentVajramInfo.dependencies().stream()
+              currentVajramInfo().dependencies().stream()
                   .filter(d -> d.name().equals(depName))
                   .findAny()
                   .orElseThrow();
@@ -1031,11 +1080,11 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                                 .flatMap(
                                     facet ->
                                         Stream.of(
-                                            currentVajramInfo.facetsInterfaceType(),
+                                            currentVajramInfo().facetsInterfaceType(),
                                             facet.name() + FACET_SPEC_SUFFIX))
                                 .toArray()),
                         ResolutionTarget.class,
-                        currentVajramInfo.facetsInterfaceType(),
+                        currentVajramInfo().facetsInterfaceType(),
                         dep.name() + FACET_SPEC_SUFFIX,
                         ImmutableSet.class,
                         CodeBlock.of(
@@ -1087,15 +1136,15 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
   private ParsedVajramData initParsedVajramData() {
     if (parsedVajramData == null) {
       this.parsedVajramData =
-          fromVajramInfo(currentVajramInfo, vajramUtil)
+          fromVajramInfo(currentVajramInfo(), vajramUtil)
               .orElseThrow(
                   () ->
                       util.errorAndThrow(
                           """
                                         Could not load Vajram class for vajramDef %s.
                                         ParsedVajram Data should never be accessed in model generation phase."""
-                              .formatted(currentVajramInfo.lite().vajramId()),
-                          currentVajramInfo.vajramClassElem()));
+                              .formatted(currentVajramInfo().lite().vajramId()),
+                          currentVajramInfo().vajramClassElem()));
     }
     return parsedVajramData;
   }
@@ -1130,7 +1179,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
           getParsedVajramData().vajramInfo().givenFacets().stream()
               .filter(DefaultFacetModel::isBatched)
               .findAny()
-              .<Element>map(DefaultFacetModel::facetElement)
+              .map(DefaultFacetModel::facetElement)
               .orElse(getParsedVajramData().vajramInfo().vajramClassElem()));
     } else { // TODO : Need non batched IO vajramDef to test this
       nonBatchedExecuteMethodBuilder(executeBuilder, false);
@@ -1172,7 +1221,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
           outputLogicParams);
     } else {
       TypeMirror expectedReturnType =
-          currentVajramInfo.lite().responseType().typeMirror(util.processingEnv());
+          currentVajramInfo().lite().responseType().typeMirror(util.processingEnv());
       if (!typeUtils.isSameType(util.box(returnType), util.box(expectedReturnType))) {
         util.error(
             "The OutputLogic of the Compute vajram %s must return %s"
@@ -1201,9 +1250,9 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
         }
         """,
         ExecutionItem.class,
-        currentVajramInfo.facetsInterfaceType(),
+        currentVajramInfo().facetsInterfaceType(),
         FACET_VALUES_VAR,
-        currentVajramInfo.facetsInterfaceType(),
+        currentVajramInfo().facetsInterfaceType(),
         facetLocalVars,
         returnBuilder.build());
   }
@@ -1252,7 +1301,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     CodeBlock.Builder codeBuilder = CodeBlock.builder();
 
     ImmutableMap<String, FacetGenModel> facets =
-        currentVajramInfo
+        currentVajramInfo()
             .facetStream()
             .collect(toImmutableMap(FacetGenModel::name, Function.identity()));
 
@@ -1309,7 +1358,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     valueMap.put("facetValuesList", FACETS_LIST);
     valueMap.put("logicInput", OUTPUT_LOGIC_INPUT_VAR);
     valueMap.put("facetsVar", FACET_VALUES_VAR);
-    valueMap.put("facetsInterface", currentVajramInfo.facetsInterfaceType());
+    valueMap.put("facetsInterface", currentVajramInfo().facetsInterfaceType());
     valueMap.put("inputBatching", getBatchItemIfaceName());
     valueMap.put("commonInput", getCommonFacetsClassName());
     valueMap.put("vajramResponseType", vajramResponseTypeName);
@@ -1534,7 +1583,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
             "No facet with the name "
                 + param.getSimpleName()
                 + " exists in the vajramDef "
-                + currentVajramInfo.lite().vajramId();
+                + currentVajramInfo().lite().vajramId();
         @Nullable Element[] elements = param.elementArray();
         util.error(message, elements);
       } else if (!facet.isUsedToGroupBatches()) {
@@ -1591,7 +1640,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     codeBuilder.addStatement(
         "var $L = (($T)_rawFacetValues)",
         FACET_VALUES_VAR,
-        currentVajramInfo.facetsInterfaceType());
+        currentVajramInfo().facetsInterfaceType());
     // TODO : add validation if fanout, then method should accept dependencyDef
     // response for the
     // bind type parameter else error
@@ -1631,7 +1680,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     FacetGenModel usingFacetModel = inferFacet(parameter);
     CodeBlock facetLocalVarCode = EMPTY_CODE_BLOCK;
     if (usingFacetModel instanceof DependencyModel) {
-      facetLocalVarCode = depFacetLocalVariable(method, usingFacetModel.id(), parameter);
+      facetLocalVarCode = depFacetLocalVariable(method, usingFacetModel.name(), parameter);
     } else if (usingFacetModel instanceof DefaultFacetModel defaultFacetModel) {
       TypeMirror facetType = defaultFacetModel.dataType().typeMirror(util.processingEnv());
       TypeMirror parameterTypeMirror = parameter.asType();
@@ -1651,7 +1700,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                     FacetValidation.class,
                     facetsVar,
                     usingFacetModel.name(),
-                    currentVajramInfo.lite().vajramId().id(),
+                    currentVajramInfo().lite().vajramId().id(),
                     usingFacetModel.name())
                 .build();
       } else if (util.isOptional(parameterTypeMirror)) {
@@ -1692,17 +1741,17 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
    * @param parameter the bind parameter in the resolver method
    */
   private CodeBlock depFacetLocalVariable(
-      ExecutableElement method, final int usingFacetId, VariableElement parameter) {
+      ExecutableElement method, final String usingFacetId, VariableElement parameter) {
     CodeBlock returnValue = EMPTY_CODE_BLOCK;
-    FacetGenModel usingFacetDef = checkNotNull(facetModels.get(usingFacetId));
+    FacetGenModel usingFacetDef = checkNotNull(facetModelsByName.get(usingFacetId));
 
     TypeMirror parameterType = parameter.asType();
     String usingFacetName = usingFacetDef.name();
     // ReturnType returnType
     if (usingFacetDef instanceof DependencyModel dependencyModel) {
       String variableName = usingFacetName;
-      final VajramInfoLite depVajramInfoLite = dependencyModel.depVajramInfo();
-      TypeName boxedDepType = util.toTypeName(depVajramInfoLite.responseType()).box();
+      final VajramInputsInfo depVajramInputsInfo = dependencyModel.depVajramInfo();
+      TypeName boxedDepType = util.toTypeName(depVajramInputsInfo.responseType()).box();
       TypeName unboxedDepType =
           boxedDepType.isBoxedPrimitive() ? boxedDepType.unbox() : boxedDepType;
       String logicName = method.getSimpleName().toString();
@@ -1752,7 +1801,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                     FACET_VALUES_VAR,
                     usingFacetName,
                     FacetValidation.class,
-                    currentVajramInfo.lite().vajramId().id(),
+                    currentVajramInfo().lite().vajramId().id(),
                     usingFacetName);
           } else {
             // This means the dependency being consumed is mandatory, but the type of the
@@ -2015,10 +2064,11 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     if (codeGenParams.wrapsRequest() && codeGenParams.isRequest()) {
       throw new IllegalArgumentException("A request cannot wrap another request - this is a bug");
     }
-    ClassName immutFacetsType = ClassName.get(packageName, getImmutFacetsClassName(vajramName));
     // TODO : Add checks for subsetRequest
     MethodSpec.Builder fullConstructor = constructorBuilder();
     if (codeGenParams.withImpl()) {
+      ClassName immutFacetsType =
+          ClassName.get(vajramPackageName(), getImmutFacetsClassName(vajramName));
       if (codeGenParams.isBuilder()) {
         addCommonObjectMethods(classSpec);
       } else {
@@ -2035,8 +2085,8 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
       if (codeGenParams.wrapsRequest()) {
         TypeName requestOrBuilderType =
             codeGenParams.isBuilder()
-                ? currentVajramInfo.conformsToTraitOrSelf().reqBuilderInterfaceType()
-                : currentVajramInfo.conformsToTraitOrSelf().reqImmutInterfaceTypeName();
+                ? currentVajramInfo().conformsToTraitOrSelf().reqBuilderInterfaceType()
+                : currentVajramInfo().conformsToTraitOrSelf().reqImmutInterfaceTypeName();
         fullConstructor.addParameter(
             ParameterSpec.builder(requestOrBuilderType, "_request").build());
         fullConstructor.addStatement("this._request = _request");
@@ -2052,7 +2102,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
         MethodSpec.Builder requestConstructor = constructorBuilder();
         requestConstructor.addParameter(
             ParameterSpec.builder(
-                    currentVajramInfo.conformsToTraitOrSelf().requestInterfaceClassName(),
+                    currentVajramInfo().conformsToTraitOrSelf().requestInterfaceClassName(),
                     "_request")
                 .addAnnotation(NonNull.class)
                 .build());
@@ -2167,7 +2217,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                       ? CodeBlock.builder()
                           .addStatement(
                               "this._request = $T._builder()",
-                              currentVajramInfo.lite().reqImmutPojoClassName())
+                              currentVajramInfo().lite().reqImmutPojoClassName())
                           .build()
                       : CodeBlock.builder().build())
               .build());
@@ -2183,7 +2233,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
           constructorBuilder()
               .addParameter(
                   ParameterSpec.builder(
-                          currentVajramInfo.conformsToTraitOrSelf().requestInterfaceClassName(),
+                          currentVajramInfo().conformsToTraitOrSelf().requestInterfaceClassName(),
                           "_request")
                       .build())
               .addStatement("this._request = _request._asBuilder()")
@@ -2238,7 +2288,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
    * compatibility reasons.
    */
   private void validateSerialIdReservations() {
-    Element inputsElement = currentVajramInfo.inputsElement();
+    Element inputsElement = currentVajramInfo().inputsElement();
     if (inputsElement == null) {
       return;
     }
@@ -2263,7 +2313,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                     + "This ID is reserved via the @ReservedSerialIds annotation on the _Inputs class.",
                 facetSerialId.value(),
                 facet.name(),
-                currentVajramInfo.vajramClassElem().getSimpleName());
+                currentVajramInfo().vajramClassElem().getSimpleName());
         @Nullable Element[] elements = new Element[] {facet.facetElement()};
         util.error(message, elements);
       }
@@ -2293,7 +2343,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     }
   }
 
-  private ImmutableList<MethodSpec> facetContainerMethods(
+  private static ImmutableList<MethodSpec> facetContainerMethods(
       List<? extends FacetGenModel> eligibleFacets,
       TypeName enclosingClassName,
       TypeName immutableTypeName,
@@ -2386,17 +2436,17 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
 
   private void basicFacetsClasses() {
     boolean doInputsNeedBatching =
-        currentVajramInfo.facetStream().anyMatch(FacetGenModel::isBatched);
+        currentVajramInfo().facetStream().anyMatch(FacetGenModel::isBatched);
 
-    List<FacetGenModel> allFacets = currentVajramInfo.facetStream().toList();
+    List<FacetGenModel> allFacets = currentVajramInfo().facetStream().toList();
 
-    ClassName facetsType = currentVajramInfo.facetsInterfaceType();
-    ClassName immutableFacetsType = currentVajramInfo.facetsImmutPojoType();
+    ClassName facetsType = currentVajramInfo().facetsInterfaceType();
+    ClassName immutableFacetsType = currentVajramInfo().facetsImmutPojoType();
 
     TypeSpec.Builder facetsInterface =
         util.interfaceBuilder(
-                currentVajramInfo.facetsInterfaceType().simpleName(),
-                currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                currentVajramInfo().facetsInterfaceType().simpleName(),
+                currentVajramInfo().vajramClassElem().getQualifiedName().toString())
             .addModifiers(PUBLIC)
             .addSuperinterface(
                 doInputsNeedBatching ? BatchEnabledFacetValues.class : FacetValues.class);
@@ -2408,7 +2458,11 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
             .addStatement("return $T." + VAJRAM_ID_CONSTANT_NAME, getRequestInterfaceType())
             .build());
     facetConstants(
-        facetsInterface, currentVajramInfo.facetStream().toList(), CodeGenParams.builder().build());
+        facetsInterface,
+        currentVajramInfo().facetStream().toList(),
+        CodeGenParams.builder().build(),
+        currentVajramInfo().lite().inputsInfo(),
+        currentVajramInfo().conformsToTraitOrSelf().inputsInfo());
     allFacets.forEach(
         facet ->
             createFacetGetter(
@@ -2417,7 +2471,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     TypeSpec.Builder immutFacetsClass =
         util.classBuilder(
                 getImmutFacetsClassName(vajramName),
-                currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                currentVajramInfo().vajramClassElem().getQualifiedName().toString())
             .addModifiers(PUBLIC, FINAL)
             .addSuperinterface(facetsType)
             .addSuperinterface(
@@ -2432,7 +2486,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
 
     TypeSpec.Builder facetsBuilderClass =
         util.classBuilder(
-                "Builder", currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                "Builder", currentVajramInfo().vajramClassElem().getQualifiedName().toString())
             .addModifiers(PUBLIC, STATIC, FINAL)
             .addSuperinterface(facetsType)
             .addSuperinterface(
@@ -2453,7 +2507,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     try {
       StringWriter writer = new StringWriter();
       JavaFile.builder(
-              packageName,
+              vajramPackageName(),
               facetsInterface
                   .addMethods(
                       facetContainerMethods(
@@ -2466,17 +2520,17 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
           .build()
           .writeTo(writer);
       util.generateSourceFile(
-          currentVajramInfo.facetsInterfaceType().canonicalName(),
+          currentVajramInfo().facetsInterfaceType().canonicalName(),
           writer.toString(),
-          currentVajramInfo.vajramClassElem());
+          currentVajramInfo().vajramClassElem());
     } catch (IOException e) {
       String message = String.valueOf(e.getMessage());
-      util.error(message, currentVajramInfo.vajramClassElem());
+      util.error(message, currentVajramInfo().vajramClassElem());
     }
     try {
       StringWriter writer = new StringWriter();
       JavaFile.builder(
-              packageName,
+              vajramPackageName(),
               immutFacetsClass
                   .addMethods(
                       facetContainerMethods(
@@ -2510,30 +2564,30 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
           .build()
           .writeTo(writer);
       util.generateSourceFile(
-          packageName + '.' + getImmutFacetsClassName(vajramName),
+          vajramPackageName() + '.' + getImmutFacetsClassName(vajramName),
           writer.toString(),
-          currentVajramInfo.vajramClassElem());
+          currentVajramInfo().vajramClassElem());
     } catch (IOException e) {
       String message = String.valueOf(e.getMessage());
-      util.error(message, currentVajramInfo.vajramClassElem());
+      util.error(message, currentVajramInfo().vajramClassElem());
     }
   }
 
   private void batchFacetsClasses() {
-    ClassName allFacetsType = currentVajramInfo.facetsInterfaceType();
+    ClassName allFacetsType = currentVajramInfo().facetsInterfaceType();
     ClassName batchItemsIfaceType = getBatchItemIfaceName();
 
     ClassName commonImmutFacetsType = getCommonFacetsClassName();
 
     List<FacetGenModel> batchedFacets =
-        currentVajramInfo.facetStream().filter(FacetGenModel::isBatched).toList();
+        currentVajramInfo().facetStream().filter(FacetGenModel::isBatched).toList();
     List<FacetGenModel> commonFacets =
-        currentVajramInfo.facetStream().filter(FacetGenModel::isUsedToGroupBatches).toList();
+        currentVajramInfo().facetStream().filter(FacetGenModel::isUsedToGroupBatches).toList();
 
     TypeSpec.Builder batchItemsIface =
         util.interfaceBuilder(
                 batchItemsIfaceType.simpleName(),
-                currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                currentVajramInfo().vajramClassElem().getQualifiedName().toString())
             .addSuperinterface(ImmutableFacetValuesContainer.class)
             .addSuperinterface(Model.class)
             .addAnnotation(
@@ -2583,7 +2637,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                           .filter($T::isBatched)
                           .collect($T.toImmutableSet())
                         """,
-                    currentVajramInfo.facetsInterfaceType(),
+                    currentVajramInfo().facetsInterfaceType(),
                     FacetSpec.class,
                     ImmutableSet.class)
                 .build())
@@ -2597,10 +2651,13 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                 .addModifiers(PUBLIC, STATIC)
                 .returns(
                     ClassName.get(
-                        packageName, getBatchItemIfaceName().simpleName() + "ImmutPojo", "Builder"))
+                        vajramPackageName(),
+                        getBatchItemIfaceName().simpleName() + "ImmutPojo",
+                        "Builder"))
                 .addStatement(
                     "return $T._builder()",
-                    ClassName.get(packageName, getBatchItemIfaceName().simpleName() + "ImmutPojo"))
+                    ClassName.get(
+                        vajramPackageName(), getBatchItemIfaceName().simpleName() + "ImmutPojo"))
                 .build())
         .addMethod(
             methodBuilder("_fromFacets")
@@ -2620,7 +2677,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
     TypeSpec.Builder commonImmutFacetsClass =
         util.classBuilder(
                 commonImmutFacetsType.simpleName(),
-                currentVajramInfo.vajramClassElem().getQualifiedName().toString())
+                currentVajramInfo().vajramClassElem().getQualifiedName().toString())
             .addModifiers(FINAL)
             .addSuperinterface(ImmutableFacetValuesContainer.class)
             .addField(allFacetsType, FACET_VALUES_VAR, PRIVATE, FINAL)
@@ -2641,7 +2698,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                           .filter(spec -> !spec.isBatched())
                           .collect($T.toImmutableSet())
                         """,
-                        currentVajramInfo.facetsInterfaceType(),
+                        currentVajramInfo().facetsInterfaceType(),
                         ImmutableSet.class)
                     .build())
             .addMethod(
@@ -2668,24 +2725,28 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
 
     util.generateSourceFile(
         batchItemsIfaceType.canonicalName(),
-        JavaFile.builder(packageName, batchItemsIface.build()).build().toString(),
-        currentVajramInfo.vajramClassElem());
+        JavaFile.builder(vajramPackageName(), batchItemsIface.build()).build().toString(),
+        currentVajramInfo().vajramClassElem());
     util.generateSourceFile(
         commonImmutFacetsType.canonicalName(),
-        JavaFile.builder(packageName, commonImmutFacetsClass.build()).build().toString(),
-        currentVajramInfo.vajramClassElem());
+        JavaFile.builder(vajramPackageName(), commonImmutFacetsClass.build()).build().toString(),
+        currentVajramInfo().vajramClassElem());
+  }
+
+  private String vajramPackageName() {
+    return requireNonNull(packageName);
   }
 
   private ClassName getRequestInterfaceType() {
-    return ClassName.get(packageName, getRequestInterfaceName(vajramName));
+    return ClassName.get(requestPackageName, getRequestInterfaceName(vajramName));
   }
 
   private ClassName getBatchItemIfaceName() {
-    return ClassName.get(packageName, vajramName + BATCH_ITEM_FACETS_SUFFIX);
+    return ClassName.get(vajramPackageName(), vajramName + BATCH_ITEM_FACETS_SUFFIX);
   }
 
   private ClassName getCommonFacetsClassName() {
-    return ClassName.get(packageName, vajramName + BATCH_KEY_FACETS_SUFFIX);
+    return ClassName.get(vajramPackageName(), vajramName + BATCH_KEY_FACETS_SUFFIX);
   }
 
   private void codegenBatchableFacets(TypeSpec.Builder allFacetsType, CodeGenParams codeGenParams) {
@@ -2708,7 +2769,9 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
   private void facetConstants(
       TypeSpec.Builder classBuilder,
       List<? extends FacetGenModel> facetValues,
-      CodeGenParams codeGenParams) {
+      CodeGenParams codeGenParams,
+      VajramInputsInfo inputsInfo,
+      VajramInputsInfo conformsToTraitInfo) {
     List<FieldSpec> specFields = new ArrayList<>(facetValues.size());
     List<FieldSpec> idFields = new ArrayList<>();
     int facetCount = 0;
@@ -2718,7 +2781,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
       FieldSpec facetIdField =
           FieldSpec.builder(String.class, facet.name() + FACET_NAME_SUFFIX)
               .addModifiers(PUBLIC, STATIC, FINAL)
-              .initializer("$S", vajramName + QUALIFIED_FACET_SEPARATOR + facet.name())
+              .initializer("$S", inputsInfo.vajramName() + QUALIFIED_FACET_SEPARATOR + facet.name())
               .addJavadoc(facetDoc != null ? CodeBlock.of(facetDoc) : EMPTY_CODE_BLOCK)
               .build();
 
@@ -2727,7 +2790,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
       CodeGenType dataType = facet.dataType();
       TypeAndName facetType = util.getTypeName(dataType);
       TypeAndName boxedFacetType = util.box(facetType);
-      ClassName vajramReqClass = getRequestInterfaceType();
+      ClassName vajramReqClass = inputsInfo.requestInterfaceClassName();
       ClassName specType =
           ClassName.get(
               codeGenParams.isRequest()
@@ -2759,7 +2822,6 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
               .addModifiers(PUBLIC, STATIC, FINAL)
               .addAnnotation(
                   AnnotationSpec.builder(FacetIdNameMapping.class)
-                      .addMember("id", "$L", facet.id())
                       .addMember("name", "$S", facet.name())
                       .build());
 
@@ -2776,7 +2838,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
               specType,
               facet.id(),
               facet.name(),
-              getRequestInterfaceType(),
+              inputsInfo.requestInterfaceClassName(),
               VAJRAM_ID_CONSTANT_NAME)
           .add(
               util.getJavaTypeCreationCode(javaType, collectClassNames) + ",",
@@ -2811,7 +2873,6 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
       }
       initializerCodeBlock.add("$S,", docComment);
       if (codeGenParams.isRequest()) {
-        VajramInfoLite conformsToTraitInfoOrSelf = currentVajramInfo.conformsToTraitOrSelf();
         initializerCodeBlock.add(
             """
                   $T.fieldTagsParser(() -> $T.class.getDeclaredField($S)),
@@ -2824,11 +2885,11 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                 )
                 """,
             FacetUtils.class,
-            currentVajramInfo.lite().requestInterfaceClassName(),
+            inputsInfo.requestInterfaceClassName(),
             facet.name() + FACET_SPEC_SUFFIX,
-            conformsToTraitInfoOrSelf.requestInterfaceClassName(),
+            conformsToTraitInfo.requestInterfaceClassName(),
             facet.name(),
-            conformsToTraitInfoOrSelf.reqImmutInterfaceClassName().nestedClass("Builder"),
+            conformsToTraitInfo.reqImmutInterfaceClassName().nestedClass("Builder"),
             facet.name());
         fieldSpec.addAnnotations(
             facet.facetElement().getAnnotationMirrors().stream()
@@ -2862,15 +2923,15 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                 """,
             facet.isBatched(),
             FacetUtils.class,
-            currentVajramInfo.vajramClassElem(),
+            currentVajramInfo().vajramClassElem(),
             facet.facetType().equals(INPUT) ? _INPUTS_CLASS : _INTERNAL_FACETS_CLASS,
             facetReflectionAccessor,
             facet.name(),
-            currentVajramInfo.facetsInterfaceType(),
+            currentVajramInfo().facetsInterfaceType(),
             facet.name() + FACET_SPEC_SUFFIX,
-            currentVajramInfo.facetsInterfaceType(),
+            currentVajramInfo().facetsInterfaceType(),
             facet.name(),
-            ClassName.get(packageName, getImmutFacetsClassName(vajramName), "Builder"),
+            ClassName.get(vajramPackageName(), getImmutFacetsClassName(vajramName), "Builder"),
             facet.name());
         if (facet instanceof DependencyModel dep && dep.depVajramInfo().isTrait()) {
           fieldSpec.addAnnotation(TraitDependency.class);
@@ -2891,7 +2952,7 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
                         ? ClassName.get(InputMirrorSpec.class)
                         : ClassName.get(FacetSpec.class),
                     WildcardTypeName.subtypeOf(Object.class),
-                    WildcardTypeName.subtypeOf(getRequestInterfaceType()))));
+                    WildcardTypeName.subtypeOf(inputsInfo.requestInterfaceClassName()))));
     FieldSpec facetsField =
         FieldSpec.builder(facetsFieldType, "_facets", PUBLIC, STATIC, FINAL)
             .initializer(

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramInputsGenProcessor.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramInputsGenProcessor.java
@@ -8,6 +8,7 @@ import static com.flipkart.krystal.core.VajramID.vajramID;
 import static com.flipkart.krystal.facets.FacetType.INPUT;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 import com.flipkart.krystal.codegen.common.datatypes.CodeGenType;
@@ -17,6 +18,7 @@ import com.flipkart.krystal.codegen.common.models.RunOnlyWhenCodegenPhaseIs;
 import com.flipkart.krystal.codegen.common.models.TypeNameVisitor;
 import com.flipkart.krystal.core.VajramID;
 import com.flipkart.krystal.data.Request;
+import com.flipkart.krystal.facets.ImportVajramInputs;
 import com.flipkart.krystal.facets.InputsForVajram;
 import com.flipkart.krystal.facets.VajramInputs;
 import com.flipkart.krystal.vajram.codegen.common.models.DefaultFacetModel;
@@ -28,6 +30,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -39,9 +42,11 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
 import org.jetbrains.annotations.UnknownNullability;
 
 /**
@@ -51,34 +56,38 @@ import org.jetbrains.annotations.UnknownNullability;
  * <p>This processor runs during the MODELS codegen phase and generates the request interface in the
  * {@code parentPackage.shared_models} package.
  */
-@SupportedAnnotationTypes("com.flipkart.krystal.facets.InputsForVajram")
+@SupportedAnnotationTypes({
+  "com.flipkart.krystal.facets.InputsForVajram",
+  "com.flipkart.krystal.facets.ImportVajramInputs"
+})
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 @AutoService(Processor.class)
 @SupportedOptions({CODEGEN_PHASE_KEY, MODULE_ROOT_PATH_KEY})
 @RunOnlyWhenCodegenPhaseIs(MODELS)
-public final class SharedModelsGenProcessor extends AbstractKrystalAnnoProcessor {
+public final class VajramInputsGenProcessor extends AbstractKrystalAnnoProcessor {
 
   private VajramCodeGenUtility vajramUtil;
 
   @Override
   protected void processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     this.vajramUtil = new VajramCodeGenUtility(codeGenUtil());
-    Set<? extends Element> annotatedElements =
-        roundEnv.getElementsAnnotatedWith(InputsForVajram.class);
+    Set<Element> inputsForVajramElements =
+        new LinkedHashSet<>(roundEnv.getElementsAnnotatedWith(InputsForVajram.class));
+    inputsForVajramElements.addAll(getImportedVajramInputs(roundEnv));
 
     VajramCodeGenUtility vajramUtil = new VajramCodeGenUtility(codeGenUtil());
 
     CharSequence message =
         "SharedModelsGenProcessor found @InputsForVajram elements: %s"
             .formatted(
-                annotatedElements.stream()
+                inputsForVajramElements.stream()
                     .map(Objects::toString)
                     .collect(
                         joining(lineSeparator(), '[' + lineSeparator(), lineSeparator() + ']')));
     codeGenUtil().note(message);
 
     List<Failure> failures = new ArrayList<>();
-    for (Element element : annotatedElements) {
+    for (Element element : inputsForVajramElements) {
       if (!(element instanceof TypeElement inputsInterface)) {
         codeGenUtil().error("@InputsForVajram can only be applied to interfaces", element);
         continue;
@@ -100,6 +109,31 @@ public final class SharedModelsGenProcessor extends AbstractKrystalAnnoProcessor
               "[SharedModels Codegen Exception] " + getStackTraceAsString(failure.throwable()),
               failure.element());
     }
+  }
+
+  private Set<TypeElement> getImportedVajramInputs(RoundEnvironment roundEnv) {
+    Set<? extends Element> elementsAnnotatedWith =
+        roundEnv.getElementsAnnotatedWith(ImportVajramInputs.class);
+    Set<TypeElement> importedVajramInputs = new LinkedHashSet<>();
+
+    for (Element element : elementsAnnotatedWith) {
+      ImportVajramInputs importVajramInputs =
+          requireNonNull(element.getAnnotation(ImportVajramInputs.class));
+      String[] importedPackages = importVajramInputs.fromPackages();
+      for (String importedPackage : importedPackages) {
+        PackageElement packageElement =
+            codeGenUtil().processingEnv().getElementUtils().getPackageElement(importedPackage);
+        if (packageElement == null) {
+          throw codeGenUtil().errorAndThrow("Package " + importedPackage + " not found", element);
+        }
+        ElementFilter.typesIn(packageElement.getEnclosedElements()).stream()
+            .filter(
+                typeElement -> typeElement.getAnnotationsByType(InputsForVajram.class).length != 0)
+            .forEach(importedVajramInputs::add);
+      }
+    }
+
+    return importedVajramInputs;
   }
 
   private void processInputsForVajram(

--- a/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/exec/VajramDefinition.java
+++ b/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/exec/VajramDefinition.java
@@ -47,7 +47,6 @@ public final class VajramDefinition {
   private final ImmutableSet<FacetSpec> facetSpecs;
   private final ImmutableSet<InputMirror> inputMirrors;
   private final ImmutableMap<String, FacetSpec> facetsByName;
-  private final ImmutableMap<Integer, FacetSpec> facetsById;
 
   public VajramDefinition(VajramDefRoot<Object> vajramDefRoot) {
     this.vajramId = parseVajramId(vajramDefRoot);
@@ -65,7 +64,6 @@ public final class VajramDefinition {
     this.inputMirrors = ImmutableSet.copyOf(vajramDefRoot.newRequestBuilder()._facets());
     this.facetsByName =
         facetSpecs.stream().collect(toImmutableMap(Facet::name, Function.identity()));
-    this.facetsById = facetSpecs.stream().collect(toImmutableMap(Facet::id, Function.identity()));
 
     this.outputLogicTags = parseOutputLogicTags(vajramDefRoot);
     this.vajramTags = parseVajramTags(vajramDefRoot);

--- a/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/FacetIdNameMapping.java
+++ b/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/FacetIdNameMapping.java
@@ -10,7 +10,5 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Target({FIELD, TYPE})
 public @interface FacetIdNameMapping {
-  int id();
-
   String name();
 }

--- a/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/specs/AbstractFacetSpec.java
+++ b/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/specs/AbstractFacetSpec.java
@@ -39,7 +39,7 @@ public abstract sealed class AbstractFacetSpec<T, CV extends Request> extends Ab
       String documentation,
       boolean isBatched,
       Callable<ElementTags> tagsParser) {
-    super(id, name, ofVajramID, facetType, documentation);
+    super(name, ofVajramID, facetType, documentation);
     this.type = type;
     this.ofVajram = ofVajram;
     this.tagsParser = tagsParser;

--- a/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/specs/InputMirrorSpec.java
+++ b/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/specs/InputMirrorSpec.java
@@ -21,7 +21,6 @@ public final class InputMirrorSpec<T, CV extends Request> implements InputMirror
   @Getter private final VajramID ofVajramID;
   @Getter private final DataType<T> type;
   @Getter private final Class<? extends CV> ofVajram;
-  @Getter private final int id;
   @Getter private final String name;
   @Getter private final String documentation;
   private @MonotonicNonNull ElementTags tags;
@@ -39,7 +38,6 @@ public final class InputMirrorSpec<T, CV extends Request> implements InputMirror
       Callable<ElementTags> tagsParser,
       Function<CV, @Nullable T> getFromRequest,
       BiConsumer<ImmutableRequest.Builder<?>, @Nullable T> setToRequest) {
-    this.id = id;
     this.name = name;
     this.ofVajramID = ofVajramID;
     this.type = type;
@@ -64,7 +62,7 @@ public final class InputMirrorSpec<T, CV extends Request> implements InputMirror
 
   @Override
   public String toString() {
-    return "InputMirror(id=" + id + ", name=" + name + ", doc=" + documentation + ')';
+    return "InputMirror(name=" + name + ", doc=" + documentation + ')';
   }
 
   @SneakyThrows

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/StaticCallGraphTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/StaticCallGraphTest.java
@@ -17,7 +17,7 @@ import static com.flipkart.krystal.visualization.StaticCallGraphGenerator.genera
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flipkart.krystal.traits.TraitDispatchPolicies;
-import com.flipkart.krystal.vajram.guice.traitbinding.StaticDispatchPolicyImpl;
+import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.samples.calculator.add.Add;
 import com.flipkart.krystal.vajram.samples.calculator.add.AddUsingTraits;
@@ -120,7 +120,7 @@ class StaticCallGraphTest {
           .to(SplitAdd_Req.class);
       kGraph.traitDispatchPolicies(
           new TraitDispatchPolicies(
-              new StaticDispatchPolicyImpl(
+              new GuiceyStaticDispatchPolicy(
                   graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder),
               dispatchTrait(CustomerServiceAgent_Req.class, graph)
                   .conditionally(
@@ -207,7 +207,7 @@ class StaticCallGraphTest {
         .to(SplitAdd_Req.class);
     kGraph.traitDispatchPolicies(
         new TraitDispatchPolicies(
-            new StaticDispatchPolicyImpl(
+            new GuiceyStaticDispatchPolicy(
                 graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder)));
     // Generate complete static call graph (no specific Vajram filter)
     GraphGenerationResult result = generateStaticCallGraphContent(kGraph.build(), null);

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/AddUsingTraitsTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/AddUsingTraitsTest.java
@@ -20,7 +20,7 @@ import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
 import com.flipkart.krystal.traits.TraitDispatchPolicies;
-import com.flipkart.krystal.vajram.guice.traitbinding.StaticDispatchPolicyImpl;
+import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.samples.Util;
 import com.flipkart.krystal.vajram.samples.calculator.add.AddUsingTraits.ThreeSums;
@@ -86,7 +86,7 @@ class AddUsingTraitsTest {
     this.kGraph = KrystexGraph.builder().vajramGraph(graph);
     this.kGraph.traitDispatchPolicies(
         new TraitDispatchPolicies(
-            new StaticDispatchPolicyImpl(
+            new GuiceyStaticDispatchPolicy(
                 graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder)));
   }
 

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/MultiAddTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/MultiAddTest.java
@@ -29,7 +29,7 @@ import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
 import com.flipkart.krystal.traits.TraitDispatchPolicies;
-import com.flipkart.krystal.vajram.guice.traitbinding.StaticDispatchPolicyImpl;
+import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.samples.Util;
 import com.flipkart.krystal.vajram.samples.calculator.add.MultiAdd.AdditionMethod;
@@ -420,7 +420,7 @@ class MultiAddTest {
         .to(SplitAdd_Req.class);
     this.kGraph.traitDispatchPolicies(
         new TraitDispatchPolicies(
-            new StaticDispatchPolicyImpl(
+            new GuiceyStaticDispatchPolicy(
                 vGraph, vGraph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder)));
   }
 


### PR DESCRIPTION
This is so that it can be used to generate request models in different module and package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External/shared Vajram inputs support via a new inputs annotation and generic inputs interface.
  * Shared-models support with an opt-in flag to generate models into a shared subpackage.
  * Name-based protocol configuration added (protocol-by-name annotations).

* **Breaking Changes**
  * Facet identification moved from numeric IDs to string names; related APIs now use names.
  * Removed legacy integer-based facet id elements.

* **Chores**
  * Protobuf toolchain bumped to 4.35.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->