### PR TITLE
Treat duplicate requests within the same dependentChain as a cachehit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g
 #org.gradle.configuration-cache=true
 
-com.flipkart.krystal.previousVersion=11.2.4
-com.flipkart.krystal.currentVersion=11.2.5
-com.flipkart.krystal.lattice.currentVersion=0.5.5
+com.flipkart.krystal.previousVersion=11.2.6
+com.flipkart.krystal.currentVersion=11.2.6
+com.flipkart.krystal.lattice.currentVersion=0.5.6
 java_code_std_version=6.0
 # This project property is consumed by the "com.flipkart.java.code.standard" Gradle plugin
 #

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
@@ -245,8 +245,11 @@ public sealed class RequestLevelCache permits TestRequestLevelCache {
     private CompletableFuture<KryonCommandResponse> readFromCache(
         Kryon<KryonCommand<?>, KryonCommandResponse> kryon, DirectForwardReceive command) {
       List<ExecutionItem> cacheMisses = new ArrayList<>();
-      for (ExecutionItem executionItem :
-          command.executionItems(getKryonDefinition().kryonDefinitionRegistry())) {
+      List<ExecutionItem> executionItems =
+          command.executionItems(getKryonDefinition().kryonDefinitionRegistry());
+      Map<ImmutableFacetValues, CompletableFuture<@Nullable Object>> localCache =
+          new LinkedHashMap<>();
+      for (ExecutionItem executionItem : executionItems) {
         FacetValues facetValues = executionItem.facetValues();
         var cacheKey = newCacheKey(facetValues);
         if (cacheKey == null) {
@@ -255,6 +258,12 @@ public sealed class RequestLevelCache permits TestRequestLevelCache {
               "Skipping DirectForwardReceive caching for request {} since cache key is null",
               facetValues);
           cacheMisses.add(executionItem);
+          continue;
+        }
+        CompletableFuture<@Nullable Object> existingFuture =
+            localCache.putIfAbsent(cacheKey, executionItem.response());
+        if (existingFuture != null) {
+          propagateCompletion(existingFuture, executionItem.response());
           continue;
         }
         // We are in a KryonDecorator. If we get cached Future which is potentially not complete,
@@ -532,9 +541,9 @@ public sealed class RequestLevelCache permits TestRequestLevelCache {
         if (cachedFuture == null) {
           cache.putFuture(cacheKey, executionItem.response());
           cacheMisses.add(executionItem);
-          continue;
+        } else {
+          propagateCompletion(cachedFuture, executionItem.response());
         }
-        propagateCompletion(cachedFuture, executionItem.response());
       }
       logicToDecorate.execute(input.withExecutionItems(cacheMisses));
     }


### PR DESCRIPTION
- this stopped being the case after moving to cache values for kryon decorator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-level caching to avoid repeated work for duplicate cache requests.
  * Ensured duplicate requests consistently reuse the first available response.
  * Preserved cache-miss handling while improving execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->