### PR TITLE
Add support for GraphQl fragments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g
 #org.gradle.configuration-cache=true
 
-com.flipkart.krystal.previousVersion=11.2.7
-com.flipkart.krystal.currentVersion=11.3.2
-com.flipkart.krystal.lattice.currentVersion=0.6.2
+com.flipkart.krystal.previousVersion=11.3.2
+com.flipkart.krystal.currentVersion=11.3.3
+com.flipkart.krystal.lattice.currentVersion=0.6.3
 java_code_std_version=6.0
 # This project property is consumed by the "com.flipkart.java.code.standard" Gradle plugin
 #

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
@@ -296,10 +296,14 @@ public sealed class RequestLevelCache permits TestRequestLevelCache {
           cacheMisses.add(executionItem);
         } else if (cachedValue.future().isDone()
             || getCurrentEpoch(command) >= cachedValue.epoch()) {
-          stats.kryonStats().globalCacheCompletedFuture();
+          if (cachedValue.future().isDone()) {
+            stats.kryonStats().globalCacheHitsCompletedFuture();
+          } else {
+            stats.kryonStats().globalCacheHitsIncompleteFuture();
+          }
           propagateCompletion(cachedValue.future(), executionItem.response());
         } else {
-          stats.kryonStats().globalCacheIncompleteFuture();
+          stats.kryonStats().globalCacheMissIncompleteFuture();
           cacheMisses.add(executionItem);
         }
       }

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCache.java
@@ -61,15 +61,23 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * annotated correctly.
  *
  * <p>For example, any caching decorator applied before decorators like {@link
- * InputBatchingDecorator}, must not cache {@link CompletableFuture}s - doing so can cause deadlocks
- * because {@link InputBatchingDecorator} groups dependentChains by epoch where each depChain in
- * epoch(n+1) is blocked on the response from at least one depChain from epoch(n) - at the same
- * time, some dependentChain in epoch(n) could end up getting a future from the cache which itself
- * was inserted by a depChain from epoch(n+1). Because of this, the {@link KryonDecorator} provided
- * by this class only caches completed values, and not futures. Also, the {@link
- * OutputLogicDecorator} provided by this class caches futures (which is needed to avoid duplicate
- * IO calls due to concurrent requests with same inputs), and this MUST be applied AFTER decorators
- * like {@link InputBatchingDecorator}.
+ * InputBatchingDecorator}, must not blindly treat incomplete futures {@link CompletableFuture}s in
+ * the cache as cache hits - doing so can cause deadlocks because {@link InputBatchingDecorator}
+ * groups dependentChains by epoch where each depChain in epoch(n+1) is blocked on the response from
+ * at least one depChain from epoch(n) - at the same time, some dependentChain in epoch(n) could end
+ * up getting a future from the cache which itself was inserted by a depChain from epoch(n+1).
+ * Because of this, the {@link KryonDecorator} provided by this class compares the epochs of the
+ * current request and the cached future to decide which incomplete futures can safely be considered
+ * cache hits. Also, the {@link OutputLogicDecorator} provided by this class caches futures (which
+ * is needed to avoid duplicate IO calls due to concurrent requests with same inputs), and this MUST
+ * be applied AFTER decorators like {@link InputBatchingDecorator}.
+ *
+ * <p>Request level caching also affects correctness of graphs in which some data is being read and
+ * written by different vajrams. Let's say in a given request, vajram Vr reads an entity E1 from a
+ * database, then Vw updates the same entity, and then Vr is called again - this class will end up
+ * returning the original value because it was already cached. But this would be a functional error.
+ * To prevent these kind of errors, {@link RequestLevelCacheInvalidator} can be used Vw to
+ * invalidate cache keys of Vr. See @{@link DataAccess} as well for more details.
  */
 @Slf4j
 public sealed class RequestLevelCache permits TestRequestLevelCache {
@@ -271,24 +279,33 @@ public sealed class RequestLevelCache permits TestRequestLevelCache {
           continue;
         }
         stats.kryonStats().localCacheMiss();
-        // We are in a KryonDecorator. If we get cached Future which is potentially not complete,
+        // We are in a KryonDecorator. If we get consider any incomplete future present in the cache
         // and use that as the cached response hoping that it would complete later, we can introduce
         // a deadlock during graph execution.
         // This can happen if, for example, KryonDecorator for Vajram V1 is invoked with inputs I1,
         // and its response F1 is cached. That F1 might be blocked on InputBatchingDecorator being
-        // flushed for all dependentChains which are part of a particular epoch lets Say E1. Later
-        // Vajram V1 gets invoked with same I1, and we return F1 as is. But if this second call to
-        // V1 happened via a dependentChain which is part of Epoch E0 and if some dependency chain
-        // in E1 is waiting for all dependentChains of E0 to return, that would never happen in this
-        // scenario because E0 is waiting for F1 and F1 is waiting for E1 to flush and some
+        // flushed for all dependentChains including the one whose parent chaing's F1 was cache
+        // earlier - which are part of a particular epoch lets Say E1. Later
+        // Vajram V1 gets invoked again with same I1, and we return F1 as is. But if this second
+        // call to V1 happened via a dependentChain which is part of Epoch E0 and if some dependency
+        // chain in E1 is waiting for all dependentChains of E0 to return, that would never happen
+        // in this scenario because E0 is waiting for F1 and F1 is waiting for E1 to flush and some
         // dependentChain in E1 is waiting for some E0 to complete - this will cause a deadlock (We
-        // encountered this in one of the applications). To prevent this deadlock, KryonDecorators,
-        // or any other decorators which get invoked before the batching decorator, must never treat
-        // an incomplete future as a cache hit. That why we check if an actual value is available
-        // here, else we treat it as a cache miss. THe actual cache hit in this scenario will happen
-        // in the caching OutputLogicDecorator (which treats incomplete futures as cache hits). The
-        // output logic decorator MUST be configured to decorate AFTER the input batching decorator
-        // (else the same deadlock will happen there as well).
+        // encountered this in an applications). To prevent this deadlock, KryonDecorators,
+        // or any other decorators which get invoked before the batching decorator, must not blindly
+        // treat an incomplete future as a cache hit. That's why we compare the epoch of the cached
+        // value with the current epoch, and we consider an incomplete future as a cache hit only if
+        // it safe to do so - and that is if the future was cached by a depChain in the current or
+        // previous epoch. In the rare case that this future was cached by a depChain whose epoch is
+        // greater than the current epoch, we treat it as a cache miss (rare because we have
+        // measured it to happen 0.2% of the time in one application and 0% of the time in other
+        // applications). This means that this KryonLogicDecorator cannot guarantee one-time
+        // execution of a compute vajram for a set of inputs. So business logic in compute vajrams
+        // and resolvers of compute and IO vajrams MUST be idempotent,
+        // In the cases where an incomplete future has to be treated as a cache miss, the actual
+        // caching will happen in the caching OutputLogicDecorator (which treats incomplete futures
+        // as cache hits always). The output logic decorator MUST be configured to decorate AFTER
+        // the input batching decorator (else the same deadlock will happen there as well).
         var cachedValue = getCachedFuture(cacheKey);
         if (cachedValue == null) {
           stats.kryonStats().globalCacheNoFuture();

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCacheKryonStats.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/caching/RequestLevelCacheKryonStats.java
@@ -14,6 +14,8 @@ public class RequestLevelCacheKryonStats {
   private int globalCacheMissesNoFuture;
   private int globalCacheMissesIncompleteFuture;
   private int noCacheKey;
+  private int globalCacheHitsCompletedFuture;
+  private int globalCacheHitsIncompleteFuture;
 
   void localCacheHit() {
     localCacheHits++;
@@ -24,7 +26,14 @@ public class RequestLevelCacheKryonStats {
     localCacheMisses++;
   }
 
-  void globalCacheCompletedFuture() {
+  void globalCacheHitsCompletedFuture() {
+    globalCacheHits++;
+    globalCacheHitsCompletedFuture++;
+    cacheHits++;
+  }
+
+  void globalCacheHitsIncompleteFuture() {
+    globalCacheHitsIncompleteFuture++;
     globalCacheHits++;
     cacheHits++;
   }
@@ -34,7 +43,7 @@ public class RequestLevelCacheKryonStats {
     cacheMisses++;
   }
 
-  void globalCacheIncompleteFuture() {
+  void globalCacheMissIncompleteFuture() {
     globalCacheMissesIncompleteFuture++;
     cacheMisses++;
   }

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/GraphQlEndpointsE2eTest.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/GraphQlEndpointsE2eTest.java
@@ -2,6 +2,8 @@ package com.flipkart.krystal.lattice.samples.graphql.rest.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import java.net.URI;
@@ -23,89 +25,132 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 @TestInstance(Lifecycle.PER_CLASS)
 class GraphQlEndpointsE2eTest {
 
+  private static final JsonMapper JSON_MAPPER = new JsonMapper();
+
   @TestHTTPResource private URI baseUri;
 
   private final HttpClient httpClient =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
 
-  @Test
-  void graphQlQuery_returnsOwnerNameAndEmail() throws Exception {
-    String query =
-        """
-        {
-          "query": "{ account(id: \\"ACC123\\") { owner { name { firstName lastName } email } } }"
-        }
-        """;
+  private JsonNode postGraphQl(String query) throws Exception {
     HttpResponse<String> resp =
         httpClient.send(
             HttpRequest.newBuilder(baseUri.resolve("HttpPostGraphQl"))
-                .POST(BodyPublishers.ofString(query))
+                .POST(
+                    BodyPublishers.ofString(
+                        "{\"query\": " + JSON_MAPPER.writeValueAsString(query) + "}"))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .build(),
             BodyHandlers.ofString());
-
     assertThat(resp.statusCode()).isEqualTo(200);
+    return JSON_MAPPER.readTree(resp.body()).path("data");
+  }
+
+  @Test
+  void graphQlQuery_returnsOwnerNameAndEmail() throws Exception {
+    JsonNode data =
+        postGraphQl("{ account(id: \"ACC123\") { owner { name { firstName lastName } email } } }");
+
+    JsonNode name = data.path("account").path("owner").path("name");
     // GetOwnerOfAccount: PersonId = "PRSN" + id  =>  "PRSNACC123"
     // GetPersonName: firstName = personId + "-FirstName" => "PRSNACC123-FirstName"
-    assertThat(resp.body()).contains("PRSNACC123-FirstName");
-    assertThat(resp.body()).contains("PRSNACC123-LastName");
+    assertThat(name.path("firstName").asText()).isEqualTo("PRSNACC123-FirstName");
+    assertThat(name.path("lastName").asText()).isEqualTo("PRSNACC123-LastName");
     // GetPersonEmail: personId + "@" + personId + ".com" => "PRSNACC123@PRSNACC123.com"
-    assertThat(resp.body()).contains("PRSNACC123@PRSNACC123.com");
+    assertThat(data.path("account").path("owner").path("email").asText())
+        .isEqualTo("PRSNACC123@PRSNACC123.com");
   }
 
   @Test
   void graphQlQuery_onlyNameRequested_returnsName() throws Exception {
-    String query =
-        """
-        {
-          "query": "{ account(id: \\"XYZ\\") { owner { name { firstName } } } }"
-        }
-        """;
-    HttpResponse<String> resp =
-        httpClient.send(
-            HttpRequest.newBuilder(baseUri.resolve("HttpPostGraphQl"))
-                .POST(BodyPublishers.ofString(query))
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json")
-                .build(),
-            BodyHandlers.ofString());
+    JsonNode data = postGraphQl("{ account(id: \"XYZ\") { owner { name { firstName } } } }");
 
-    assertThat(resp.statusCode()).isEqualTo(200);
-    assertThat(resp.body()).contains("PRSNXYZ-FirstName");
+    JsonNode owner = data.path("account").path("owner");
+    assertThat(owner.path("name").path("firstName").asText()).isEqualTo("PRSNXYZ-FirstName");
+    // Only `firstName` was requested, so no sibling fields should be present.
+    assertThat(owner.path("name").has("lastName")).isFalse();
+    assertThat(owner.has("email")).isFalse();
   }
 
   @Test
   void graphQlQuery_aliasesOperationNormalAndComposedOnlyFields() throws Exception {
-    String query =
-        """
-        {
-          "query": "{\
-            accountAlias: account(id: \\"ACC123\\") {\
-              personAlias: owner {\
-                imageAlias: imageData {\
-                  mainAlias: mainUrl\
-                  thumbnailAlias: thumbnailUrl\
-                }\
-              }\
-            }\
-          }"
-        }
-        """;
-    HttpResponse<String> resp =
-        httpClient.send(
-            HttpRequest.newBuilder(baseUri.resolve("HttpPostGraphQl"))
-                .POST(BodyPublishers.ofString(query))
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json")
-                .build(),
-            BodyHandlers.ofString());
+    JsonNode data =
+        postGraphQl(
+            """
+            {
+              accountAlias: account(id: "ACC123") {
+                personAlias: owner {
+                  imageAlias: imageData {
+                    mainAlias: mainUrl
+                    thumbnailAlias: thumbnailUrl
+                  }
+                }
+              }
+            }
+            """);
 
-    assertThat(resp.statusCode()).isEqualTo(200);
-    assertThat(resp.body()).contains("\"accountAlias\"");
-    assertThat(resp.body()).contains("\"personAlias\"");
-    assertThat(resp.body()).contains("\"imageAlias\"");
-    assertThat(resp.body()).contains("\"mainAlias\":\"PRSNACC123-mainUrl.png\"");
-    assertThat(resp.body()).contains("\"thumbnailAlias\":\"PRSNACC123-thumbnailUrl.png\"");
+    JsonNode imageAlias = data.path("accountAlias").path("personAlias").path("imageAlias");
+    assertThat(data.has("accountAlias")).isTrue();
+    assertThat(data.path("accountAlias").has("personAlias")).isTrue();
+    assertThat(data.path("accountAlias").path("personAlias").has("imageAlias")).isTrue();
+    assertThat(imageAlias.path("mainAlias").asText()).isEqualTo("PRSNACC123-mainUrl.png");
+    assertThat(imageAlias.path("thumbnailAlias").asText()).isEqualTo("PRSNACC123-thumbnailUrl.png");
+  }
+
+  @Test
+  void graphQlQuery_namedFragment_noAliases_returnsOwnerNameAndEmail() throws Exception {
+    JsonNode data =
+        postGraphQl(
+            """
+            query {
+              account(id: "ACC123") {
+                owner {
+                  ...personFields
+                }
+              }
+            }
+            fragment personFields on Person {
+              name {
+                firstName
+                lastName
+              }
+              email
+            }
+            """);
+
+    JsonNode owner = data.path("account").path("owner");
+    assertThat(owner.path("name").path("firstName").asText()).isEqualTo("PRSNACC123-FirstName");
+    assertThat(owner.path("name").path("lastName").asText()).isEqualTo("PRSNACC123-LastName");
+    assertThat(owner.path("email").asText()).isEqualTo("PRSNACC123@PRSNACC123.com");
+  }
+
+  @Test
+  void graphQlQuery_namedFragment_withAliasesAtSpreadSiteAndInsideFragment_succeeds()
+      throws Exception {
+    JsonNode data =
+        postGraphQl(
+            """
+            query {
+              accountAlias: account(id: "ACC123") {
+                ownerAlias: owner {
+                  ...personFields
+                }
+              }
+            }
+            fragment personFields on Person {
+              n: name {
+                first: firstName
+              }
+              emailAlias: email
+            }
+            """);
+
+    JsonNode ownerAlias = data.path("accountAlias").path("ownerAlias");
+    assertThat(data.has("accountAlias")).isTrue();
+    assertThat(data.path("accountAlias").has("ownerAlias")).isTrue();
+    assertThat(ownerAlias.has("n")).isTrue();
+    assertThat(ownerAlias.path("n").path("first").asText()).isEqualTo("PRSNACC123-FirstName");
+    assertThat(ownerAlias.path("emailAlias").asText()).isEqualTo("PRSNACC123@PRSNACC123.com");
   }
 }

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
@@ -400,6 +400,146 @@ public class VajramGraphQlTest {
     assertThat(executionResult.getErrors().isEmpty()).isFalse();
   }
 
+  @Test
+  void graphqlQueryWithNamedFragment_noAliases_succeeds() {
+    // A named fragment spread on `Order`, with no aliases anywhere in the query.
+    CompletableFuture<ExecutionResult> result;
+    try (VajramKryonExecutor executor = createExecutor()) {
+      result =
+          new GraphQlExecutionFacade(GRAPHQL)
+              .executeGraphQl(
+                  executor,
+                  VajramExecutionConfig.builder().build(),
+                  new GraphQLQuery(
+                      """
+                      query {\
+                        order(id: "order1") {\
+                          ...orderFields\
+                        }
+                      }
+                      fragment orderFields on Order {
+                        state
+                        orderItemNames
+                      }
+                      """,
+                      Map.of()));
+    }
+    assertThat(result).succeedsWithin(TEST_TIMEOUT);
+    Map<String, Object> queryData = requireNonNull(result.join().getData());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> orderData = requireNonNull((Map<String, Object>) queryData.get("order"));
+
+    assertThat(orderData.get("state")).isEqualTo(State.COMPLETED);
+    assertThat(orderData.get("orderItemNames")).isEqualTo(List.of("order1_1", "order1_2"));
+  }
+
+  @Test
+  void graphqlQueryWithNamedFragment_underQueryLevelAliases_succeeds() {
+    // The same named fragment is spread under two differently-aliased `order` selections. Each
+    // alias must resolve the fragment's fields against its own argument-specific order.
+    CompletableFuture<ExecutionResult> result;
+    try (VajramKryonExecutor executor = createExecutor()) {
+      result =
+          new GraphQlExecutionFacade(GRAPHQL)
+              .executeGraphQl(
+                  executor,
+                  VajramExecutionConfig.builder().build(),
+                  new GraphQLQuery(
+                      """
+                      query {
+                        o1: order(id: "order1") {
+                          ...orderFields
+                        }
+                        o2: order(id: "order2") {
+                          ...orderFields
+                        }
+                      }
+                      fragment orderFields on Order {
+                        state
+                        orderItemNames
+                      }
+                      """,
+                      Map.of()));
+    }
+    assertThat(result).succeedsWithin(TEST_TIMEOUT);
+    Map<String, Object> queryData = requireNonNull(result.join().getData());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> o1Data = requireNonNull((Map<String, Object>) queryData.get("o1"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> o2Data = requireNonNull((Map<String, Object>) queryData.get("o2"));
+
+    assertThat(o1Data.get("state")).isEqualTo(State.COMPLETED);
+    assertThat(o1Data.get("orderItemNames")).isEqualTo(List.of("order1_1", "order1_2"));
+    assertThat(o2Data.get("state")).isEqualTo(State.COMPLETED);
+    assertThat(o2Data.get("orderItemNames")).isEqualTo(List.of("order2_1", "order2_2"));
+  }
+
+  @Test
+  void graphqlQueryWithNamedFragment_havingFieldAliasesInsideFragment_succeeds() {
+    // Fields aliased *inside* the fragment definition itself (not at the spread site) must
+    // resolve under their aliased response keys.
+    CompletableFuture<ExecutionResult> result;
+    try (VajramKryonExecutor executor = createExecutor()) {
+      result =
+          new GraphQlExecutionFacade(GRAPHQL)
+              .executeGraphQl(
+                  executor,
+                  VajramExecutionConfig.builder().build(),
+                  new GraphQLQuery(
+                      """
+                      query {
+                        order(id: "order1") {
+                          ...orderFields
+                        }
+                      }
+                      fragment orderFields on Order {
+                        s: state
+                        names: orderItemNames
+                      }
+                      """,
+                      Map.of()));
+    }
+    assertThat(result).succeedsWithin(TEST_TIMEOUT);
+    Map<String, Object> queryData = requireNonNull(result.join().getData());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> orderData = requireNonNull((Map<String, Object>) queryData.get("order"));
+
+    assertThat(orderData.get("s")).isEqualTo(State.COMPLETED);
+    assertThat(orderData.get("names")).isEqualTo(List.of("order1_1", "order1_2"));
+  }
+
+  @Test
+  void graphqlQueryWithInlineFragment_succeeds() {
+    // An inline fragment (`... on Order { ... }`), with no named fragment and no aliases.
+    CompletableFuture<ExecutionResult> result;
+    try (VajramKryonExecutor executor = createExecutor()) {
+      result =
+          new GraphQlExecutionFacade(GRAPHQL)
+              .executeGraphQl(
+                  executor,
+                  VajramExecutionConfig.builder().build(),
+                  new GraphQLQuery(
+                      """
+                      query {
+                        order(id: "order1") {
+                          ... on Order {
+                            state
+                            orderItemNames
+                          }
+                        }
+                      }
+                      """,
+                      Map.of()));
+    }
+    assertThat(result).succeedsWithin(TEST_TIMEOUT);
+    Map<String, Object> queryData = requireNonNull(result.join().getData());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> orderData = requireNonNull((Map<String, Object>) queryData.get("order"));
+
+    assertThat(orderData.get("state")).isEqualTo(State.COMPLETED);
+    assertThat(orderData.get("orderItemNames")).isEqualTo(List.of("order1_1", "order1_2"));
+  }
+
   private VajramKryonExecutor createExecutor() {
     return kGraph
         .build()

--- a/vajram/extensions/graphql/vajram-graphql/src/main/java/com/flipkart/krystal/vajram/graphql/api/execution/VajramExecutionStrategy.java
+++ b/vajram/extensions/graphql/vajram-graphql/src/main/java/com/flipkart/krystal/vajram/graphql/api/execution/VajramExecutionStrategy.java
@@ -29,9 +29,10 @@ import graphql.execution.NonNullableFieldValidator;
 import graphql.execution.NonNullableFieldWasNullException;
 import graphql.execution.ResultPath;
 import graphql.language.OperationDefinition.Operation;
-import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.concurrent.CompletableFuture;
@@ -109,13 +110,43 @@ public final class VajramExecutionStrategy extends ExecutionStrategy {
     if (field != null) {
       builder.field(field);
     }
-    ExecutionStepInfo executionStepInfo = parameters.getExecutionStepInfo();
-    GraphQLObjectType resolvedObjectType =
-        resolveType(executionContext, parameters, executionStepInfo.getUnwrappedNonNullType());
-    ExecutionStepInfo newExecutionStepInfo =
-        executionStepInfo.changeTypeWithPreservedNonNull(resolvedObjectType);
+    ExecutionStrategyParameters paramsWithField = builder.build();
+
+    // The field's own declared return type (e.g. `Order` for the `order` field) must be looked
+    // up from its definition on the *parent* type - it must not be conflated with the parent's
+    // own type (e.g. `Query`). Reusing the parent's type here previously caused fragment type
+    // conditions (`... on Order` / `fragment F on Order`) on this field's sub-selections to never
+    // match, silently dropping all fragment-selected fields.
+    ExecutionStepInfo executionStepInfo;
+    if (field != null) {
+      GraphQLObjectType parentType =
+          (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
+      GraphQLFieldDefinition fieldDef =
+          getFieldDef(executionContext.getGraphQLSchema(), parentType, field.getSingleField());
+      executionStepInfo =
+          createExecutionStepInfo(executionContext, paramsWithField, fieldDef, parentType);
+    } else {
+      executionStepInfo = parameters.getExecutionStepInfo();
+    }
+
     NonNullableFieldValidator nonNullableFieldValidator =
         new NonNullableFieldValidator(executionContext);
+    if (field != null && GraphQLTypeUtil.isLeaf(executionStepInfo.getType())) {
+      // Scalar/enum leaf field (e.g. a single-field @dataFetcher returning String or [String]):
+      // it has no sub-selection to collect, and there is no object type to resolve. Callers only
+      // need this field's own executionStepInfo (e.g. to read its resolved arguments).
+      builder
+          .executionStepInfo(executionStepInfo)
+          .nonNullFieldValidator(nonNullableFieldValidator)
+          .source(executionContext.getValueUnboxer().unbox(parameters.getSource()))
+          .parent(parameters);
+      return newParameters(builder.build()).build();
+    }
+
+    GraphQLObjectType resolvedObjectType =
+        resolveType(executionContext, paramsWithField, executionStepInfo.getUnwrappedNonNullType());
+    ExecutionStepInfo newExecutionStepInfo =
+        executionStepInfo.changeTypeWithPreservedNonNull(resolvedObjectType);
     builder
         .executionStepInfo(newExecutionStepInfo)
         .nonNullFieldValidator(nonNullableFieldValidator)
@@ -130,19 +161,9 @@ public final class VajramExecutionStrategy extends ExecutionStrategy {
             .build();
 
     ExecutionStrategyParameters newParameters = builder.build();
-    MergedSelectionSet subFields;
-
     if (field != null) {
-      subFields = fieldCollector.collectFields(collectorParameters, newParameters.getField());
-      newParameters =
-          newParameters(newParameters)
-              .executionStepInfo(
-                  createExecutionStepInfo(
-                      executionContext,
-                      newParameters,
-                      getFieldDef(executionContext, newParameters, field.getSingleField()),
-                      resolvedObjectType))
-              .build();
+      MergedSelectionSet subFields =
+          fieldCollector.collectFields(collectorParameters, newParameters.getField());
       return newParameters(newParameters).fields(subFields).build();
     } else {
       return newParameters(newParameters).build();
@@ -162,9 +183,8 @@ public final class VajramExecutionStrategy extends ExecutionStrategy {
       ExecutionContext executionContext,
       ExecutionStrategyParameters parameters,
       GraphQLType fieldType) {
-    if (fieldType instanceof GraphQLList graphQLList) {
-      fieldType = graphQLList.getWrappedType();
-    }
-    return super.resolveType(executionContext, parameters, fieldType);
+    // Fully unwrap List/NonNull wrappers (e.g. `[Dummy!]!`) down to the named type before
+    // resolving, since the base implementation only accepts Object/Interface/Union types.
+    return super.resolveType(executionContext, parameters, GraphQLTypeUtil.unwrapAll(fieldType));
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved GraphQL query execution for named fragments, inline fragments, field aliases, nested selections, and list or non-null types.
  - Added support for resolving fragment fields correctly across aliased queries.

- **Bug Fixes**
  - Corrected GraphQL responses so selected nested fields are preserved and leaf fields resolve reliably.
  - Improved cache reporting by distinguishing completed and incomplete cached results from cache misses.

- **Chores**
  - Updated project versions to the latest patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->