### PR TITLE
Fix bug and add new feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4096m
 
-com.flipkart.krystal.previousVersion=11.0.0.3-alpha
-com.flipkart.krystal.currentVersion=11.0.0.4-alpha
-com.flipkart.krystal.lattice.currentVersion=0.2.1.3-alpha
+com.flipkart.krystal.previousVersion=11.0.0.4-alpha
+com.flipkart.krystal.currentVersion=11.0.0.5-alpha
+com.flipkart.krystal.lattice.currentVersion=0.2.1.5-alpha
 java_code_std_version=5.8
 
 # Facing some issues when the below line is un-commented

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -1482,14 +1482,14 @@ public class CodeGenUtility {
   }
 
   public <T extends Annotation> @Nullable AnnotationMirror getAnnotationMirror(
-      AnnotatedConstruct annotatedElement, Class<T> annoClass) {
-    return getAnnotationMirror(annotatedElement, requireNonNull(annoClass.getCanonicalName()));
+      AnnotatedConstruct annotatedConstruct, Class<T> annoClass) {
+    return getAnnotationMirror(annotatedConstruct, requireNonNull(annoClass.getCanonicalName()));
   }
 
   public @Nullable AnnotationMirror getAnnotationMirror(
-      AnnotatedConstruct annotatedElement, String annoClassCanonicalName) {
+      AnnotatedConstruct annotatedConstruct, String annoClassCanonicalName) {
     Optional<? extends AnnotationMirror> any =
-        annotatedElement.getAnnotationMirrors().stream()
+        annotatedConstruct.getAnnotationMirrors().stream()
             .filter(
                 annotationMirror ->
                     annotationMirror.getAnnotationType().asElement() instanceof QualifiedNameable q
@@ -1499,7 +1499,7 @@ public class CodeGenUtility {
   }
 
   public <T extends Annotation> @Nullable AnnotationInfo<T> getAnnotationInfo(
-      AnnotatedConstruct annotatedElement, Class<T> annoClass) {
+      Element annotatedElement, Class<T> annoClass) {
     T annotation = annotatedElement.getAnnotation(annoClass);
     Optional<? extends AnnotationMirror> mirror =
         annotatedElement.getAnnotationMirrors().stream()

--- a/krystal-common/src/main/java/com/flipkart/krystal/traits/TraitDispatchPolicies.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/traits/TraitDispatchPolicies.java
@@ -5,10 +5,8 @@ import static java.util.function.Function.identity;
 
 import com.flipkart.krystal.core.VajramID;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import lombok.Builder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TraitDispatchPolicies {
@@ -22,7 +20,6 @@ public class TraitDispatchPolicies {
     this(List.of(traitDispatchPolicies));
   }
 
-  @Builder
   public TraitDispatchPolicies(Collection<? extends TraitDispatchPolicy> traitDispatchPolicies) {
     this.traitDispatchPolicies =
         traitDispatchPolicies.stream()
@@ -31,21 +28,5 @@ public class TraitDispatchPolicies {
 
   public @Nullable TraitDispatchPolicy get(VajramID traitId) {
     return traitDispatchPolicies.get(traitId);
-  }
-
-  public List<TraitDispatchPolicy> traitDispatchPolicies() {
-    return traitDispatchPolicies.values().asList();
-  }
-
-  public static class TraitDispatchPoliciesBuilder {
-
-    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") // Used by lombok
-    private final List<TraitDispatchPolicy> traitDispatchPolicies = new ArrayList<>();
-
-    public TraitDispatchPolicies.TraitDispatchPoliciesBuilder traitDispatchPolicies(
-        List<? extends TraitDispatchPolicy> traitDispatchPolicies) {
-      this.traitDispatchPolicies.addAll(traitDispatchPolicies);
-      return this;
-    }
   }
 }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/logicdecorators/observability/MainLogicExecReporter.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/logicdecorators/observability/MainLogicExecReporter.java
@@ -33,7 +33,6 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -91,10 +90,7 @@ public final class MainLogicExecReporter
       /*
        Report logic end
       */
-      allOf(
-              input.facetValueResponses().stream()
-                  .map(ExecutionItem::response)
-                  .toArray(CompletableFuture[]::new))
+      allOf(input.responseFutures())
           .whenComplete(
               (unused, throwable) ->
                   kryonExecutionReport.reportMainLogicEnd(

--- a/lattice/extensions/graphql/rest/lattice-graphql-rest/src/main/java/com/flipkart/krystal/lattice/graphql/rest/dopant/GraphQlOverRestSpec.java
+++ b/lattice/extensions/graphql/rest/lattice-graphql-rest/src/main/java/com/flipkart/krystal/lattice/graphql/rest/dopant/GraphQlOverRestSpec.java
@@ -6,6 +6,7 @@ import com.flipkart.krystal.lattice.core.doping.SimpleDopantSpec;
 import com.flipkart.krystal.lattice.core.doping.SimpleDopantSpecBuilder;
 import com.flipkart.krystal.lattice.ext.rest.RestServiceDopantSpec;
 import com.flipkart.krystal.lattice.graphql.rest.dispatch.GraphQlOperationExecutor;
+import com.flipkart.krystal.lattice.krystex.KrystexDopantSpec;
 import com.flipkart.krystal.lattice.krystex.KrystexDopantSpec.KrystexDopantSpecBuilder;
 import com.flipkart.krystal.lattice.vajram.VajramDopantSpec;
 import com.flipkart.krystal.vajram.graphql.api.traits.GraphQlOperationDispatch;
@@ -29,8 +30,7 @@ public record GraphQlOverRestSpec(
       GraphQlOperationDispatch graphQlOperationDispatch) {
     krystexDopantSpecBuilder.configureExecutorWith(
         graphQlOperationExecutor.asKryonExecutorConfigurator());
-    krystexDopantSpecBuilder.buildKrystexGraphWith(
-        kg -> kg.traitDispatchPolicies(graphQlOperationDispatch));
+    krystexDopantSpecBuilder.traitDispatchPolicies(graphQlOperationDispatch);
   }
 
   @Override
@@ -43,7 +43,8 @@ public record GraphQlOverRestSpec(
 
     @Override
     public List<DopantSpecBuilder<?, ?, ?>> getAdditionalDopants() {
-      return List.of(VajramDopantSpec.builder(), RestServiceDopantSpec.builder());
+      return List.of(
+          VajramDopantSpec.builder(), KrystexDopantSpec.builder(), RestServiceDopantSpec.builder());
     }
   }
 }

--- a/lattice/lattice-core/src/main/java/com/flipkart/krystal/lattice/krystex/KrystexDopant.java
+++ b/lattice/lattice-core/src/main/java/com/flipkart/krystal/lattice/krystex/KrystexDopant.java
@@ -2,6 +2,7 @@ package com.flipkart.krystal.lattice.krystex;
 
 import static com.flipkart.krystal.lattice.core.di.Util.asOptional;
 import static com.flipkart.krystal.lattice.krystex.KrystexDopant.DOPANT_TYPE;
+import static com.flipkart.krystal.vajramexecutor.krystex.batching.DepChainBatcherConfig.computeSharedBatcherConfig;
 
 import com.flipkart.krystal.concurrent.SingleThreadExecutor;
 import com.flipkart.krystal.data.ImmutableRequest;
@@ -14,14 +15,16 @@ import com.flipkart.krystal.lattice.core.doping.DopantType;
 import com.flipkart.krystal.lattice.core.doping.SimpleDopant;
 import com.flipkart.krystal.lattice.core.execution.ThreadingStrategyDopant;
 import com.flipkart.krystal.lattice.vajram.RequestInitializer;
-import com.flipkart.krystal.lattice.vajram.VajramDopant;
 import com.flipkart.krystal.lattice.vajram.VajramRequestExecutionContext;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph.KrystexGraphBuilder;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexVajramExecutor;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexVajramExecutorConfig;
+import com.flipkart.krystal.vajramexecutor.krystex.VajramGraph;
+import com.flipkart.krystal.vajramexecutor.krystex.batching.DepChainBatcherConfig.BatchSizeSupplier;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -52,7 +55,7 @@ public final class KrystexDopant implements SimpleDopant {
   public KrystexDopant(
       KrystexDopantSpec krystexDopantSpec,
       DependencyInjectionFramework dependencyInjectionFramework,
-      VajramDopant vajramDopant,
+      VajramGraph vajramGraph,
       ThreadingStrategyDopant threadingStrategyDopant,
       Provider<KryonExecutorConfigurator> kryonExecutorConfigurator) {
     this.threadingStrategyDopant = threadingStrategyDopant;
@@ -67,11 +70,21 @@ public final class KrystexDopant implements SimpleDopant {
           krystexDopantSpec.configureExecutorWith().forEach(configBuilder::configureWith);
         };
 
-    this.krystexGraph =
+    TraitDispatchPolicies traitDispatchPolicies =
+        new TraitDispatchPolicies(krystexDopantSpec.traitDispatchPolicies());
+    KrystexGraphBuilder graphBuilder =
         krystexGraphBuilder
-            .vajramGraph(vajramDopant.vajramGraph())
+            .vajramGraph(vajramGraph)
             .injectionProvider(dependencyInjectionFramework.toVajramInjectionProvider())
-            .build();
+            .traitDispatchPolicies(traitDispatchPolicies);
+    if (krystexDopantSpec.enableSharedAutoBatchers()) {
+      BatchSizeSupplier batchSizeSupplier = krystexDopantSpec.batchSizeSupplier();
+      if (batchSizeSupplier != null) {
+        krystexGraphBuilder.inputBatcherConfig(
+            computeSharedBatcherConfig(vajramGraph, batchSizeSupplier, traitDispatchPolicies));
+      }
+    }
+    this.krystexGraph = graphBuilder.build();
   }
 
   public <RespT extends @Nullable Object> CompletionStage<RespT> executeRequest(

--- a/lattice/lattice-core/src/main/java/com/flipkart/krystal/lattice/krystex/KrystexDopantSpec.java
+++ b/lattice/lattice-core/src/main/java/com/flipkart/krystal/lattice/krystex/KrystexDopantSpec.java
@@ -36,6 +36,7 @@ public record KrystexDopantSpec(
   public KrystexDopantSpec {
     buildKrystexGraphWith = requireNonNullElse(buildKrystexGraphWith, List.of());
     configureExecutorWith = requireNonNullElse(configureExecutorWith, ImmutableList.of());
+    traitDispatchPolicies = requireNonNullElse(traitDispatchPolicies, ImmutableList.of());
   }
 
   @Override

--- a/lattice/lattice-core/src/main/java/com/flipkart/krystal/lattice/krystex/KrystexDopantSpec.java
+++ b/lattice/lattice-core/src/main/java/com/flipkart/krystal/lattice/krystex/KrystexDopantSpec.java
@@ -3,22 +3,34 @@ package com.flipkart.krystal.lattice.krystex;
 import static com.flipkart.krystal.lattice.krystex.KrystexDopant.DOPANT_TYPE;
 import static java.util.Objects.requireNonNullElse;
 
+import com.flipkart.krystal.krystex.kryon.DependentChain;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfigurator;
-import com.flipkart.krystal.lattice.core.doping.DopantType;
 import com.flipkart.krystal.lattice.core.doping.SimpleDopantSpec;
 import com.flipkart.krystal.lattice.core.doping.SimpleDopantSpecBuilder;
+import com.flipkart.krystal.traits.TraitDispatchPolicy;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph.KrystexGraphBuilder;
+import com.flipkart.krystal.vajramexecutor.krystex.batching.DepChainBatcherConfig.BatchSizeSupplier;
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.Singular;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 @Builder(buildMethodName = "_buildSpec")
 public record KrystexDopantSpec(
     @Singular("buildKrystexGraphWith") List<Consumer<KrystexGraphBuilder>> buildKrystexGraphWith,
     @Singular("configureExecutorWith")
-        ImmutableList<KryonExecutorConfigurator> configureExecutorWith)
+        ImmutableList<KryonExecutorConfigurator> configureExecutorWith,
+    Collection<? extends TraitDispatchPolicy> traitDispatchPolicies,
+    Set<DependentChain> disabledDependentChains,
+    @Nullable BatchSizeSupplier batchSizeSupplier,
+    boolean enableSharedAutoBatchers)
     implements SimpleDopantSpec<KrystexDopant> {
 
   public KrystexDopantSpec {
@@ -36,7 +48,36 @@ public record KrystexDopantSpec(
     return DOPANT_TYPE;
   }
 
-  @DopantType(DOPANT_TYPE)
   public static final class KrystexDopantSpecBuilder
-      extends SimpleDopantSpecBuilder<KrystexDopantSpec> {}
+      extends SimpleDopantSpecBuilder<KrystexDopantSpec> {
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") // Used by lombok
+    private final List<TraitDispatchPolicy> traitDispatchPolicies = new ArrayList<>();
+
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") // Used by lombok
+    private final Set<DependentChain> disabledDependentChains = new LinkedHashSet<>();
+
+    public KrystexDopantSpecBuilder traitDispatchPolicies(
+        Collection<? extends TraitDispatchPolicy> traitDispatchPolicies) {
+      this.traitDispatchPolicies.addAll(traitDispatchPolicies);
+      return this;
+    }
+
+    public KrystexDopantSpecBuilder traitDispatchPolicies(
+        TraitDispatchPolicy... traitDispatchPolicies) {
+      this.traitDispatchPolicies.addAll(Arrays.asList(traitDispatchPolicies));
+      return this;
+    }
+
+    public KrystexDopantSpecBuilder disabledDependentChains(
+        Collection<? extends DependentChain> disabledDependentChains) {
+      this.disabledDependentChains.addAll(disabledDependentChains);
+      return this;
+    }
+
+    public KrystexDopantSpecBuilder disabledDependentChains(
+        DependentChain... disabledDependentChains) {
+      this.disabledDependentChains.addAll(Arrays.asList(disabledDependentChains));
+      return this;
+    }
+  }
 }

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
@@ -12,6 +12,7 @@ import com.flipkart.krystal.krystex.kryon.KryonExecutionConfig;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.graphql.api.execution.GraphQLQuery;
 import com.flipkart.krystal.vajram.graphql.api.execution.GraphQlExecutionFacade;
 import com.flipkart.krystal.vajram.graphql.api.schema.GraphQlInitializer;
@@ -74,8 +75,9 @@ public class VajramGraphQlTest {
             .build();
     this.kGraph = KrystexGraph.builder().vajramGraph(vGraph);
     kGraph.traitDispatchPolicies(
-        PredicateDispatchUtil.dispatchTrait(GraphQlOperationAggregate_Req.class, vGraph)
-            .alwaysTo(Query_GQlAggr_Req.class));
+        new TraitDispatchPolicies(
+            PredicateDispatchUtil.dispatchTrait(GraphQlOperationAggregate_Req.class, vGraph)
+                .alwaysTo(Query_GQlAggr_Req.class)));
   }
 
   @AfterEach

--- a/vajram/extensions/sql/vertx/vajram-sql-vertx-samples/src/test/java/com/flipkart/krystal/vajram/ext/sql/vertx/samples/users/statement/SqlTraitIntegrationTest.java
+++ b/vajram/extensions/sql/vertx/vajram-sql-vertx-samples/src/test/java/com/flipkart/krystal/vajram/ext/sql/vertx/samples/users/statement/SqlTraitIntegrationTest.java
@@ -9,6 +9,7 @@ import com.flipkart.krystal.krystex.kryon.KryonExecutionConfig;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.ext.sql.vertx.ExecuteVertxSql;
 import com.flipkart.krystal.vajram.ext.sql.vertx.samples.users.clause.OrderAmountGtPredicate;
 import com.flipkart.krystal.vajram.ext.sql.vertx.samples.users.clause.OrderAmountLtePredicate;
@@ -1163,15 +1164,14 @@ class SqlTraitIntegrationTest {
     assertThat(verifyFuture)
         .succeedsWithin(TIMEOUT)
         .satisfies(
-            orders -> {
-              assertThat(orders.stream().filter(o -> o.orderId() == 999L).findFirst())
-                  .isPresent()
-                  .hasValueSatisfying(
-                      o -> {
-                        assertThat(o.userId()).isEqualTo(1L);
-                        assertThat(o.amountCents()).isEqualTo(7500L);
-                      });
-            });
+            orders ->
+                assertThat(orders.stream().filter(o -> o.orderId() == 999L).findFirst())
+                    .isPresent()
+                    .hasValueSatisfying(
+                        o -> {
+                          assertThat(o.userId()).isEqualTo(1L);
+                          assertThat(o.amountCents()).isEqualTo(7500L);
+                        }));
 
     // Cleanup
     runSql("DELETE FROM OrderEntity WHERE orderId = 999");
@@ -1417,8 +1417,8 @@ class SqlTraitIntegrationTest {
         .bindTrait(GetUserWithAddressById_Req.class)
         .to(GetUserWithAddressById_VertxSql_Req.class);
 
-    kGraph
-        .traitDispatchPolicies(
+    kGraph.traitDispatchPolicies(
+        new TraitDispatchPolicies(
             Stream.of(
                     GetUserInfoById_Req._VAJRAM_ID,
                     GetOrderInfoByUserId_Req._VAJRAM_ID,
@@ -1439,8 +1439,7 @@ class SqlTraitIntegrationTest {
                     InsertUsersReturning_Req._VAJRAM_ID,
                     GetUserWithAddressById_Req._VAJRAM_ID)
                 .map(vajramID -> new GuiceyStaticDispatchPolicy(vajramGraph, vajramID, traitBinder))
-                .toList())
-        .build();
+                .toList()));
     return kGraph
         .build()
         .createExecutor(

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/CodeGenParams.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/CodeGenParams.java
@@ -5,7 +5,7 @@ package com.flipkart.krystal.vajram.codegen.common.models;
  *
  * @param isRequest {@code true} when the class being generated is a request class
  * @param isModelRoot {@code true} when the interface being generated is the root type for that
- *     vajram model hierarchy. For example, Vajram_Req and Vajram_Fac.
+ *     vajram model hierarchy having @ModelRoot annotation. For example, Vajram_Req.
  * @param isBuilder {@code true} when the class being generated is a builder.
  * @param isBuilderRoot {@code true} when the interface being generated is the root type for that
  *     vajram model builder hierarchy. For example, Vajram_ReqImmut.Builder and

--- a/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/FacetJavaType.java
+++ b/vajram/vajram-codegen-common/src/main/java/com/flipkart/krystal/vajram/codegen/common/models/FacetJavaType.java
@@ -14,6 +14,7 @@ import com.flipkart.krystal.vajram.facets.FacetValidation;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
 import java.util.Optional;
+import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract sealed class FacetJavaType {
@@ -64,7 +65,7 @@ public abstract sealed class FacetJavaType {
     }
   }
 
-  public Class<?>[] typeAnnotations(FacetGenModel facet, CodeGenParams codeGenParams) {
+  public Class<?>[] additionalTypeAnnotations(FacetGenModel facet, CodeGenParams codeGenParams) {
     return new Class[] {};
   }
 
@@ -76,18 +77,21 @@ public abstract sealed class FacetJavaType {
 
     @Override
     public TypeName javaTypeName(FacetGenModel facet) {
-      CodeGenType dataType = facet.dataType();
-      return util.codegenUtil().getTypeName(dataType).typeName();
+      return util.codegenUtil().getTypeName(facet.dataType()).typeName();
     }
 
     @Override
-    public Class<?>[] typeAnnotations(FacetGenModel facet, CodeGenParams codeGenParams) {
+    public Class<?>[] additionalTypeAnnotations(FacetGenModel facet, CodeGenParams codeGenParams) {
       if (!(facet instanceof DependencyModel)
           && !javaTypeName(facet).isPrimitive()
           && !codeGenParams.isSubsetBatch()) {
-        return new Class[] {Nullable.class};
+        TypeMirror typeMirror = facet.dataType().typeMirror(util.processingEnv());
+        if (util.codegenUtil().getAnnotationMirror(typeMirror, Nullable.class) == null) {
+          // Since declared type doesn't have @Nullable, we add it
+          return new Class[] {Nullable.class};
+        }
       }
-      return super.typeAnnotations(facet, codeGenParams);
+      return super.additionalTypeAnnotations(facet, codeGenParams);
     }
 
     @Override
@@ -126,8 +130,15 @@ public abstract sealed class FacetJavaType {
     }
 
     @Override
-    public Class<?>[] typeAnnotations(FacetGenModel facet, CodeGenParams codeGenParams) {
-      return new Class<?>[] {Nullable.class};
+    public Class<?>[] additionalTypeAnnotations(FacetGenModel facet, CodeGenParams codeGenParams) {
+      if (util.codegenUtil()
+              .getAnnotationMirror(
+                  facet.dataType().typeMirror(util.processingEnv()), Nullable.class)
+          == null) {
+        // Since declared type doesn't have @Nullable, we add it
+        return new Class<?>[] {Nullable.class};
+      }
+      return super.additionalTypeAnnotations(facet, codeGenParams);
     }
   }
 

--- a/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramCodeGenerator.java
+++ b/vajram/vajram-codegen/src/main/java/com/flipkart/krystal/vajram/codegen/processor/VajramCodeGenerator.java
@@ -2134,7 +2134,9 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
           ParameterSpec.builder(
                   facetFieldType
                       .javaTypeName(facet)
-                      .annotated(annotations(facetFieldType.typeAnnotations(facet, codeGenParams))),
+                      .annotated(
+                          annotations(
+                              facetFieldType.additionalTypeAnnotations(facet, codeGenParams))),
                   facet.name())
               .build();
       boolean isInput = facet.facetType().equals(INPUT);
@@ -2144,7 +2146,9 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
               FieldSpec.builder(
                   facetFieldType
                       .javaTypeName(facet)
-                      .annotated(annotations(facetFieldType.typeAnnotations(facet, codeGenParams))),
+                      .annotated(
+                          annotations(
+                              facetFieldType.additionalTypeAnnotations(facet, codeGenParams))),
                   facet.name(),
                   PRIVATE);
           if (codeGenParams.isBuilder()) {
@@ -2262,7 +2266,8 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
             .returns(
                 returnType
                     .javaTypeName(facet)
-                    .annotated(annotations(returnType.typeAnnotations(facet, codeGenParams))));
+                    .annotated(
+                        annotations(returnType.additionalTypeAnnotations(facet, codeGenParams))));
 
     if (codeGenParams.isModelRoot()) {
       String documentation = facet.documentation();
@@ -2633,7 +2638,8 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
               .returns(
                   returnType
                       .javaTypeName(facet)
-                      .annotated(annotations(returnType.typeAnnotations(facet, codeGenParams))))
+                      .annotated(
+                          annotations(returnType.additionalTypeAnnotations(facet, codeGenParams))))
               .build());
     }
     batchItemsIface
@@ -2724,7 +2730,8 @@ if (_$facetName:L_reqBuilders.isEmpty()) {
               .returns(
                   returnType
                       .javaTypeName(facet)
-                      .annotated(annotations(returnType.typeAnnotations(facet, codeGenParams))))
+                      .annotated(
+                          annotations(returnType.additionalTypeAnnotations(facet, codeGenParams))))
               .addStatement(returnType.fieldGetterCode(facet, codeGenParams));
       if (facet.isGiven()) {
         getter.addAnnotation(Include.class);

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexGraph.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/KrystexGraph.java
@@ -1,6 +1,7 @@
 package com.flipkart.krystal.vajramexecutor.krystex;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
 import static lombok.AccessLevel.PACKAGE;
 
 import com.flipkart.krystal.core.VajramID;
@@ -22,10 +23,6 @@ import com.flipkart.krystal.vajramexecutor.krystex.batching.InputBatchingDecorat
 import com.flipkart.krystal.vajramexecutor.krystex.inputinjection.KryonInputInjector;
 import com.flipkart.krystal.vajramexecutor.krystex.traits.DefaultTraitDispatcher;
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import lombok.Builder;
@@ -55,11 +52,12 @@ public final class KrystexGraph {
   @Builder
   private KrystexGraph(
       @NonNull VajramGraph vajramGraph,
-      Collection<? extends TraitDispatchPolicy> traitDispatchPolicies,
+      @Nullable TraitDispatchPolicies traitDispatchPolicies,
       @Nullable InputBatcherConfig inputBatcherConfig,
       @Nullable VajramInjectionProvider injectionProvider) {
     this.vajramGraph = vajramGraph;
-    this.traitDispatchPolicies = new TraitDispatchPolicies(traitDispatchPolicies);
+    this.traitDispatchPolicies =
+        requireNonNullElseGet(traitDispatchPolicies, TraitDispatchPolicies::new);
     this.traitDispatchDecorator =
         new DefaultTraitDispatcher(vajramGraph, this.traitDispatchPolicies);
     this.inputInjectionConfig = create(injectionProvider, vajramGraph);
@@ -166,21 +164,5 @@ public final class KrystexGraph {
     return configBuilder ->
         configBuilder.outputLogicDecoratorConfig(
             InputBatchingDecorator.DECORATOR_TYPE, batchingDecoratorConfig);
-  }
-
-  public static class KrystexGraphBuilder {
-    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") // Used by lombok
-    private final List<TraitDispatchPolicy> traitDispatchPolicies = new ArrayList<>();
-
-    public KrystexGraphBuilder traitDispatchPolicies(
-        Collection<? extends TraitDispatchPolicy> traitDispatchPolicies) {
-      this.traitDispatchPolicies.addAll(traitDispatchPolicies);
-      return this;
-    }
-
-    public KrystexGraphBuilder traitDispatchPolicies(TraitDispatchPolicy... traitDispatchPolicies) {
-      this.traitDispatchPolicies.addAll(Arrays.asList(traitDispatchPolicies));
-      return this;
-    }
   }
 }

--- a/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramGraph.java
+++ b/vajram/vajram-krystex/src/main/java/com/flipkart/krystal/vajramexecutor/krystex/VajramGraph.java
@@ -91,8 +91,21 @@ public final class VajramGraph {
   private final Set<VajramID> vajramExecutables =
       Collections.synchronizedSet(new LinkedHashSet<>());
 
+  private final boolean ignoreMissingDependencies;
+
+  /**
+   * @param packagePrefixes Load all vajrams within these packages and their sub-packages
+   * @param classes Load all this classes
+   * @param ignoreMissingDependencies if a vajram's dependency is missing, don't throw an error
+   *     while loading the graph. Throw an error during vajram execution instead (if the dependency
+   *     is invoked).
+   */
   @lombok.Builder
-  private VajramGraph(Set<String> packagePrefixes, Set<Class<? extends VajramDefRoot>> classes) {
+  private VajramGraph(
+      Set<String> packagePrefixes,
+      Set<Class<? extends VajramDefRoot>> classes,
+      boolean ignoreMissingDependencies) {
+    this.ignoreMissingDependencies = ignoreMissingDependencies;
     LogicDefinitionRegistry logicDefinitionRegistry = new LogicDefinitionRegistry();
     this.kryonDefinitionRegistry = new KryonDefinitionRegistry(logicDefinitionRegistry);
     this.logicRegistryDecorator = new LogicDefRegistryDecorator(logicDefinitionRegistry);
@@ -238,7 +251,14 @@ public final class VajramGraph {
     }
     tagParsingInProgress.put(vajramID, true);
     try {
-      VajramDefinition vajramDefinition = getVajramDefinition(vajramID);
+      VajramDefinition vajramDefinition = vajramDefinitions.get(vajramID);
+      if (vajramDefinition == null) {
+        if (ignoreMissingDependencies) {
+          return emptyTags();
+        } else {
+          throw new IllegalStateException("Vajram definition not found for vajramID: " + vajramID);
+        }
+      }
       List<ElementTags> depVajramTags =
           vajramDefinition.facetSpecs().stream()
               .filter(DependencySpec.class::isInstance)
@@ -456,8 +476,13 @@ public final class VajramGraph {
       var vajramID = dependency.onVajramID();
       VajramDefinition dependencyVajram = vajramDefinitions.get(vajramID);
       if (dependencyVajram == null) {
-        throw new VajramDefinitionException(
-            "Unable to find vajram for vajramId %s".formatted(vajramID));
+        String message = "Unable to find vajram for vajramId " + vajramID;
+        if (ignoreMissingDependencies) {
+          log.warn(message);
+          continue;
+        } else {
+          throw new VajramDefinitionException(message);
+        }
       }
       loadKryonSubgraph(dependencyVajram.vajramId(), loadingInProgress);
     }

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/StaticCallGraphTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/StaticCallGraphTest.java
@@ -16,6 +16,7 @@ import static com.flipkart.krystal.vajramexecutor.krystex.traits.PredicateDispat
 import static com.flipkart.krystal.visualization.StaticCallGraphGenerator.generateStaticCallGraphContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.samples.calculator.add.Add;
@@ -118,30 +119,31 @@ class StaticCallGraphTest {
           .annotatedWith(AdditionMethod.Creator.create(SPLIT))
           .to(SplitAdd_Req.class);
       kGraph.traitDispatchPolicies(
-          new GuiceyStaticDispatchPolicy(
-              graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder),
-          dispatchTrait(CustomerServiceAgent_Req.class, graph)
-              .conditionally(
-                  when(agentType_s, equalsEnum(L1))
-                      .and(initialCommunication_s, isInstanceOf(Call.class))
-                      .to(L1CallAgent_Req.class),
-                  when(agentType_s, equalsEnum(L1))
-                      .and(initialCommunication_s, isInstanceOf(Email.class))
-                      .to(L1EmailAgent_Req.class),
-                  when(agentType_s, equalsEnum(L2))
-                      .and(initialCommunication_s, isInstanceOf(Call.class))
-                      .to(L2CallAgent_Req.class),
-                  when(agentType_s, equalsEnum(L3))
-                      .and(initialCommunication_s, isInstanceOf(Email.class))
-                      .to(L3EmailAgent_Req.class),
-                  when(initialCommunication_s, isInstanceOf(Call.class))
-                      .to(DefaultCallAgent_Req.class),
-                  when(initialCommunication_s, isInstanceOf(Email.class))
-                      .to(DefaultEmailAgent_Req.class),
-                  // Default fallback
-                  when(agentType_s, isAnyValue())
-                      .and(initialCommunication_s, isAnyValue())
-                      .to(DefaultCustomerServiceAgent_Req.class)));
+          new TraitDispatchPolicies(
+              new GuiceyStaticDispatchPolicy(
+                  graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder),
+              dispatchTrait(CustomerServiceAgent_Req.class, graph)
+                  .conditionally(
+                      when(agentType_s, equalsEnum(L1))
+                          .and(initialCommunication_s, isInstanceOf(Call.class))
+                          .to(L1CallAgent_Req.class),
+                      when(agentType_s, equalsEnum(L1))
+                          .and(initialCommunication_s, isInstanceOf(Email.class))
+                          .to(L1EmailAgent_Req.class),
+                      when(agentType_s, equalsEnum(L2))
+                          .and(initialCommunication_s, isInstanceOf(Call.class))
+                          .to(L2CallAgent_Req.class),
+                      when(agentType_s, equalsEnum(L3))
+                          .and(initialCommunication_s, isInstanceOf(Email.class))
+                          .to(L3EmailAgent_Req.class),
+                      when(initialCommunication_s, isInstanceOf(Call.class))
+                          .to(DefaultCallAgent_Req.class),
+                      when(initialCommunication_s, isInstanceOf(Email.class))
+                          .to(DefaultEmailAgent_Req.class),
+                      // Default fallback
+                      when(agentType_s, isAnyValue())
+                          .and(initialCommunication_s, isAnyValue())
+                          .to(DefaultCustomerServiceAgent_Req.class))));
       // Generate complete static call graph (no specific Vajram filter)
       GraphGenerationResult result = generateStaticCallGraphContent(kGraph.build(), null);
 
@@ -204,8 +206,9 @@ class StaticCallGraphTest {
         .annotatedWith(AdditionMethod.Creator.create(SPLIT))
         .to(SplitAdd_Req.class);
     kGraph.traitDispatchPolicies(
-        new GuiceyStaticDispatchPolicy(
-            graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder));
+        new TraitDispatchPolicies(
+            new GuiceyStaticDispatchPolicy(
+                graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder)));
     // Generate complete static call graph (no specific Vajram filter)
     GraphGenerationResult result = generateStaticCallGraphContent(kGraph.build(), null);
 

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/AddUsingTraitsTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/AddUsingTraitsTest.java
@@ -19,6 +19,7 @@ import com.flipkart.krystal.krystex.kryon.KryonExecutionConfig;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.samples.Util;
@@ -84,8 +85,9 @@ class AddUsingTraitsTest {
     this.graph = Util.loadFromClasspath(AddUsingTraits.class.getPackageName()).build();
     this.kGraph = KrystexGraph.builder().vajramGraph(graph);
     this.kGraph.traitDispatchPolicies(
-        new GuiceyStaticDispatchPolicy(
-            graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder));
+        new TraitDispatchPolicies(
+            new GuiceyStaticDispatchPolicy(
+                graph, graph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder)));
   }
 
   @Test

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/MultiAddTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/calculator/add/MultiAddTest.java
@@ -28,6 +28,7 @@ import com.flipkart.krystal.krystex.kryon.KryonExecutor.KryonExecStrategy;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.guice.traitbinding.GuiceyStaticDispatchPolicy;
 import com.flipkart.krystal.vajram.guice.traitbinding.TraitBinder;
 import com.flipkart.krystal.vajram.samples.Util;
@@ -183,8 +184,9 @@ class MultiAddTest {
   @Test
   void chainAdd_predicateDispatch_success() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .conditionally(when(numbers_s, isAnyValue()).to(ChainAdd_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .conditionally(when(numbers_s, isAnyValue()).to(ChainAdd_Req.class))));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -213,8 +215,9 @@ class MultiAddTest {
   @Test
   void splitAdd_predicateDispatch_success() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .conditionally(when(numbers_s, isAnyValue()).to(SplitAdd_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .conditionally(when(numbers_s, isAnyValue()).to(SplitAdd_Req.class))));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -243,8 +246,9 @@ class MultiAddTest {
   @Test
   void simpleAdd_predicateDispatch_success() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .conditionally(when(numbers_s, isAnyValue()).to(SimpleAdd_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .conditionally(when(numbers_s, isAnyValue()).to(SimpleAdd_Req.class))));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -273,10 +277,11 @@ class MultiAddTest {
   @Test
   void chainAdd_computeDispatch_success() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .computingTargetWith(
-                multiAddReq -> Optional.of(ChainAdd_Req.class),
-                ImmutableSet.of(ChainAdd_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .computingTargetWith(
+                    multiAddReq -> Optional.of(ChainAdd_Req.class),
+                    ImmutableSet.of(ChainAdd_Req.class))));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -305,10 +310,11 @@ class MultiAddTest {
   @Test
   void splitAdd_computeDispatch_success() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .computingTargetWith(
-                multiAddReq -> Optional.of(SplitAdd_Req.class),
-                ImmutableSet.of(SplitAdd_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .computingTargetWith(
+                    multiAddReq -> Optional.of(SplitAdd_Req.class),
+                    ImmutableSet.of(SplitAdd_Req.class))));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -337,10 +343,11 @@ class MultiAddTest {
   @Test
   void simpleAdd_computeDispatch_success() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .computingTargetWith(
-                multiAddReq -> Optional.of(SimpleAdd_Req.class),
-                ImmutableSet.of(SimpleAdd_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .computingTargetWith(
+                    multiAddReq -> Optional.of(SimpleAdd_Req.class),
+                    ImmutableSet.of(SimpleAdd_Req.class))));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -369,8 +376,9 @@ class MultiAddTest {
   @Test
   void nullResolution_computeDispatch_throws() {
     this.kGraph.traitDispatchPolicies(
-        dispatchTrait(MultiAdd_Req.class, vGraph)
-            .computingTargetWith(multiAddReq -> Optional.empty(), ImmutableSet.of()));
+        new TraitDispatchPolicies(
+            dispatchTrait(MultiAdd_Req.class, vGraph)
+                .computingTargetWith(multiAddReq -> Optional.empty(), ImmutableSet.of())));
 
     // Setup test data
     List<Integer> numbers1 = asList(1, 2, 3);
@@ -411,8 +419,9 @@ class MultiAddTest {
         .annotatedWith(AdditionMethod.Creator.create(SPLIT))
         .to(SplitAdd_Req.class);
     this.kGraph.traitDispatchPolicies(
-        new GuiceyStaticDispatchPolicy(
-            vGraph, vGraph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder));
+        new TraitDispatchPolicies(
+            new GuiceyStaticDispatchPolicy(
+                vGraph, vGraph.getVajramIdByVajramDefType(MultiAdd.class), traitBinder)));
   }
 
   private KrystexVajramExecutorConfigBuilder executorConfig() {

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/chess/GetPieceTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/chess/GetPieceTest.java
@@ -14,6 +14,7 @@ import com.flipkart.krystal.concurrent.SingleThreadExecutorsPool;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph.KrystexGraphBuilder;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexVajramExecutorConfig;
@@ -48,10 +49,11 @@ class GetPieceTest {
 
     // Create and register dispatch policy
     kGraph.traitDispatchPolicies(
-        dispatchTrait(GetPiece_Req.class, graph)
-            .conditionally(
-                when(type_s, equalsEnum(KNIGHT)).to(GetKnight_Req.class),
-                when(type_s, equalsEnum(ROOK)).to(GetRook_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(GetPiece_Req.class, graph)
+                .conditionally(
+                    when(type_s, equalsEnum(KNIGHT)).to(GetKnight_Req.class),
+                    when(type_s, equalsEnum(ROOK)).to(GetRook_Req.class))));
   }
 
   @AfterEach

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/customer_service/CustomerServiceAgentComputeTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/customer_service/CustomerServiceAgentComputeTest.java
@@ -14,6 +14,7 @@ import com.flipkart.krystal.concurrent.SingleThreadExecutorsPool;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.samples.customer_service.CustomerServiceAgent.*;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph.KrystexGraphBuilder;
@@ -83,24 +84,25 @@ class CustomerServiceAgentComputeTest {
                 Set.copyOf(defaultsByCommType.values())));
     dispatchTargets.add(DefaultCustomerServiceAgent_Req.class);
     kGraph.traitDispatchPolicies(
-        new ComputeDispatchPolicyImpl<>(
-            CustomerServiceAgent_Req.class,
-            (DispatchTargetReqTypeComputer<CustomerServiceAgent_Req>)
-                (dependency, request) -> {
-                  InitialCommunication initialCommunication = request.initialCommunication();
-                  var commType =
-                      initialCommunication == null
-                          ? CustomerServiceAgent_Req.class
-                          : initialCommunication.getClass();
-                  return byAgent
-                      .getOrDefault(request.agentType(), Map.of())
-                      .getOrDefault(
-                          commType,
-                          defaultsByCommType.getOrDefault(
-                              commType, DefaultCustomerServiceAgent_Req.class));
-                },
-            ImmutableSet.copyOf(dispatchTargets),
-            graph));
+        new TraitDispatchPolicies(
+            new ComputeDispatchPolicyImpl<>(
+                CustomerServiceAgent_Req.class,
+                (DispatchTargetReqTypeComputer<CustomerServiceAgent_Req>)
+                    (dependency, request) -> {
+                      InitialCommunication initialCommunication = request.initialCommunication();
+                      var commType =
+                          initialCommunication == null
+                              ? CustomerServiceAgent_Req.class
+                              : initialCommunication.getClass();
+                      return byAgent
+                          .getOrDefault(request.agentType(), Map.of())
+                          .getOrDefault(
+                              commType,
+                              defaultsByCommType.getOrDefault(
+                                  commType, DefaultCustomerServiceAgent_Req.class));
+                    },
+                ImmutableSet.copyOf(dispatchTargets),
+                graph)));
   }
 
   @AfterEach

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/customer_service/CustomerServiceAgentPredicateTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/customer_service/CustomerServiceAgentPredicateTest.java
@@ -18,6 +18,7 @@ import com.flipkart.krystal.concurrent.SingleThreadExecutorsPool;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.samples.customer_service.CustomerServiceAgent.*;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph;
 import com.flipkart.krystal.vajramexecutor.krystex.KrystexGraph.KrystexGraphBuilder;
@@ -54,28 +55,29 @@ class CustomerServiceAgentPredicateTest {
 
     // Create and register dispatch policy
     kGraph.traitDispatchPolicies(
-        dispatchTrait(CustomerServiceAgent_Req.class, graph)
-            .conditionally(
-                when(agentType_s, equalsEnum(L1))
-                    .and(initialCommunication_s, isInstanceOf(Call.class))
-                    .to(L1CallAgent_Req.class),
-                when(agentType_s, equalsEnum(L1))
-                    .and(initialCommunication_s, isInstanceOf(Email.class))
-                    .to(L1EmailAgent_Req.class),
-                when(agentType_s, equalsEnum(L2))
-                    .and(initialCommunication_s, isInstanceOf(Call.class))
-                    .to(L2CallAgent_Req.class),
-                when(agentType_s, equalsEnum(L3))
-                    .and(initialCommunication_s, isInstanceOf(Email.class))
-                    .to(L3EmailAgent_Req.class),
-                when(initialCommunication_s, isInstanceOf(Call.class))
-                    .to(DefaultCallAgent_Req.class),
-                when(initialCommunication_s, isInstanceOf(Email.class))
-                    .to(DefaultEmailAgent_Req.class),
-                // Default fallback
-                when(agentType_s, isAnyValue())
-                    .and(initialCommunication_s, isAnyValue())
-                    .to(DefaultCustomerServiceAgent_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(CustomerServiceAgent_Req.class, graph)
+                .conditionally(
+                    when(agentType_s, equalsEnum(L1))
+                        .and(initialCommunication_s, isInstanceOf(Call.class))
+                        .to(L1CallAgent_Req.class),
+                    when(agentType_s, equalsEnum(L1))
+                        .and(initialCommunication_s, isInstanceOf(Email.class))
+                        .to(L1EmailAgent_Req.class),
+                    when(agentType_s, equalsEnum(L2))
+                        .and(initialCommunication_s, isInstanceOf(Call.class))
+                        .to(L2CallAgent_Req.class),
+                    when(agentType_s, equalsEnum(L3))
+                        .and(initialCommunication_s, isInstanceOf(Email.class))
+                        .to(L3EmailAgent_Req.class),
+                    when(initialCommunication_s, isInstanceOf(Call.class))
+                        .to(DefaultCallAgent_Req.class),
+                    when(initialCommunication_s, isInstanceOf(Email.class))
+                        .to(DefaultEmailAgent_Req.class),
+                    // Default fallback
+                    when(agentType_s, isAnyValue())
+                        .and(initialCommunication_s, isAnyValue())
+                        .to(DefaultCustomerServiceAgent_Req.class))));
   }
 
   @AfterEach

--- a/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/customer_service/MultiAgentContactTest.java
+++ b/vajram/vajram-samples/src/test/java/com/flipkart/krystal/vajram/samples/customer_service/MultiAgentContactTest.java
@@ -20,6 +20,7 @@ import com.flipkart.krystal.concurrent.SingleThreadExecutorsPool;
 import com.flipkart.krystal.krystex.kryon.KryonExecutorConfig;
 import com.flipkart.krystal.pooling.Lease;
 import com.flipkart.krystal.pooling.LeaseUnavailableException;
+import com.flipkart.krystal.traits.TraitDispatchPolicies;
 import com.flipkart.krystal.vajram.samples.customer_service.CustomerServiceAgent.AgentType;
 import com.flipkart.krystal.vajram.samples.customer_service.CustomerServiceAgent.Call;
 import com.flipkart.krystal.vajram.samples.customer_service.CustomerServiceAgent.Email;
@@ -71,28 +72,29 @@ class MultiAgentContactTest {
 
     // Create and register dispatch policy
     kGraph.traitDispatchPolicies(
-        dispatchTrait(CustomerServiceAgent_Req.class, graph)
-            .conditionally(
-                when(agentType_s, equalsEnum(L1))
-                    .and(initialCommunication_s, isInstanceOf(Call.class))
-                    .to(L1CallAgent_Req.class),
-                when(agentType_s, equalsEnum(L1))
-                    .and(initialCommunication_s, isInstanceOf(Email.class))
-                    .to(L1EmailAgent_Req.class),
-                when(agentType_s, equalsEnum(L2))
-                    .and(initialCommunication_s, isInstanceOf(Call.class))
-                    .to(L2CallAgent_Req.class),
-                when(agentType_s, equalsEnum(L3))
-                    .and(initialCommunication_s, isInstanceOf(Email.class))
-                    .to(L3EmailAgent_Req.class),
-                when(initialCommunication_s, isInstanceOf(Call.class))
-                    .to(DefaultCallAgent_Req.class),
-                when(initialCommunication_s, isInstanceOf(Email.class))
-                    .to(DefaultEmailAgent_Req.class),
-                // Default fallback
-                when(agentType_s, isAnyValue())
-                    .and(initialCommunication_s, isAnyValue())
-                    .to(DefaultCustomerServiceAgent_Req.class)));
+        new TraitDispatchPolicies(
+            dispatchTrait(CustomerServiceAgent_Req.class, graph)
+                .conditionally(
+                    when(agentType_s, equalsEnum(L1))
+                        .and(initialCommunication_s, isInstanceOf(Call.class))
+                        .to(L1CallAgent_Req.class),
+                    when(agentType_s, equalsEnum(L1))
+                        .and(initialCommunication_s, isInstanceOf(Email.class))
+                        .to(L1EmailAgent_Req.class),
+                    when(agentType_s, equalsEnum(L2))
+                        .and(initialCommunication_s, isInstanceOf(Call.class))
+                        .to(L2CallAgent_Req.class),
+                    when(agentType_s, equalsEnum(L3))
+                        .and(initialCommunication_s, isInstanceOf(Email.class))
+                        .to(L3EmailAgent_Req.class),
+                    when(initialCommunication_s, isInstanceOf(Call.class))
+                        .to(DefaultCallAgent_Req.class),
+                    when(initialCommunication_s, isInstanceOf(Email.class))
+                        .to(DefaultEmailAgent_Req.class),
+                    // Default fallback
+                    when(agentType_s, isAnyValue())
+                        .and(initialCommunication_s, isAnyValue())
+                        .to(DefaultCustomerServiceAgent_Req.class))));
     // Create request for L1 agent and Call communication
     MultiAgentContact_ReqImmut request =
         MultiAgentContact_ReqImmutPojo._builder()
@@ -156,22 +158,23 @@ class MultiAgentContactTest {
 
     // Create and register dispatch policy
     kGraph.traitDispatchPolicies(
-        dispatchTrait(CustomerServiceAgent_Req.class, graph)
-            .computingTargetWith(
-                request -> {
-                  var ic = request.initialCommunication();
-                  var aClass = ic == null ? null : ic.getClass();
-                  var target = map.get(new Key(request.agentType(), aClass));
-                  if (target != null) {
-                    return Optional.of(target);
-                  }
-                  target = map.get(new Key(null, aClass));
-                  if (target != null) {
-                    return Optional.of(target);
-                  }
-                  return Optional.ofNullable(map.get(new Key(null, null)));
-                },
-                ImmutableSet.copyOf(map.values())));
+        new TraitDispatchPolicies(
+            dispatchTrait(CustomerServiceAgent_Req.class, graph)
+                .computingTargetWith(
+                    request -> {
+                      var ic = request.initialCommunication();
+                      var aClass = ic == null ? null : ic.getClass();
+                      var target = map.get(new Key(request.agentType(), aClass));
+                      if (target != null) {
+                        return Optional.of(target);
+                      }
+                      target = map.get(new Key(null, aClass));
+                      if (target != null) {
+                        return Optional.of(target);
+                      }
+                      return Optional.ofNullable(map.get(new Key(null, null)));
+                    },
+                    ImmutableSet.copyOf(map.values()))));
     // Create request for L1 agent and Call communication
     MultiAgentContact_ReqImmut request =
         MultiAgentContact_ReqImmutPojo._builder()


### PR DESCRIPTION
Bug: 
Prevent duplicate `@Nullable` annotation generation. Move TraitDispatchPolicy building to KrystexDopantSpec

Feature:
Add support to ignore missing dependency vajram during vajramGraph creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to ignore missing dependencies during graph building/execution.
* **Bug Fixes**
  * Improved generated Java nullability handling to avoid duplicate or redundant `@Nullable` annotations.
* **Refactor**
  * Simplified trait dispatch policy configuration by standardizing it behind `TraitDispatchPolicies`.
  * Updated Krystex dopant/graph wiring and executor completion reporting for more consistent behavior.
* **Tests**
  * Updated sample and integration tests to use the new trait dispatch policy wrapper.
* **Chores**
  * Bumped Gradle/Krystal versions to newer alpha releases and refreshed codegen documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->