### PR TITLE
Gracefully handle missing vajrams when constructing epoch groups

### DIFF
--- a/krystex/src/main/java/com/flipkart/krystal/krystex/epochs/EpochGroups.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/epochs/EpochGroups.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -64,7 +65,10 @@ public record EpochGroups(ImmutableMap<VajramID, VajramEpochGroups> vajramEpochG
       VajramGraph graph,
       TraitDispatchPolicies traitDispatchPolicies,
       Dependency dependency) {
-    VajramDefinition depVajramDef = graph.getVajramDefinition(depVajramID);
+    VajramDefinition depVajramDef = graph.tryGetVajramDefinition(depVajramID);
+    if (depVajramDef == null) {
+      return List.of();
+    }
     Collection<VajramID> depVajramIDs = new ArrayList<>();
     if (depVajramDef.isTrait()) {
       TraitDispatchPolicy traitDispatchPolicy = traitDispatchPolicies.get(depVajramID);
@@ -190,7 +194,10 @@ public record EpochGroups(ImmutableMap<VajramID, VajramEpochGroups> vajramEpochG
               graph,
               dependentChainDisabler,
               traitDispatchPolicies);
-      if (graph.getVajramDefinition(vajramBeingInvokedID).def() instanceof IOVajramDef<?>) {
+      if (Optional.ofNullable(graph.tryGetVajramDefinition(vajramBeingInvokedID))
+              .map(VajramDefinition::def)
+              .orElse(null)
+          instanceof IOVajramDef<?>) {
         responseOrdinal++;
       }
       vajramsToResponseOrdinals.put(vajramBeingInvokedID, responseOrdinal);
@@ -224,7 +231,10 @@ public record EpochGroups(ImmutableMap<VajramID, VajramEpochGroups> vajramEpochG
     if (dependentChainDisabler.isDisabled(incomingDepChain)) {
       return;
     }
-    VajramDefinition vajramBeingInvoked = graph.getVajramDefinition(vajramIDBeingInvoked);
+    VajramDefinition vajramBeingInvoked = graph.tryGetVajramDefinition(vajramIDBeingInvoked);
+    if (vajramBeingInvoked == null) {
+      return;
+    }
     if (vajramBeingInvoked.isTrait()) {
       throw new AssertionError(
           "collateDepChainOrdinals cannot be called for traits. First resolve dispatch targets before calling this method.");

--- a/krystex/src/main/java/com/flipkart/krystal/krystex/epochs/LogicSet.java
+++ b/krystex/src/main/java/com/flipkart/krystal/krystex/epochs/LogicSet.java
@@ -27,7 +27,10 @@ sealed interface LogicSet {
 
     @Override
     public Set<Facet> sources(VajramGraph graph) {
-      VajramDefinition vajramDef = graph.getVajramDefinition(dependency.ofVajramID());
+      VajramDefinition vajramDef = graph.tryGetVajramDefinition(dependency.ofVajramID());
+      if (vajramDef == null) {
+        return Set.of();
+      }
       List<ResolverDefinition> resolvers =
           vajramDef.inputResolvers().keySet().stream()
               .filter(r -> r.target().dependency().equals(dependency))
@@ -50,7 +53,11 @@ sealed interface LogicSet {
 
     @Override
     public Set<FacetSpec> sources(VajramGraph graph) {
-      return graph.getVajramDefinition(vajramID()).outputLogicSources();
+      VajramDefinition vajramDefinition = graph.tryGetVajramDefinition(vajramID());
+      if (vajramDefinition == null) {
+        return Set.of();
+      }
+      return vajramDefinition.outputLogicSources();
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when vajram definitions are missing.
  * Prevented errors during dispatch target calculation and dependency-chain processing.
  * Ensured response ordinal calculations continue safely when optional definitions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->