### PR TITLE
refactor: replace byte[]/OutputStream serialization with InputStream in SerializableModel

### DIFF
--- a/krystal-common/src/main/java/com/flipkart/krystal/except/KrystalCompletionException.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/except/KrystalCompletionException.java
@@ -48,13 +48,21 @@ public class KrystalCompletionException extends CompletionException {
     };
   }
 
+  /**
+   * Wraps the throwable in a {@link KrystalCompletionException} if it is not of type {@link
+   * CompletionException}. Else returns the throwable as it is.
+   */
   public static CompletionException wrapAsCompletionException(Throwable t) {
     return wrapAsCompletionException(t, null);
   }
 
+  /**
+   * If {@code wrapperMessage} is null, and {@code t} is a {@link CompletionException}, returns t as
+   * it is. Else, wraps the t in a {@link KrystalCompletionException}
+   */
   public static CompletionException wrapAsCompletionException(
       Throwable t, @Nullable String wrapperMessage) {
-    if (t instanceof CompletionException c) {
+    if (t instanceof CompletionException c && wrapperMessage == null) {
       return c;
     }
     if (wrapperMessage == null) {

--- a/krystal-common/src/main/java/com/flipkart/krystal/serial/SerializableModel.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/serial/SerializableModel.java
@@ -1,12 +1,13 @@
 package com.flipkart.krystal.serial;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
 
 public interface SerializableModel {
-  byte[] _serialize() throws Exception;
 
-  void _serialize(OutputStream outputStream) throws IOException;
+  /**
+   * Returns a non-blocking {@link InputStream} representing the serialized version of this object.
+   */
+  InputStream _serialize() throws Exception;
 
   SerdeProtocol _serdeProtocol();
 }

--- a/lattice/extensions/rest/lattice-rest/src/main/java/com/flipkart/krystal/lattice/ext/rest/RestServiceDopant.java
+++ b/lattice/extensions/rest/lattice-rest/src/main/java/com/flipkart/krystal/lattice/ext/rest/RestServiceDopant.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.UriInfo;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -80,8 +81,8 @@ public abstract class RestServiceDopant implements Dopant<RestService, RestServi
                     if (response == null || response instanceof Unit) {
                       responseBuilder = Response.ok();
                     } else if (response instanceof SerializableModel serializableResponse) {
-                      byte[] bytes = serializableResponse._serialize();
-                      contentLength = bytes.length;
+                      InputStream bytes = serializableResponse._serialize();
+                      contentLength = bytes.available();
                       responseBuilder =
                           Response.ok(bytes)
                               .header(

--- a/lattice/samples/grpc-proto2024e-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto2024e/sampleProtoService/Proto2024eLatticeSampleResponseTest.java
+++ b/lattice/samples/grpc-proto2024e-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto2024e/sampleProtoService/Proto2024eLatticeSampleResponseTest.java
@@ -42,7 +42,7 @@ class Proto2024eLatticeSampleResponseTest {
             ._build();
 
     // Serialize to bytes
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     assertThat(serialized).isNotEmpty();
 
     // Deserialize from bytes
@@ -107,7 +107,7 @@ class Proto2024eLatticeSampleResponseTest {
             .status(Status.UNKNOWN)
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     Proto2024eLatticeSampleResponse_ImmutProto deserialized =
         new Proto2024eLatticeSampleResponse_ImmutProto(serialized);
 
@@ -229,7 +229,7 @@ class Proto2024eLatticeSampleResponseTest {
             .status(Status.IN_PROGRESS)
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     Proto2024eLatticeSampleResponse_ImmutProto deserialized =
         new Proto2024eLatticeSampleResponse_ImmutProto(serialized);
 
@@ -325,7 +325,7 @@ class Proto2024eLatticeSampleResponseTest {
             .subStatuses(List.of(Status.COMPLETED, Status.UNKNOWN))
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     SubMessage_ImmutProto deserialized = new SubMessage_ImmutProto(serialized);
 
     assertThat(deserialized.count()).isEqualTo(99);
@@ -352,7 +352,7 @@ class Proto2024eLatticeSampleResponseTest {
   }
 
   @Test
-  void unknownProtoEnumValue_deserializesToUnknown() throws Exception {
+  void unknownProtoEnumValue_deserializesToUnknown() {
     // Build a raw proto message with an unrecognized enum value (999) for the status field
     Proto2024eLatticeSampleResponseProto rawProto =
         Proto2024eLatticeSampleResponseProto.newBuilder()
@@ -404,7 +404,7 @@ class Proto2024eLatticeSampleResponseTest {
             .namedStatuses(Map.of("x", Status.FAILED, "y", Status.IN_PROGRESS))
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     Proto2024eLatticeSampleResponse_ImmutProto deserialized =
         new Proto2024eLatticeSampleResponse_ImmutProto(serialized);
 

--- a/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto3/sampleProtoService/Proto3LatticeSampleResponseTest.java
+++ b/lattice/samples/grpc-proto3-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/grpc/proto3/sampleProtoService/Proto3LatticeSampleResponseTest.java
@@ -42,7 +42,7 @@ class Proto3LatticeSampleResponseTest {
             ._build();
 
     // Serialize to bytes
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     assertThat(serialized).isNotEmpty();
 
     // Deserialize from bytes
@@ -107,7 +107,7 @@ class Proto3LatticeSampleResponseTest {
             .status(Status.UNKNOWN)
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     Proto3LatticeSampleResponse_ImmutProto3 deserialized =
         new Proto3LatticeSampleResponse_ImmutProto3(serialized);
 
@@ -229,7 +229,7 @@ class Proto3LatticeSampleResponseTest {
             .status(Status.IN_PROGRESS)
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     Proto3LatticeSampleResponse_ImmutProto3 deserialized =
         new Proto3LatticeSampleResponse_ImmutProto3(serialized);
 
@@ -326,7 +326,7 @@ class Proto3LatticeSampleResponseTest {
             .subStatuses(List.of(Status.COMPLETED, Status.UNKNOWN))
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     SubMessage_ImmutProto3 deserialized = new SubMessage_ImmutProto3(serialized);
 
     assertThat(deserialized.count()).isEqualTo(99);
@@ -353,7 +353,7 @@ class Proto3LatticeSampleResponseTest {
   }
 
   @Test
-  void unknownProtoEnumValue_deserializesToUnknown() throws Exception {
+  void unknownProtoEnumValue_deserializesToUnknown() {
     // Build a raw proto message with an unrecognized enum value (999) for the status field
     Proto3LatticeSampleResponseProto3 rawProto =
         Proto3LatticeSampleResponseProto3.newBuilder()
@@ -405,7 +405,7 @@ class Proto3LatticeSampleResponseTest {
             .namedStatuses(Map.of("x", Status.FAILED, "y", Status.IN_PROGRESS))
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     Proto3LatticeSampleResponse_ImmutProto3 deserialized =
         new Proto3LatticeSampleResponse_ImmutProto3(serialized);
 

--- a/lattice/samples/rest/fory/quarkus/rest-fory-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/fory/quarkus/sampleForyService/ForyQuarkusE2eTest.java
+++ b/lattice/samples/rest/fory/quarkus/rest-fory-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/fory/quarkus/sampleForyService/ForyQuarkusE2eTest.java
@@ -54,7 +54,7 @@ class ForyQuarkusE2eTest {
     ForyRequest_ImmutFory request =
         ForyRequest_ImmutFory._builder().mandatoryInput(7).mandatoryLongInput(99L)._build();
 
-    byte[] requestBytes = request._serialize();
+    byte[] requestBytes = request._serialize().readAllBytes();
 
     HttpResponse<byte[]> resp =
         httpClient.send(

--- a/lattice/samples/rest/fory/quarkus/rest-fory-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/fory/quarkus/sampleForyService/ForyResponseTest.java
+++ b/lattice/samples/rest/fory/quarkus/rest-fory-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/fory/quarkus/sampleForyService/ForyResponseTest.java
@@ -27,7 +27,7 @@ class ForyResponseTest {
             .nestedData(ForyInnerData_ImmutFory._builder().value("inner").count(10)._build())
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     assertThat(serialized).isNotEmpty();
 
     ForyResponse_ImmutFory deserialized = new ForyResponse_ImmutFory(serialized);
@@ -47,7 +47,7 @@ class ForyResponseTest {
     ForyResponse_ImmutFory original =
         ForyResponse_ImmutFory._builder().message("Sparse").mandatoryInt(1)._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     ForyResponse_ImmutFory deserialized = new ForyResponse_ImmutFory(serialized);
 
     assertThat(deserialized.message()).isEqualTo("Sparse");
@@ -69,7 +69,7 @@ class ForyResponseTest {
                     ForyInnerData_ImmutFory._builder().value("B").count(2)._build()))
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     ForyResponse_ImmutFory deserialized = new ForyResponse_ImmutFory(serialized);
 
     assertThat(deserialized.nestedDataList()).hasSize(2);
@@ -91,7 +91,7 @@ class ForyResponseTest {
                     ForyInnerData_ImmutFory._builder().value("Y").count(20)._build()))
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     ForyResponse_ImmutFory deserialized = new ForyResponse_ImmutFory(serialized);
 
     assertThat(deserialized.namedInnerData()).hasSize(2);
@@ -110,7 +110,7 @@ class ForyResponseTest {
             .innerData(ForyInnerData_ImmutFory._builder().value("nested").count(5)._build())
             ._build();
 
-    byte[] serialized = original._serialize();
+    byte[] serialized = original._serialize().readAllBytes();
     ForyRequest_ImmutFory deserialized = new ForyRequest_ImmutFory(serialized);
 
     assertThat(deserialized.mandatoryInput()).isEqualTo(7);

--- a/lattice/samples/rest/json/dropwizard/rest-json-dropwizard-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/json/dropwizard/sampleRestService/JsonResponseTest.java
+++ b/lattice/samples/rest/json/dropwizard/rest-json-dropwizard-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/json/dropwizard/sampleRestService/JsonResponseTest.java
@@ -26,7 +26,7 @@ class JsonResponseTest {
             .mapTypedField(Map.of("X", "A", "Y", "B", "Z", "C"))
             .byteArray(JsonByteArray.copyOf(new byte[] {23, 45, 23, 56, 67, 64, 45, 45, 3, 45, 56}))
             ._build();
-    byte[] serializedPayload = immutJson._serialize();
+    byte[] serializedPayload = immutJson._serialize().readAllBytes();
     System.out.println(new String(serializedPayload, StandardCharsets.UTF_8));
     JsonResponse_ImmutJson deserialized = new JsonResponse_ImmutJson(serializedPayload);
     assertThat(deserialized).isEqualTo(immutJson);

--- a/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/JsonResponseTest.java
+++ b/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/JsonResponseTest.java
@@ -33,7 +33,7 @@ class JsonResponseTest {
             .nestedData(InnerData_ImmutJson._builder().value("Hello").count(11)._build())
             .priority(Priority.HIGH)
             ._build();
-    byte[] serializedPayload = immutJson._serialize();
+    byte[] serializedPayload = immutJson._serialize().readAllBytes();
     System.out.println(new String(serializedPayload, UTF_8));
     JsonResponse_ImmutJson deserialized = new JsonResponse_ImmutJson(serializedPayload);
     assertThat(deserialized).isEqualTo(immutJson);
@@ -54,7 +54,7 @@ class JsonResponseTest {
             .nestedData(InnerData_ImmutJson._builder().value("v").count(1)._build())
             .priority(Priority.HIGH)
             ._build();
-    String json = new String(original._serialize(), UTF_8);
+    String json = new String(original._serialize().readAllBytes(), UTF_8);
 
     // Replace "HIGH" with a non-existent enum value
     String modifiedJson = json.replace("\"HIGH\"", "\"NONEXISTENT\"");

--- a/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/QuarkusRestEndpointsE2eTest.java
+++ b/lattice/samples/rest/json/quarkus/rest-json-quarkus-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/rest/json/quarkus/sampleRestService/QuarkusRestEndpointsE2eTest.java
@@ -72,7 +72,7 @@ class QuarkusRestEndpointsE2eTest {
     HttpResponse<CompletionStage<JsonResponse_ImmutJson>> resp =
         httpClient.send(
             HttpRequest.newBuilder(baseUri.resolve("foo/bar"))
-                .POST(BodyPublishers.ofByteArray(body._serialize()))
+                .POST(BodyPublishers.ofByteArray(body._serialize().readAllBytes()))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .build(),

--- a/vajram/extensions/fory/vajram-fory-codegen/src/main/java/com/flipkart/krystal/vajram/ext/fory/codegen/ForyModelsGen.java
+++ b/vajram/extensions/fory/vajram-fory-codegen/src/main/java/com/flipkart/krystal/vajram/ext/fory/codegen/ForyModelsGen.java
@@ -43,6 +43,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -130,8 +131,9 @@ final class ForyModelsGen implements CodeGenerator {
                 if (_serializedPayload == null) {
                   this._serializedPayload = _FORY.serialize(this);
                 }
-                return _serializedPayload;
-                """)
+                return new $T(_serializedPayload);
+                """,
+                ByteArrayInputStream.class)
             .build());
 
     // _deserialize method (lazily copies fields from a Fory-deserialized temp instance)

--- a/vajram/extensions/fory/vajram-fory/src/main/java/com/flipkart/krystal/vajram/fory/SerializableForyModel.java
+++ b/vajram/extensions/fory/vajram-fory/src/main/java/com/flipkart/krystal/vajram/fory/SerializableForyModel.java
@@ -4,7 +4,6 @@ import static com.flipkart.krystal.vajram.fory.Fory.FORY;
 
 import com.flipkart.krystal.model.SupportedModelProtocol;
 import com.flipkart.krystal.serial.SerializableModel;
-import java.io.OutputStream;
 
 /**
  * Marker interface for Krystal model classes whose on-wire representation is produced by Apache
@@ -17,10 +16,5 @@ public interface SerializableForyModel extends SerializableModel {
   @Override
   default Fory _serdeProtocol() {
     return FORY;
-  }
-
-  @Override
-  default void _serialize(OutputStream outputStream) {
-    Fory.foryInstance().serialize(outputStream, this);
   }
 }

--- a/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
+++ b/vajram/extensions/json/vajram-json-codegen/src/main/java/com/flipkart/krystal/vajram/ext/json/codegen/JsonModelsGen.java
@@ -34,7 +34,7 @@ import com.flipkart.krystal.vajram.codegen.common.generators.SerdeModelValidator
 import com.flipkart.krystal.vajram.json.Json;
 import com.flipkart.krystal.vajram.json.SerializableJsonModel;
 import com.flipkart.krystal.vajram.json.serialized.BytesJson;
-import com.flipkart.krystal.vajram.json.serialized.SerializedJson;
+import com.flipkart.krystal.vajram.json.serialized.JsonRepresentation;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -53,7 +53,6 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeSpec.Builder;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -129,7 +128,7 @@ final class JsonModelsGen implements CodeGenerator {
     jacksonToolFields(classBuilder, immutableJsonModelName);
 
     classBuilder.addField(
-        FieldSpec.builder(SerializedJson.class, "_serializedPayload", PRIVATE)
+        FieldSpec.builder(JsonRepresentation.class, "_serializedPayload", PRIVATE)
             .addAnnotation(JsonIgnore.class)
             .build());
     classBuilder.addField(
@@ -144,12 +143,10 @@ final class JsonModelsGen implements CodeGenerator {
             .addCode(
                 """
                 if (_serializedPayload == null) {
-                  this._serializedPayload = new BytesJson(_WRITER.get().writeValueAsBytes(this));
+                  this._serializedPayload = new $T(_WRITER.get().writeValueAsBytes(this));
                 }
                 return _serializedPayload;
                 """,
-                BytesJson.class,
-                BytesJson.class,
                 BytesJson.class)
             .build());
 
@@ -181,21 +178,6 @@ final class JsonModelsGen implements CodeGenerator {
         MethodSpec.overriding(
                 util.getMethod(() -> SerializableJsonModel.class.getMethod("_writer")))
             .addStatement("return _WRITER.get()")
-            .build());
-
-    classBuilder.addMethod(
-        MethodSpec.overriding(
-                util.getMethod(
-                    () -> SerializableJsonModel.class.getMethod("_serialize", OutputStream.class)))
-            .addCode(
-"""
-      if(_serializedPayload != null) {
-        _serializedPayload.writeTo(outputStream);
-      } else {
-        $T.super._serialize(outputStream);
-      }
-""",
-                SerializableJsonModel.class)
             .build());
 
     List<MethodSpec> methods = new ArrayList<>();
@@ -269,7 +251,7 @@ final class JsonModelsGen implements CodeGenerator {
             // Primary constructor accepting SerializedJson
             MethodSpec.constructorBuilder()
                 .addModifiers(PUBLIC)
-                .addParameter(SerializedJson.class, "_serializedPayload")
+                .addParameter(JsonRepresentation.class, "_serializedPayload")
                 .addStatement("this._serializedPayload = _serializedPayload")
                 .addStatement("this._deserializationPending = true")
                 .build())

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/Json.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/Json.java
@@ -21,7 +21,7 @@ import com.flipkart.krystal.serial.SerdeProtocol;
 import com.flipkart.krystal.vajram.json.array.ByteArrays.ByteArrayDeserializer;
 import com.flipkart.krystal.vajram.json.array.ByteArrays.ByteArraySerializer;
 import com.flipkart.krystal.vajram.json.array.JsonByteArray;
-import com.flipkart.krystal.vajram.json.serialized.SerializedJson;
+import com.flipkart.krystal.vajram.json.serialized.JsonRepresentation;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.io.IOException;
@@ -133,7 +133,7 @@ public final class Json implements SerdeProtocol<JsonConfig, SerializableJsonMod
       return deserialize(innerPayload, reader);
     }
     try {
-      return SerializedJson.of(payload).deserialize(reader);
+      return JsonRepresentation.of(payload).deserialize(reader);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/SerializableJsonModel.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/SerializableJsonModel.java
@@ -10,9 +10,8 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.flipkart.krystal.model.SupportedModelProtocol;
 import com.flipkart.krystal.serial.SerializableModel;
 import com.flipkart.krystal.vajram.json.serialized.BytesJson;
-import com.flipkart.krystal.vajram.json.serialized.SerializedJson;
-import java.io.IOException;
-import java.io.OutputStream;
+import com.flipkart.krystal.vajram.json.serialized.JsonRepresentation;
+import java.io.InputStream;
 
 @SupportedModelProtocol(Json.class)
 public interface SerializableJsonModel extends SerializableModel {
@@ -23,16 +22,11 @@ public interface SerializableJsonModel extends SerializableModel {
   }
 
   @Override
-  default byte[] _serialize() throws JsonProcessingException {
-    return _serializedJson().asBytes().clone();
+  default InputStream _serialize() throws JsonProcessingException {
+    return _serializedJson().newInputStream();
   }
 
-  @Override
-  default void _serialize(OutputStream outputStream) throws IOException {
-    _writer().writeValue(outputStream, this);
-  }
-
-  default SerializedJson _serializedJson() throws JsonProcessingException {
+  default JsonRepresentation _serializedJson() throws JsonProcessingException {
     return new BytesJson(_writer().writeValueAsBytes(this));
   }
 

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/AbstractJsonRepresentation.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/AbstractJsonRepresentation.java
@@ -1,0 +1,28 @@
+package com.flipkart.krystal.vajram.json.serialized;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+abstract sealed class AbstractJsonRepresentation implements JsonRepresentation
+    permits ByteArrayJson, BytesJson, NodeJson, StringJson {
+
+  /* ----Derived fields ----- */
+  protected String string;
+
+  @Override
+  public InputStream newInputStream() {
+    return new ByteArrayInputStream(asBytes());
+  }
+
+  @Override
+  public String asString() {
+    if (string == null) {
+      string = new String(asBytes(), UTF_8);
+    }
+    return string;
+  }
+
+  protected abstract byte[] asBytes();
+}

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/ByteArrayJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/ByteArrayJson.java
@@ -1,21 +1,18 @@
 package com.flipkart.krystal.vajram.json.serialized;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.flipkart.krystal.model.array.ByteArray;
 import com.flipkart.krystal.vajram.json.array.JsonByteArray;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-public final class ByteArrayJson implements SerializedJson {
+public final class ByteArrayJson extends AbstractJsonRepresentation {
 
   private final ByteArray data;
 
   /* ---------- DERIVED FIELDS ----------- */
   private byte @MonotonicNonNull [] bytes;
-  private @MonotonicNonNull String string;
 
   public ByteArrayJson(ByteArray data) {
     this.data = data;
@@ -31,24 +28,8 @@ public final class ByteArrayJson implements SerializedJson {
   }
 
   @Override
-  public byte[] asBytes() {
-    if (bytes == null) {
-      bytes = data.toArray();
-    }
-    return bytes.clone();
-  }
-
-  @Override
-  public String asString() {
-    if (string == null) {
-      string = new String(asBytes(), UTF_8);
-    }
-    return string;
-  }
-
-  @Override
-  public void writeTo(OutputStream outputStream) throws IOException {
-    outputStream.write(asBytes());
+  public InputStream newInputStream() {
+    return data.newInputStream();
   }
 
   @Override
@@ -62,5 +43,13 @@ public final class ByteArrayJson implements SerializedJson {
   @Override
   public int hashCode() {
     return data.hashCode();
+  }
+
+  @Override
+  protected byte[] asBytes() {
+    if (bytes == null) {
+      bytes = data.toArray();
+    }
+    return bytes;
   }
 }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/BytesJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/BytesJson.java
@@ -3,21 +3,15 @@ package com.flipkart.krystal.vajram.json.serialized;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.Objects;
 
-public final class BytesJson implements SerializedJson {
+public final class BytesJson extends AbstractJsonRepresentation {
   private final byte[] data;
   private final int start;
   private final int length;
-
-  /* ---------- DERIVED FIELDS ----------- */
-
-  private byte[] bytes;
-  private String string;
 
   public BytesJson(InputStream inputStream) throws IOException {
     this(inputStream.readAllBytes());
@@ -39,15 +33,8 @@ public final class BytesJson implements SerializedJson {
   }
 
   @Override
-  public byte[] asBytes() {
-    if (bytes == null) {
-      if (start == 0 && length == data.length) {
-        bytes = data;
-      } else {
-        bytes = Arrays.copyOfRange(data, start, start + length);
-      }
-    }
-    return bytes.clone();
+  public InputStream newInputStream() {
+    return new ByteArrayInputStream(data, start, length);
   }
 
   @Override
@@ -59,8 +46,14 @@ public final class BytesJson implements SerializedJson {
   }
 
   @Override
-  public void writeTo(OutputStream outputStream) throws IOException {
-    outputStream.write(data, start, length);
+  protected byte[] asBytes() {
+    byte[] bytes;
+    if (start == 0 && length == data.length) {
+      bytes = data;
+    } else {
+      bytes = Arrays.copyOfRange(data, start, start + length);
+    }
+    return bytes;
   }
 
   @Override
@@ -83,7 +76,11 @@ public final class BytesJson implements SerializedJson {
 
   @Override
   public int hashCode() {
-    return Objects.hash(data, start, length);
+    int result = 1;
+    for (int i = start; i < start + length; i++) {
+      result = 31 * result + data[i];
+    }
+    return result;
   }
 
   @Override

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/JsonRepresentation.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/JsonRepresentation.java
@@ -1,37 +1,37 @@
 package com.flipkart.krystal.vajram.json.serialized;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.flipkart.krystal.model.array.ByteArray;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
-public sealed interface SerializedJson permits BytesJson, StringJson, ByteArrayJson {
+public sealed interface JsonRepresentation permits AbstractJsonRepresentation {
   <T> T deserialize(ObjectReader reader) throws IOException;
 
-  byte[] asBytes();
+  InputStream newInputStream();
 
   String asString();
-
-  void writeTo(OutputStream outputStream) throws IOException;
 
   default boolean isReusable() {
     return true;
   }
 
-  static SerializedJson of(Object payload) throws IOException {
-    SerializedJson serializedJson;
+  static JsonRepresentation of(Object payload) throws IOException {
+    JsonRepresentation jsonRepresentation;
     if (payload instanceof InputStream inputStream) {
-      serializedJson = new BytesJson(inputStream);
+      jsonRepresentation = new BytesJson(inputStream);
     } else if (payload instanceof byte[] bytes) {
-      serializedJson = new BytesJson(bytes);
+      jsonRepresentation = new BytesJson(bytes);
     } else if (payload instanceof String string) {
-      serializedJson = new StringJson(string);
+      jsonRepresentation = new StringJson(string);
     } else if (payload instanceof ByteArray byteArray) {
-      serializedJson = new ByteArrayJson(byteArray);
+      jsonRepresentation = new ByteArrayJson(byteArray);
+    } else if (payload instanceof JsonNode jsonNode) {
+      jsonRepresentation = new NodeJson(jsonNode);
     } else {
       throw new IllegalArgumentException("Unsupported payload type: " + payload.getClass());
     }
-    return serializedJson;
+    return jsonRepresentation;
   }
 }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/NodeJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/NodeJson.java
@@ -1,0 +1,38 @@
+package com.flipkart.krystal.vajram.json.serialized;
+
+import static com.flipkart.krystal.except.KrystalCompletionException.wrapAsCompletionException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.flipkart.krystal.vajram.json.Json;
+import java.io.IOException;
+
+public final class NodeJson extends AbstractJsonRepresentation {
+
+  private final JsonNode jsonNode;
+
+  /* ----Derived fields ----- */
+  private byte[] bytes;
+
+  public NodeJson(JsonNode jsonNode) {
+    this.jsonNode = jsonNode;
+  }
+
+  @Override
+  public <T> T deserialize(ObjectReader reader) throws IOException {
+    return reader.readValue(jsonNode);
+  }
+
+  @Override
+  protected byte[] asBytes() {
+    if (bytes == null) {
+      try {
+        bytes = Json.OBJECT_WRITER.writeValueAsBytes(jsonNode);
+      } catch (JsonProcessingException e) {
+        throw wrapAsCompletionException(e, "Unable to convert json node to byte array");
+      }
+    }
+    return bytes;
+  }
+}

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
@@ -3,11 +3,12 @@ package com.flipkart.krystal.vajram.json.serialized;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.io.CharSource;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-public final class StringJson implements SerializedJson {
+public final class StringJson extends AbstractJsonRepresentation {
 
   private final String string;
 
@@ -27,11 +28,12 @@ public final class StringJson implements SerializedJson {
   }
 
   @Override
-  public byte[] asBytes() {
-    if (bytes == null) {
-      bytes = string.getBytes(UTF_8);
+  public InputStream newInputStream() {
+    try {
+      return CharSource.wrap(string).asByteSource(UTF_8).openStream();
+    } catch (IOException e) {
+      throw new ArrayStoreException("String CharSource cannot throw exception when opening Stream");
     }
-    return bytes.clone();
   }
 
   @Override
@@ -39,9 +41,11 @@ public final class StringJson implements SerializedJson {
     return string;
   }
 
-  @Override
-  public void writeTo(OutputStream outputStream) throws IOException {
-    outputStream.write(asBytes());
+  protected byte[] asBytes() {
+    if (bytes == null) {
+      bytes = string.getBytes(UTF_8);
+    }
+    return bytes;
   }
 
   @Override

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
@@ -32,7 +32,7 @@ public final class StringJson extends AbstractJsonRepresentation {
     try {
       return CharSource.wrap(string).asByteSource(UTF_8).openStream();
     } catch (IOException e) {
-      throw new ArrayStoreException("String CharSource cannot throw exception when opening Stream");
+      throw new AssertionError("String CharSource cannot throw exception when opening Stream");
     }
   }
 

--- a/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/BaseProtoModelsGen.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-codegen-util/src/main/java/com/flipkart/krystal/vajram/protobuf/codegen/util/BaseProtoModelsGen.java
@@ -39,6 +39,7 @@ import com.flipkart.krystal.vajram.protobuf.util.SerializableProtoModel;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.protobuf.ByteString;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
@@ -215,8 +216,6 @@ public abstract class BaseProtoModelsGen implements CodeGenerator {
         ParameterizedTypeName.get(
             ClassName.get(config.serializableProtoSubInterface()), protoMsgType);
 
-    TypeName byteArrayType = ArrayTypeName.of(TypeName.BYTE);
-
     Builder classBuilder =
         util.classBuilder(protoClassName, modelRootType.getQualifiedName().toString())
             .addModifiers(PUBLIC)
@@ -224,11 +223,7 @@ public abstract class BaseProtoModelsGen implements CodeGenerator {
             .addSuperinterface(serializableTypeName);
 
     classBuilder.addField(
-        FieldSpec.builder(
-                byteArrayType.annotated(AnnotationSpec.builder(MonotonicNonNull.class).build()),
-                "_serializedPayload",
-                PRIVATE)
-            .build());
+        FieldSpec.builder(ByteString.class, "_serializedPayload", PRIVATE).build());
     classBuilder.addField(
         FieldSpec.builder(
                 protoMsgType.annotated(AnnotationSpec.builder(MonotonicNonNull.class).build()),
@@ -239,7 +234,14 @@ public abstract class BaseProtoModelsGen implements CodeGenerator {
     classBuilder.addMethod(
         MethodSpec.constructorBuilder()
             .addModifiers(PUBLIC)
-            .addParameter(byteArrayType, "_serializedPayload")
+            .addParameter(ArrayTypeName.of(TypeName.BYTE), "_serializedPayload")
+            .addStatement("this($T.copyFrom(_serializedPayload))", ByteString.class)
+            .build());
+
+    classBuilder.addMethod(
+        MethodSpec.constructorBuilder()
+            .addModifiers(PUBLIC)
+            .addParameter(ByteString.class, "_serializedPayload")
             .addStatement("this._serializedPayload = _serializedPayload")
             .addStatement("this._proto = null")
             .build());
@@ -266,10 +268,10 @@ public abstract class BaseProtoModelsGen implements CodeGenerator {
         MethodSpec.overriding(util.getMethod(SerializableModel.class, "_serialize", 0))
             .addCode(
 """
-if (_serializedPayload == null){
-  this._serializedPayload = _proto.toByteArray();
-}
-return _serializedPayload.clone();
+    if (_serializedPayload == null){
+      this._serializedPayload = _proto.toByteString();
+    }
+    return _serializedPayload.newInput();
 """)
             .build());
 

--- a/vajram/extensions/protobuf/vajram-protobuf-util/src/main/java/com/flipkart/krystal/vajram/protobuf/util/SerializableProtoModel.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-util/src/main/java/com/flipkart/krystal/vajram/protobuf/util/SerializableProtoModel.java
@@ -2,8 +2,6 @@ package com.flipkart.krystal.vajram.protobuf.util;
 
 import com.flipkart.krystal.serial.SerializableModel;
 import com.google.protobuf.Message;
-import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * Common base interface for any model whose on-wire representation is a protobuf message,
@@ -14,9 +12,4 @@ import java.io.OutputStream;
  */
 public interface SerializableProtoModel<P extends Message> extends SerializableModel {
   P _proto();
-
-  @Override
-  default void _serialize(OutputStream outputStream) throws IOException {
-    _proto().writeTo(outputStream);
-  }
 }


### PR DESCRIPTION


Change `SerializableModel._serialize()` to return a non-blocking `InputStream` instead of `byte[]`, and remove the `_serialize(OutputStream)` overload from the interface and all protocol-specific sub-interfaces.

- `SerializableModel`: `_serialize()` now returns `InputStream`; drop `_serialize(OutputStream)`
- `SerializableForyModel`, `SerializableProtoModel`: remove `_serialize(OutputStream)` default impls
- `SerializableJsonModel`: `_serialize()` returns `InputStream` via `_serializedJson().newInputStream()`; drop `_serialize(OutputStream)` default
- Rename `SerializedJson` → `JsonRepresentation` (sealed interface); expose `newInputStream()` and `asString()`, hide `asBytes()` as a protected impl detail
- Introduce `AbstractJsonRepresentation` sealed base class with shared `newInputStream()` and `asString()` logic
- Add `NodeJson` for `JsonNode`-backed representations
- Migrate `ByteArrayJson`, `BytesJson`, `StringJson` to extend `AbstractJsonRepresentation`; replace `writeTo(OutputStream)` with `newInputStream()`
- Add `JsonRepresentation.of(Object)` factory for common payload types
- Fix `KrystalCompletionException.wrapAsCompletionException(t, message)` to always wrap when a message is supplied, even if `t` is already a `CompletionException`; add javadoc
- Update `JsonModelsGen`, `ForyModelsGen`, `BaseProtoModelsGen` and lattice sample tests accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Serialization now supports streaming through input streams, improving handling of large payloads.
  * REST responses can stream serialized model data instead of requiring full in-memory byte arrays.
  * JSON serialization supports node-based representations and more flexible payload handling.
  * Serialization support is aligned across JSON, protobuf, and Fory models.

* **Bug Fixes**
  * Completion exceptions now preserve explicitly provided wrapper messages when wrapping existing completion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->