### PR TITLE
VajramId interning, Remove isolating anno processor config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g
 org.gradle.configuration-cache=true
 
-com.flipkart.krystal.previousVersion=11.2.1
-com.flipkart.krystal.currentVersion=11.2.2
-com.flipkart.krystal.lattice.currentVersion=0.5.2
+com.flipkart.krystal.previousVersion=11.2.2
+com.flipkart.krystal.currentVersion=11.2.3
+com.flipkart.krystal.lattice.currentVersion=0.5.3
 java_code_std_version=5.8

--- a/krystal-codegen-common/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/krystal-codegen-common/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,1 +1,0 @@
-com.flipkart.krystal.codegen.common.processors.ModelGenProcessor,isolating

--- a/krystal-common/src/main/java/com/flipkart/krystal/core/VajramID.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/core/VajramID.java
@@ -1,10 +1,23 @@
 package com.flipkart.krystal.core;
 
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+
 // @jdk.internal.ValueBased
-public record VajramID(String id) {
+public final class VajramID {
+
+  // Must use ConcurrentHashMap for thread safety - else we will encounter
+  // ConcurrentModificationException
+  private static final ConcurrentHashMap<String, VajramID> internPool = new ConcurrentHashMap<>();
+
+  @Getter private final String id;
+
+  private VajramID(String id) {
+    this.id = id;
+  }
 
   public static VajramID vajramID(String id) {
-    return new VajramID(id);
+    return internPool.computeIfAbsent(id, _k -> new VajramID(id));
   }
 
   @Override

--- a/krystal-common/src/test/java/com/flipkart/krystal/core/VajramIDTest.java
+++ b/krystal-common/src/test/java/com/flipkart/krystal/core/VajramIDTest.java
@@ -1,0 +1,41 @@
+package com.flipkart.krystal.core;
+
+import static com.flipkart.krystal.core.VajramID.vajramID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class VajramIDTest {
+
+  @Test
+  void sameIdReturnsSameInstance() {
+    VajramID first = vajramID("testVajram");
+    VajramID second = vajramID("testVajram");
+    assertThat(first).isSameAs(second);
+  }
+
+  @Test
+  void differentIdsReturnDifferentInstances() {
+    VajramID a = vajramID("vajramA");
+    VajramID b = vajramID("vajramB");
+    assertThat(a).isNotSameAs(b);
+  }
+
+  @Test
+  void internedInstancesAreEqualByReference() {
+    VajramID first = vajramID("internedVajram");
+    VajramID second = vajramID("internedVajram");
+    // interning guarantees reference equality, so == is equivalent to equals
+    assertThat(first == second).isTrue();
+  }
+
+  @Test
+  void idValueIsPreserved() {
+    assertThat(vajramID("myVajram").id()).isEqualTo("myVajram");
+  }
+
+  @Test
+  void toStringFormat() {
+    assertThat(vajramID("foo").toString()).isEqualTo("v<foo>");
+  }
+}

--- a/krystal-visualization/src/test/java/com/flipkart/krystal/visualization/executiongraph/DefaultKryonExecutionReportTest.java
+++ b/krystal-visualization/src/test/java/com/flipkart/krystal/visualization/executiongraph/DefaultKryonExecutionReportTest.java
@@ -1,5 +1,6 @@
 package com.flipkart.krystal.visualization.executiongraph;
 
+import static com.flipkart.krystal.core.VajramID.vajramID;
 import static com.flipkart.krystal.data.Errable.withValue;
 import static com.flipkart.krystal.krystex.testfixtures.SimpleFacet.input;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -43,7 +44,7 @@ class DefaultKryonExecutionReportTest {
 
   @Test
   void reportStartAndEnd_success() {
-    VajramID vajramID = new VajramID("kryon_1");
+    VajramID vajramID = vajramID("kryon_1");
     KryonLogicId kryonLogicId = new KryonLogicId(vajramID, "kryon_1__logic_1");
     Set<SimpleFacet> allInputs = Set.of(input("facet1"));
     ImmutableList<ExecutionItem> facetValuesList =
@@ -123,7 +124,7 @@ class DefaultKryonExecutionReportTest {
 
   @Test
   void reportMainLogicStart_calledTwice_hasNoEffect() {
-    VajramID vajramID = new VajramID("kryon_1");
+    VajramID vajramID = vajramID("kryon_1");
     KryonLogicId kryonLogicId = new KryonLogicId(vajramID, "kryon_1__logic_1");
     ImmutableList<ExecutionItem> facetValuesList =
         ImmutableList.of(
@@ -162,7 +163,7 @@ class DefaultKryonExecutionReportTest {
 
   @Test
   void reportMainLogicEnd_calledTwice_hasNoEffect() {
-    VajramID vajramID = new VajramID("kryon_1");
+    VajramID vajramID = vajramID("kryon_1");
     KryonLogicId kryonLogicId = new KryonLogicId(vajramID, "kryon_1__logic_1");
     ImmutableList<ExecutionItem> facetValuesList =
         ImmutableList.of(
@@ -220,7 +221,7 @@ class DefaultKryonExecutionReportTest {
 
   @Test
   void reportMainLogicEnd_calledWithoutCallingStart_hasNoEffect() {
-    VajramID vajramID = new VajramID("kryon_1");
+    VajramID vajramID = vajramID("kryon_1");
     KryonLogicId kryonLogicId = new KryonLogicId(vajramID, "kryon_1__logic_1");
     ImmutableList<FacetValues> facetValuesList =
         ImmutableList.of(

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/LogicDefRegistryDecorator.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/LogicDefRegistryDecorator.java
@@ -12,10 +12,9 @@ import java.util.Set;
 public record LogicDefRegistryDecorator(LogicDefinitionRegistry delegate) {
 
   public LogicDefinition<ResolverLogic> newResolverLogic(
-      String kryonId, String kryonLogicId, Set<? extends Facet> inputs, ResolverLogic logic) {
+      VajramID vajramID, String kryonLogicId, Set<? extends Facet> inputs, ResolverLogic logic) {
     LogicDefinition<ResolverLogic> def =
-        new LogicDefinition<>(
-            new KryonLogicId(new VajramID(kryonId), kryonLogicId), inputs, emptyTags(), logic);
+        new LogicDefinition<>(new KryonLogicId(vajramID, kryonLogicId), inputs, emptyTags(), logic);
     delegate.addResolver(def);
     return def;
   }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/VajramGraph.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/VajramGraph.java
@@ -236,7 +236,7 @@ public final class VajramGraph {
             vajramDefRoot::newRequestBuilder);
     if (vajramDefinition.isTrait()) {
       kryonDefinitionRegistry.newTraitKryonDefinition(
-          vajramId.id(), facets, createNewRequest, vajramDefinition.vajramTags());
+          vajramId, facets, createNewRequest, vajramDefinition.vajramTags());
     } else if (vajramDefRoot instanceof VajramDef<Object> vajramDef) {
       InputResolverCreationResult inputResolverCreationResult =
           createKryonLogicsForInputResolvers(vajramDefinition);
@@ -343,7 +343,7 @@ public final class VajramGraph {
               facetDefinitions.stream().filter(sources::contains).collect(toImmutableList());
           LogicDefinition<ResolverLogic> inputResolverLogic =
               logicRegistryDecorator.newResolverLogic(
-                  vajramId.id(),
+                  vajramId,
                   "%s:dep(%s):inputResolver(%s)"
                       .formatted(
                           vajramId,

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinitionRegistry.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/kryon/KryonDefinitionRegistry.java
@@ -74,12 +74,12 @@ public final class KryonDefinitionRegistry {
   }
 
   public TraitKryonDefinition newTraitKryonDefinition(
-      String kryonId,
+      VajramID vajramID,
       Set<? extends Facet> facets,
       LogicDefinition<CreateNewRequest> createNewRequest,
       ElementTags tags) {
     TraitKryonDefinition kryonDefinition =
-        new TraitKryonDefinition(new VajramID(kryonId), facets, createNewRequest, this, tags);
+        new TraitKryonDefinition(vajramID, facets, createNewRequest, this, tags);
     kryonDefinitions.put(kryonDefinition.vajramID(), kryonDefinition);
     return kryonDefinition;
   }

--- a/krystex/src/test/java/com/flipkart/krystal/krystex/kryon/KryonExecutionTest.java
+++ b/krystex/src/test/java/com/flipkart/krystal/krystex/kryon/KryonExecutionTest.java
@@ -640,7 +640,7 @@ class KryonExecutionTest {
         Exception.class,
         () ->
             kryonExecutor.execute(
-                SimpleImmutRequest.empty(new VajramID(kryonName)),
+                SimpleImmutRequest.empty(vajramID(kryonName)),
                 VajramExecutionConfig.builder().executionId("req_1").build()));
   }
 

--- a/lattice/lattice-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/lattice/lattice-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,1 +1,0 @@
-com.flipkart.krystal.lattice.codegen.LatticeAnnotationProcessor,isolating

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,1 +1,0 @@
-com.flipkart.krystal.vajram.graphql.codegen.GraphQLAnnotationProcessor,aggregating

--- a/vajram/extensions/resilience4j/vajram-resilience4j/src/test/java/com/flipkart/krystal/vajram/resilience4j/Resilience4JBulkheadTest.java
+++ b/vajram/extensions/resilience4j/vajram-resilience4j/src/test/java/com/flipkart/krystal/vajram/resilience4j/Resilience4JBulkheadTest.java
@@ -299,7 +299,7 @@ class Resilience4JBulkheadTest {
       String kryonId, Set<? extends Facet> usedFacets, Consumer<ExecutionItem> logic) {
     IOLogicDefinition<T> def =
         new IOLogicDefinition<>(
-            new KryonLogicId(new VajramID(kryonId), kryonId + ":asyncLogic"),
+            new KryonLogicId(vajramID(kryonId), kryonId + ":asyncLogic"),
             usedFacets,
             input -> input.executionItems().forEach(logic::accept),
             emptyTags());
@@ -310,7 +310,7 @@ class Resilience4JBulkheadTest {
   @SuppressWarnings("unchecked")
   @NonNull
   private static LogicDefinition<FacetsFromRequest> newFacetsFromRequestLogic() {
-    VajramID vajramID = new VajramID("kryon");
+    VajramID vajramID = vajramID("kryon");
     return new LogicDefinition<>(
         new KryonLogicId(vajramID, "kryon:facetsFromRequest"),
         request ->
@@ -321,7 +321,7 @@ class Resilience4JBulkheadTest {
   @NonNull
   private static LogicDefinition<CreateNewRequest> newCreateNewRequestLogic(
       Set<? extends InputMirror> inputs) {
-    VajramID vajramID = new VajramID("kryon");
+    VajramID vajramID = vajramID("kryon");
     return new LogicDefinition<>(
         new KryonLogicId(vajramID, "kryon:newRequest"),
         () -> new SimpleRequestBuilder<>(inputs, vajramID));

--- a/vajram/extensions/sql/vertx/vajram-sql-vertx-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/vajram/extensions/sql/vertx/vajram-sql-vertx-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,1 +1,0 @@
-com.flipkart.krystal.vajram.ext.sql.vertx.codegen.VertxSqlAnnoProcessor,isolating

--- a/vajram/vajram-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/vajram/vajram-codegen/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,3 +1,0 @@
-com.flipkart.krystal.vajram.codegen.processor.VajramModelGenProcessor,isolating
-com.flipkart.krystal.vajram.codegen.processor.VajramWrapperGenProcessor,isolating
-com.flipkart.krystal.vajram.codegen.processor.VajramInputsGenProcessor,isolating


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reused identical Vajram IDs to reduce duplicate object creation and improve efficiency.

* **API Improvements**
  * Updated graph and definition registration APIs to accept Vajram ID objects directly.

* **Maintenance**
  * Simplified annotation processor configuration across code generation modules.

* **Tests**
  * Updated test utilities to use the standardized Vajram ID factory without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->