### PR TITLE
Allow usage of classes generated in final phase without 'krystalModelsGen' failing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,8 @@ ext {
 // Load the gradle.private.properties file for dev-local settings
 def privateProperties = new Properties()
 def privatePropertiesFile = rootProject.file('gradle.private.properties')
-
 if (privatePropertiesFile.exists()) {
-    privateProperties.load(new FileInputStream(privatePropertiesFile))
-
-    // 2. Inject them into Gradle's extra properties
-    privateProperties.each { key, value ->
-        extensions.extraProperties.set(key, value)
-    }
+    new FileInputStream(privatePropertiesFile).withStream { stream -> privateProperties.load(stream) }
 }
 
 group = 'com.flipkart.krystal'
@@ -54,8 +48,7 @@ configure(subprojects.findAll {
     //Only leaf projects need publishing
     it.subprojects.isEmpty()
             //Exclude non java projects
-            && it.name != 'code-coverage-report'
-            && it.name != 'krystal-intellij-plugin'
+            && it.name != 'code-coverage-report' && it.name != 'krystal-intellij-plugin'
             // Exclude sample projects so that they are configured independently making
             // them a better representation of how clients should use krystal
             && !it.name.contains('sample')
@@ -131,6 +124,10 @@ configure(subprojects.findAll {
             required { System.getenv("CI") != null }
         }
     }
+}
+
+subprojects {
+    privateProperties.each { key, value -> project.extensions.extraProperties.set(key.toString(), value) }
 }
 
 configure(subprojects.findAll {

--- a/fk-java-code-std-plugin/build.gradle
+++ b/fk-java-code-std-plugin/build.gradle
@@ -17,7 +17,7 @@ ext {
 }
 
 group 'com.flipkart.java.code.standard'
-version '5.8'
+version '5.9'
 
 gradlePlugin {
     plugins {

--- a/fk-java-code-std-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/fk-java-code-std-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/fk-java-code-std-plugin/src/main/groovy/com/flipkart/java/code/FkJavaCodeStandardPlugin.groovy
+++ b/fk-java-code-std-plugin/src/main/groovy/com/flipkart/java/code/FkJavaCodeStandardPlugin.groovy
@@ -36,7 +36,7 @@ class FkJavaCodeStandardPlugin implements Plugin<Project> {
     }
 
     private static checkerFramework(Project project) {
-        def checker_version = '3.52.0'
+        def checker_version = '3.53.1'
         project.pluginManager.apply('org.checkerframework')
         CheckerFrameworkExtension checkerFramework = project.extensions.findByType(CheckerFrameworkExtension)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,15 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g
 org.gradle.configuration-cache=true
-
 com.flipkart.krystal.previousVersion=11.2.2
 com.flipkart.krystal.currentVersion=11.2.3
 com.flipkart.krystal.lattice.currentVersion=0.5.3
-java_code_std_version=5.8
+java_code_std_version=5.9
+# This project property is consumed by the "com.flipkart.java.code.standard" gradle plugin
+#
+# Change this to "false" to find code issues reported by checkerFramework, error-prone etc.
+#
+# Temporarily defaulting to unsafe compilation since there is a bug in checkerFramework
+# which causes failure when compiling DefaultFacetSpec class with this error:
+# "class file for org.checkerframework.checker.nonempty.qual.UnknownNonEmpty not found"
+unsafeCompile=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ com.flipkart.krystal.previousVersion=11.2.2
 com.flipkart.krystal.currentVersion=11.2.3
 com.flipkart.krystal.lattice.currentVersion=0.5.3
 java_code_std_version=5.9
-# This project property is consumed by the "com.flipkart.java.code.standard" gradle plugin
+# This project property is consumed by the "com.flipkart.java.code.standard" Gradle plugin
 #
 # Change this to "false" to find code issues reported by checkerFramework, error-prone etc.
 #

--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/processors/ModelGenProcessor.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/processors/ModelGenProcessor.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -144,23 +143,23 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
         modelRootType.getAnnotationsByType(SupportedModelProtocol.class);
     SupportedModelProtocolName[] protocolNames =
         modelRootType.getAnnotationsByType(SupportedModelProtocolName.class);
-    Set<Class<? extends ModelProtocol>> modelProtocolClasses =
-        Arrays.stream(protocols)
-            .map(p -> util.getTypeElemFromAnnotationMember(p::value))
-            .map(element -> element.getQualifiedName().toString())
-            .map(
-                protocolName -> {
-                  try {
-                    //noinspection unchecked
-                    return (Class<? extends ModelProtocol>)
-                        Class.forName(protocolName, false, this.getClass().getClassLoader());
-                  } catch (ClassNotFoundException e) {
-                    util.error(Throwables.getStackTraceAsString(e), modelRootType);
-                    return null;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+    Set<Class<? extends ModelProtocol>> modelProtocolClasses = new LinkedHashSet<>();
+
+    for (SupportedModelProtocol protocol : protocols) {
+      try {
+        //noinspection unchecked
+        modelProtocolClasses.add(
+            (Class<? extends ModelProtocol>)
+                Class.forName(
+                    util.getTypeElemFromAnnotationMember(protocol::value)
+                        .getQualifiedName()
+                        .toString(),
+                    false,
+                    this.getClass().getClassLoader()));
+      } catch (ClassNotFoundException e) {
+        util.error(Throwables.getStackTraceAsString(e), modelRootType);
+      }
+    }
 
     modelProtocolClasses.addAll(
         Arrays.stream(protocolNames)
@@ -179,6 +178,7 @@ public final class ModelGenProcessor extends AbstractKrystalAnnoProcessor {
                   }
                 })
             .filter(Objects::nonNull)
+            .map(Objects::requireNonNull)
             .collect(toSet()));
 
     if (modelProtocolClasses.isEmpty()) {

--- a/krystal-common/src/main/java/com/flipkart/krystal/serial/SerdeProtocol.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/serial/SerdeProtocol.java
@@ -59,5 +59,5 @@ public interface SerdeProtocol<A extends Annotation, T extends SerializableModel
    * @param customConfig custom configuration on how to deserialize
    * @return the deserialized object
    */
-  <T> @PolyNull T deserialize(@PolyNull Object payload, Object typeInfo, @Nullable A customConfig);
+  <T> @Nullable T deserialize(@Nullable Object payload, Object typeInfo, @Nullable A customConfig);
 }

--- a/krystal-common/src/main/java/com/flipkart/krystal/tags/ElementTags.java
+++ b/krystal-common/src/main/java/com/flipkart/krystal/tags/ElementTags.java
@@ -2,6 +2,7 @@ package com.flipkart.krystal.tags;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.synchronizedMap;
+import static java.util.Objects.requireNonNullElse;
 import static java.util.stream.Collectors.groupingBy;
 
 import com.flipkart.krystal.annos.ElementTagUtility;
@@ -265,7 +266,7 @@ public final class ElementTags {
     List<Annotation> unpacked = new ArrayList<>();
     try {
       Annotation[] nestedAnnos = (Annotation[]) containedAnnotationsMethod.invoke(annotation);
-      unpacked.addAll(Arrays.asList(nestedAnnos));
+      unpacked.addAll(Arrays.asList(requireNonNullElse(nestedAnnos, new Annotation[] {})));
     } catch (Exception e) {
       // Fallback in case of reflection exceptions
       unpacked.add(annotation);

--- a/lattice/samples/grpc-proto2024e-lattice-sample/build.gradle
+++ b/lattice/samples/grpc-proto2024e-lattice-sample/build.gradle
@@ -84,6 +84,16 @@ protobuf {
 
 tasks.named('extractProto').configure { mustRunAfter('krystalModelsGen') }
 
+// If the project uses classes which are generated AFTER krystalModelsGen task finishes,
+// then we need to skipCheckerFramework so that krystalModelsGen doesn't fail.
+// This is needed because checkerFramework fails if any of the classes used have not yet been generated.
+// The java compiler itself doesn't have a problem with this
+tasks.named('krystalModelsGen', org.gradle.api.tasks.compile.JavaCompile).configure {
+    checkerFramework {
+        skipCheckerFramework = true
+    }
+}
+
 extraJavaModuleInfo {
     failOnMissingModuleInfo = false
 }

--- a/lattice/samples/grpc-proto3-lattice-sample/build.gradle
+++ b/lattice/samples/grpc-proto3-lattice-sample/build.gradle
@@ -83,6 +83,16 @@ protobuf {
 
 tasks.named('extractProto').configure { mustRunAfter('krystalModelsGen') }
 
+// If the project uses classes which are generated AFTER krystalModelsGen task finishes,
+// then we need to skipCheckerFramework so that krystalModelsGen doesn't fail.
+// This is needed because checkerFramework fails if any of the classes used have not yet been generated.
+// The java compiler itself doesn't have a problem with this
+tasks.named('krystalModelsGen', org.gradle.api.tasks.compile.JavaCompile).configure {
+    checkerFramework {
+        skipCheckerFramework = true
+    }
+}
+
 extraJavaModuleInfo {
     failOnMissingModuleInfo = false
 }

--- a/vajram/extensions/fory/vajram-fory/src/main/java/com/flipkart/krystal/vajram/fory/Fory.java
+++ b/vajram/extensions/fory/vajram-fory/src/main/java/com/flipkart/krystal/vajram/fory/Fory.java
@@ -10,7 +10,6 @@ import java.util.ServiceLoader;
 import java.util.function.Function;
 import org.apache.fory.ThreadSafeFory;
 import org.apache.fory.config.Language;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
@@ -72,16 +71,16 @@ public final class Fory implements SerdeProtocol<NoAnnotation, SerializableModel
 
   @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
   @Override
-  public <T> @PolyNull T deserialize(
-      @PolyNull Object payload, Object typeInfo, @Nullable NoAnnotation customConfig) {
+  public <T> @Nullable T deserialize(
+      @Nullable Object payload, Object typeInfo, @Nullable NoAnnotation customConfig) {
     if (payload == null) {
       return null;
     }
     if (typeInfo instanceof Class<?> clazz) {
       if (payload instanceof byte[] bytes) {
-        return (@NonNull T) FORY_INSTANCE.deserialize(bytes, clazz);
+        return (T) FORY_INSTANCE.deserialize(bytes, clazz);
       } else if (payload instanceof ByteArray byteArray) {
-        return (@NonNull T) FORY_INSTANCE.deserialize(byteArray.toArray(), clazz);
+        return (T) FORY_INSTANCE.deserialize(byteArray.toArray(), clazz);
       }
     }
     throw new UnsupportedOperationException(

--- a/vajram/extensions/fory/vajram-fory/src/main/java/com/flipkart/krystal/vajram/fory/Fory.java
+++ b/vajram/extensions/fory/vajram-fory/src/main/java/com/flipkart/krystal/vajram/fory/Fory.java
@@ -10,7 +10,9 @@ import java.util.ServiceLoader;
 import java.util.function.Function;
 import org.apache.fory.ThreadSafeFory;
 import org.apache.fory.config.Language;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
 
 /**
  * {@link SerdeProtocol} implementation backed by <a href="https://fory.apache.org/">Apache Fory</a>
@@ -58,21 +60,28 @@ public final class Fory implements SerdeProtocol<NoAnnotation, SerializableModel
   }
 
   @Override
-  public ByteArray serialize(
-      Object object,
+  public @PolyNull ByteArray serialize(
+      @PolyNull Object object,
       Function<Model, SerializableModel> modelMapper,
       @Nullable NoAnnotation customConfig) {
+    if (object == null) {
+      return null;
+    }
     return SimpleByteArray.backedBy(FORY_INSTANCE.serialize(object));
   }
 
   @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
   @Override
-  public <T> T deserialize(Object payload, Object typeInfo, @Nullable NoAnnotation customConfig) {
+  public <T> @PolyNull T deserialize(
+      @PolyNull Object payload, Object typeInfo, @Nullable NoAnnotation customConfig) {
+    if (payload == null) {
+      return null;
+    }
     if (typeInfo instanceof Class<?> clazz) {
       if (payload instanceof byte[] bytes) {
-        return (T) FORY_INSTANCE.deserialize(bytes, clazz);
+        return (@NonNull T) FORY_INSTANCE.deserialize(bytes, clazz);
       } else if (payload instanceof ByteArray byteArray) {
-        return (T) FORY_INSTANCE.deserialize(byteArray.toArray(), clazz);
+        return (@NonNull T) FORY_INSTANCE.deserialize(byteArray.toArray(), clazz);
       }
     }
     throw new UnsupportedOperationException(

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/Json.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/Json.java
@@ -33,8 +33,8 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
@@ -100,42 +100,37 @@ public final class Json implements SerdeProtocol<JsonConfig, SerializableJsonMod
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> @Nullable T deserialize(
-      @Nullable Object payload, Object typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @PolyNull T deserialize(
+      @PolyNull Object payload, Object typeInfo, @Nullable JsonConfig customConfig) {
     if (typeInfo instanceof Class<?> clazz) {
-      return (T) deserialize(payload, clazz, customConfig);
+      return (@NonNull T) deserialize(payload, clazz, customConfig);
     } else if (typeInfo instanceof Type type) {
       return deserialize(payload, type, customConfig);
     } else if (typeInfo instanceof TypeReference<?> typeRef) {
-      return (T) deserialize(payload, typeRef, customConfig);
+      return (@NonNull T) deserialize(payload, typeRef, customConfig);
     } else {
       throw new IllegalArgumentException("Unsupported typeInfo: " + typeInfo);
     }
   }
 
-  public <T> @Nullable T deserialize(
-      @Nullable Object payload, Class<? extends T> typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @PolyNull T deserialize(
+      @PolyNull Object payload, Class<? extends T> typeInfo, @Nullable JsonConfig customConfig) {
     return deserialize(payload, OBJECT_READER.forType(typeInfo));
   }
 
-  public <T> @Nullable T deserialize(
-      @Nullable Object payload, Type typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @PolyNull T deserialize(
+      @PolyNull Object payload, Type typeInfo, @Nullable JsonConfig customConfig) {
     return deserialize(payload, OBJECT_READER.forType(typeInfo));
   }
 
-  public <T> @Nullable T deserialize(
-      @Nullable Object payload, TypeReference<T> typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @PolyNull T deserialize(
+      @PolyNull Object payload, TypeReference<T> typeInfo, @Nullable JsonConfig customConfig) {
     return deserialize(payload, OBJECT_READER.forType(typeInfo));
   }
 
-  private static <T> @Nullable T deserialize(@Nullable Object payload, ObjectReader reader) {
+  private static <T> @PolyNull T deserialize(@PolyNull Object payload, ObjectReader reader) {
     if (payload == null) {
       return null;
-    }
-    if (payload instanceof Optional<? extends @Nullable Object> optional) {
-      @SuppressWarnings("argument")
-      Object innerPayload = optional.orElse(null);
-      return deserialize(innerPayload, reader);
     }
     try {
       return JsonRepresentation.of(payload).deserialize(reader);

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/Json.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/Json.java
@@ -100,35 +100,35 @@ public final class Json implements SerdeProtocol<JsonConfig, SerializableJsonMod
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> @PolyNull T deserialize(
-      @PolyNull Object payload, Object typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @Nullable T deserialize(
+      @Nullable Object payload, Object typeInfo, @Nullable JsonConfig customConfig) {
     if (typeInfo instanceof Class<?> clazz) {
       return (@NonNull T) deserialize(payload, clazz, customConfig);
     } else if (typeInfo instanceof Type type) {
       return deserialize(payload, type, customConfig);
     } else if (typeInfo instanceof TypeReference<?> typeRef) {
-      return (@NonNull T) deserialize(payload, typeRef, customConfig);
+      return (T) deserialize(payload, typeRef, customConfig);
     } else {
       throw new IllegalArgumentException("Unsupported typeInfo: " + typeInfo);
     }
   }
 
-  public <T> @PolyNull T deserialize(
-      @PolyNull Object payload, Class<? extends T> typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @Nullable T deserialize(
+      @Nullable Object payload, Class<? extends T> typeInfo, @Nullable JsonConfig customConfig) {
     return deserialize(payload, OBJECT_READER.forType(typeInfo));
   }
 
-  public <T> @PolyNull T deserialize(
-      @PolyNull Object payload, Type typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @Nullable T deserialize(
+      @Nullable Object payload, Type typeInfo, @Nullable JsonConfig customConfig) {
     return deserialize(payload, OBJECT_READER.forType(typeInfo));
   }
 
-  public <T> @PolyNull T deserialize(
-      @PolyNull Object payload, TypeReference<T> typeInfo, @Nullable JsonConfig customConfig) {
+  public <T> @Nullable T deserialize(
+      @Nullable Object payload, TypeReference<T> typeInfo, @Nullable JsonConfig customConfig) {
     return deserialize(payload, OBJECT_READER.forType(typeInfo));
   }
 
-  private static <T> @PolyNull T deserialize(@PolyNull Object payload, ObjectReader reader) {
+  private static <T> @Nullable T deserialize(@Nullable Object payload, ObjectReader reader) {
     if (payload == null) {
       return null;
     }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/array/FloatArrays.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/array/FloatArrays.java
@@ -10,6 +10,7 @@ import com.flipkart.krystal.model.array.FloatArray;
 import com.flipkart.krystal.model.array.SimpleFloatArray;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class FloatArrays {
   /** Serializes {@link JsonByteArray} as a Base64-encoded string in JSON. */
@@ -35,9 +36,10 @@ public class FloatArrays {
   }
 
   /** Deserializes a Base64-encoded JSON string into {@link SimpleFloatArray}. */
-  public static final class FloatArrayDeserializer extends JsonDeserializer<SimpleFloatArray> {
+  public static final class FloatArrayDeserializer
+      extends JsonDeserializer<@Nullable SimpleFloatArray> {
     @Override
-    public SimpleFloatArray deserialize(JsonParser p, DeserializationContext context)
+    public @Nullable SimpleFloatArray deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
       float[] data = p.readValueAs(float[].class);
       if (data == null) {

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/AbstractJsonRepresentation.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/AbstractJsonRepresentation.java
@@ -4,12 +4,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 abstract sealed class AbstractJsonRepresentation implements JsonRepresentation
     permits ByteArrayJson, BytesJson, NodeJson, StringJson {
 
   /* ----Derived fields ----- */
-  protected String string;
+  protected @MonotonicNonNull String string;
 
   @Override
   public InputStream newInputStream() {

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/ByteArrayJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/ByteArrayJson.java
@@ -6,7 +6,6 @@ import com.flipkart.krystal.vajram.json.array.JsonByteArray;
 import java.io.IOException;
 import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class ByteArrayJson extends AbstractJsonRepresentation {
@@ -21,7 +20,7 @@ public final class ByteArrayJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
+  public <T> T deserialize(ObjectReader reader) throws IOException {
     if (data instanceof JsonByteArray jsonByteArray) {
       return jsonByteArray.readFromJson(reader);
     } else {

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/ByteArrayJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/ByteArrayJson.java
@@ -6,6 +6,8 @@ import com.flipkart.krystal.vajram.json.array.JsonByteArray;
 import java.io.IOException;
 import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class ByteArrayJson extends AbstractJsonRepresentation {
 
@@ -19,7 +21,7 @@ public final class ByteArrayJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> T deserialize(ObjectReader reader) throws IOException {
+  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
     if (data instanceof JsonByteArray jsonByteArray) {
       return jsonByteArray.readFromJson(reader);
     } else {
@@ -33,7 +35,7 @@ public final class ByteArrayJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/BytesJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/BytesJson.java
@@ -7,7 +7,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class BytesJson extends AbstractJsonRepresentation {
@@ -30,7 +29,7 @@ public final class BytesJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
+  public <T> T deserialize(ObjectReader reader) throws IOException {
     return reader.readValue(data, start, length);
   }
 

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/BytesJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/BytesJson.java
@@ -7,6 +7,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class BytesJson extends AbstractJsonRepresentation {
   private final byte[] data;
@@ -28,7 +30,7 @@ public final class BytesJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> T deserialize(ObjectReader reader) throws IOException {
+  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
     return reader.readValue(data, start, length);
   }
 
@@ -57,7 +59,7 @@ public final class BytesJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }
@@ -85,6 +87,12 @@ public final class BytesJson extends AbstractJsonRepresentation {
 
   @Override
   public String toString() {
-    return "BytesJson[data=" + data + ", start= " + start + ", length= " + length + "]";
+    return "BytesJson[data="
+        + Arrays.toString(data)
+        + ", start= "
+        + start
+        + ", length= "
+        + length
+        + "]";
   }
 }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/JsonRepresentation.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/JsonRepresentation.java
@@ -5,10 +5,9 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.flipkart.krystal.model.array.ByteArray;
 import java.io.IOException;
 import java.io.InputStream;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public sealed interface JsonRepresentation permits AbstractJsonRepresentation {
-  <T> @NonNull T deserialize(ObjectReader reader) throws IOException;
+  <T> T deserialize(ObjectReader reader) throws IOException;
 
   InputStream newInputStream();
 

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/JsonRepresentation.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/JsonRepresentation.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.flipkart.krystal.model.array.ByteArray;
 import java.io.IOException;
 import java.io.InputStream;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public sealed interface JsonRepresentation permits AbstractJsonRepresentation {
-  <T> T deserialize(ObjectReader reader) throws IOException;
+  <T> @NonNull T deserialize(ObjectReader reader) throws IOException;
 
   InputStream newInputStream();
 

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/NodeJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/NodeJson.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.flipkart.krystal.vajram.json.Json;
 import java.io.IOException;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class NodeJson extends AbstractJsonRepresentation {
 
@@ -22,7 +21,7 @@ public final class NodeJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
+  public <T> T deserialize(ObjectReader reader) throws IOException {
     return reader.readValue(jsonNode);
   }
 

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/NodeJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/NodeJson.java
@@ -7,20 +7,22 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.flipkart.krystal.vajram.json.Json;
 import java.io.IOException;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class NodeJson extends AbstractJsonRepresentation {
 
   private final JsonNode jsonNode;
 
   /* ----Derived fields ----- */
-  private byte[] bytes;
+  private byte @MonotonicNonNull [] bytes;
 
   public NodeJson(JsonNode jsonNode) {
     this.jsonNode = jsonNode;
   }
 
   @Override
-  public <T> T deserialize(ObjectReader reader) throws IOException {
+  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
     return reader.readValue(jsonNode);
   }
 

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class StringJson extends AbstractJsonRepresentation {
 
@@ -25,7 +27,7 @@ public final class StringJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> T deserialize(ObjectReader reader) throws IOException {
+  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
     if (bytes != null) {
       return reader.readValue(bytes);
     }
@@ -65,7 +67,7 @@ public final class StringJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
+++ b/vajram/extensions/json/vajram-json/src/main/java/com/flipkart/krystal/vajram/json/serialized/StringJson.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class StringJson extends AbstractJsonRepresentation {
@@ -27,7 +26,7 @@ public final class StringJson extends AbstractJsonRepresentation {
   }
 
   @Override
-  public <T> @NonNull T deserialize(ObjectReader reader) throws IOException {
+  public <T> T deserialize(ObjectReader reader) throws IOException {
     if (bytes != null) {
       return reader.readValue(bytes);
     }

--- a/vajram/extensions/protobuf/vajram-protobuf-util/src/main/java/com/flipkart/krystal/vajram/protobuf/util/ProtobufProtocol.java
+++ b/vajram/extensions/protobuf/vajram-protobuf-util/src/main/java/com/flipkart/krystal/vajram/protobuf/util/ProtobufProtocol.java
@@ -10,7 +10,9 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
 import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
 
 /**
  * Marker interface for SerdeProtocols that represent a protobuf flavour (proto3, edition 2024,
@@ -56,10 +58,13 @@ public interface ProtobufProtocol extends SerdeProtocol<NoAnnotation, Serializab
   }
 
   @Override
-  default ByteArray serialize(
-      Object object,
+  default @PolyNull ByteArray serialize(
+      @PolyNull Object object,
       Function<Model, SerializableModel> modelMapper,
       @Nullable NoAnnotation customConfig) {
+    if (object == null) {
+      return null;
+    }
     if (object instanceof MessageLite.Builder builder) {
       object = builder.build();
     }
@@ -79,17 +84,21 @@ public interface ProtobufProtocol extends SerdeProtocol<NoAnnotation, Serializab
    */
   @SuppressWarnings("unchecked")
   @Override
-  default <T> T deserialize(Object payload, Object typeInfo, @Nullable NoAnnotation customConfig) {
+  default <T> @PolyNull T deserialize(
+      @PolyNull Object payload, Object typeInfo, @Nullable NoAnnotation customConfig) {
+    if (payload == null) {
+      return null;
+    }
     try {
       if (typeInfo instanceof Parser<?> parser) {
         if (payload instanceof byte[] bytes) {
-          return (T) parser.parseFrom(bytes);
+          return (@NonNull T) parser.parseFrom(bytes);
         } else if (payload instanceof ProtoByteArray protoByteArray) {
-          return (T) parser.parseFrom(protoByteArray.toByteString());
+          return (@NonNull T) parser.parseFrom(protoByteArray.toByteString());
         } else if (payload instanceof ByteString bytesString) {
-          return (T) parser.parseFrom(bytesString);
+          return (@NonNull T) parser.parseFrom(bytesString);
         } else if (payload instanceof ByteArray byteArray) {
-          return (T) parser.parseFrom(byteArray.toArray());
+          return (@NonNull T) parser.parseFrom(byteArray.toArray());
         }
       }
     } catch (InvalidProtocolBufferException e) {

--- a/vajram/extensions/sql/vajram-sql/src/main/java/com/flipkart/krystal/vajram/ext/sql/data/DataUtils.java
+++ b/vajram/extensions/sql/vajram-sql/src/main/java/com/flipkart/krystal/vajram/ext/sql/data/DataUtils.java
@@ -3,6 +3,7 @@ package com.flipkart.krystal.vajram.ext.sql.data;
 import com.flipkart.krystal.model.array.FloatArray;
 import com.flipkart.krystal.model.array.SimpleFloatArray;
 import lombok.experimental.UtilityClass;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
 @UtilityClass
@@ -24,7 +25,7 @@ public class DataUtils {
     throw new IllegalArgumentException("Cannot convert " + value.getClass() + " to FloatArray");
   }
 
-  public static float[] floatArrayToSqlVal(@PolyNull FloatArray value) {
+  public static float @Nullable [] floatArrayToSqlVal(@PolyNull FloatArray value) {
     if (value == null) {
       return null;
     }

--- a/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/exec/VajramDefinition.java
+++ b/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/exec/VajramDefinition.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 @Slf4j
 @Getter
@@ -93,7 +94,7 @@ public final class VajramDefinition {
    * @param <T> The type of the metadata object
    */
   @SuppressWarnings("unchecked")
-  public <T> T getCustomMetadata(Class<T> clazz, Function<VajramDefinition, T> computer) {
+  public <T> T getCustomMetadata(Class<T> clazz, Function<VajramDefinition, @NonNull T> computer) {
     return (T) customMetadata.computeIfAbsent(clazz, _c -> computer.apply(this));
   }
 }

--- a/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/FanoutCommand.java
+++ b/vajram/vajram-java-sdk/src/main/java/com/flipkart/krystal/vajram/facets/FanoutCommand.java
@@ -12,7 +12,7 @@ public class FanoutCommand<T> implements DependencyCommand<T> {
   Collection<? extends T> values;
   boolean shouldSkip;
   String doc;
-  @Nullable Throwable skipCause;
+  private final @Nullable Throwable skipCause;
 
   private FanoutCommand(
       Collection<? extends T> values,

--- a/vajram/vajram-samples/build.gradle
+++ b/vajram/vajram-samples/build.gradle
@@ -69,6 +69,16 @@ checkerFramework {
     excludeTests = true
 }
 
+// If the project uses classes which are generated AFTER krystalModelsGen task finishes,
+// then we need to skipCheckerFramework so that krystalModelsGen doesn't fail.
+// This is needed because checkerFramework fails if any of the classes used have not yet been generated.
+// The java compiler itself doesn't have a problem with this
+tasks.named('krystalModelsGen', org.gradle.api.tasks.compile.JavaCompile).configure {
+    checkerFramework {
+        skipCheckerFramework = true
+    }
+}
+
 //Needed only if you want your project to be modularized using JPMS
 /** START: JPMS compatibility configurations **/
 configurations.configureEach {


### PR DESCRIPTION
Fix checker framework reported errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Serialization and deserialization APIs now clearly support nullable inputs and outputs.
  - Improved null handling across JSON, Protocol Buffers, SQL, and model-processing utilities.
  - Byte-array representations now display their contents more clearly when converted to text.

- **Bug Fixes**
  - Prevented failures when repeatable annotation data is missing.
  - Improved handling of unavailable model protocol classes.

- **Chores**
  - Updated the Java code standard plugin, Gradle tooling, and Checker Framework versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->