### PR TITLE
Add support for inferring multiple id fields from args

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ org.gradle.jvmargs=-Xmx2g
 #org.gradle.configuration-cache=true
 
 com.flipkart.krystal.previousVersion=11.3.2
-com.flipkart.krystal.currentVersion=11.3.3
-com.flipkart.krystal.lattice.currentVersion=0.6.3
+com.flipkart.krystal.currentVersion=11.3.4
+com.flipkart.krystal.lattice.currentVersion=0.6.4
 java_code_std_version=6.0
 # This project property is consumed by the "com.flipkart.java.code.standard" Gradle plugin
 #

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQLObjectAggregateGen.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/GraphQLObjectAggregateGen.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -1172,7 +1173,13 @@ public class GraphQLObjectAggregateGen implements CodeGenerator {
           canFanout,
           fieldName);
     }
-    if (hasArgs && fetcherType == INHERIT_ID_FROM_ARGS) {
+    if (fetcherType == INHERIT_ID_FROM_ARGS) {
+      // Only idFields with a matching arg (by name) are mapped; an optional idField with no
+      // matching arg is simply left unset (defaults to absent) on the identity being built.
+      Set<String> argNames =
+          fieldSpec.fieldDefinition().getInputValueDefinitions().stream()
+              .map(InputValueDefinition::getName)
+              .collect(Collectors.toSet());
       return createInheritIdFromArgsAliasResolver(
           parentTypeName,
           typeAggregatorClass,
@@ -1180,7 +1187,7 @@ public class GraphQLObjectAggregateGen implements CodeGenerator {
           schemaReaderUtil.entityIdClassName(fieldTypeName),
           fieldTypeDef.getFieldDefinitions().stream()
               .filter(idField -> idField.hasDirective(Directives.ID_FIELD))
-              .filter(idField -> idField.getType() instanceof NonNullType)
+              .filter(idField -> argNames.contains(idField.getName()))
               .toList(),
           fieldTypeName);
     }
@@ -1191,14 +1198,6 @@ public class GraphQLObjectAggregateGen implements CodeGenerator {
               canFanout
                   ? CodeBlock.of("$L.valueOpt().get()", entityIdFacetName)
                   : CodeBlock.of("_nonNil");
-          case INHERIT_ID_FROM_ARGS ->
-              CodeBlock.of(
-                  "$T._builder().$L(($T) $L.getExecutionStepInfo().getArgument($S))._build()",
-                  graphQlResponseImplementation(schemaReaderUtil.entityIdClassName(fieldTypeName)),
-                  schemaReaderUtil.getEntityIdFieldName(fieldTypeDef),
-                  String.class,
-                  Facets.EXECUTION_STRATEGY_PARAMS + "_new",
-                  schemaReaderUtil.getEntityIdFieldName(fieldTypeDef));
           case INHERIT_ID_FROM_PARENT -> CodeBlock.of(Facets.GQL_OBJECT_ID);
           default -> null;
         };
@@ -1367,15 +1366,26 @@ public class GraphQLObjectAggregateGen implements CodeGenerator {
     CodeBlock idSetters =
         idFields.stream()
             .map(
-                idField ->
-                    CodeBlock.of(
-                        ".$L(($T) graphql_executionStrategyParams_new.getExecutionStepInfo().getArgument($S))",
-                        idField.getName(),
-                        graphQlCodeGenUtil.toFacetTypeName(
-                            SchemaReaderUtil.fieldSpecFromField(idField, "", entityTypeName)
-                                .fieldType(),
-                            SchemaReaderUtil.fieldSpecFromField(idField, "", entityTypeName)),
-                        idField.getName()))
+                idField -> {
+                  CodeBlock argValue =
+                      CodeBlock.of(
+                          "($T) graphql_executionStrategyParams_new.getExecutionStepInfo().getArgument($S)",
+                          graphQlCodeGenUtil.toFacetTypeName(
+                              SchemaReaderUtil.fieldSpecFromField(idField, "", entityTypeName)
+                                  .fieldType(),
+                              SchemaReaderUtil.fieldSpecFromField(idField, "", entityTypeName)),
+                          idField.getName());
+                  // Mandatory (non-null) @idField facets are declared as the raw type on the id
+                  // builder, whereas optional @idField facets are declared as Errable<T> (since
+                  // the value itself may legitimately be absent/null).
+                  boolean idFieldMandatory = idField.getType() instanceof NonNullType;
+                  return CodeBlock.of(
+                      ".$L($L)",
+                      idField.getName(),
+                      idFieldMandatory
+                          ? argValue
+                          : CodeBlock.of("$T.withValue($L)", Errable.class, argValue));
+                })
             .collect(CodeBlock.joining("\n"));
 
     return MethodSpec.methodBuilder(fieldName)

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtil.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtil.java
@@ -194,6 +194,16 @@ public class SchemaReaderUtil {
                   typeDefinitionRegistry, typeName, typeDefinition, field, fieldType);
             }
           }
+          // @composedOnly types reuse their root type's identity, and root operation types
+          // (Query/Mutation/Subscription) have no identity of their own - every other type must
+          // declare at least one non-null @idField to be unambiguously identifiable.
+          if (!typeDefinition.hasDirective(Directives.COMPOSED_ONLY)
+              && !isOperationType(typeDefinitionRegistry, typeName)
+              && idFields(typeDefinition).stream()
+                  .noneMatch(idField -> idField.getType() instanceof NonNullType)) {
+            throw invalid(
+                "Type '%s' must declare at least one non-null @idField", typeName.value());
+          }
         });
     validateOperationTypes(typeDefinitionRegistry, graphQLObjectTypes);
     validateComposedOnlyReferences(typeDefinitionRegistry, graphQLObjectTypes, composedOnlyTypes);

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtil.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtil.java
@@ -222,15 +222,42 @@ public class SchemaReaderUtil {
     Map<String, InputValueDefinition> argsByName =
         field.getInputValueDefinitions().stream()
             .collect(Collectors.toMap(InputValueDefinition::getName, input -> input));
-    for (FieldDefinition idField : nonNullIdFields(objectType)) {
+    for (FieldDefinition idField : idFields(objectType)) {
+      boolean idFieldMandatory = idField.getType() instanceof NonNullType;
       InputValueDefinition arg = argsByName.get(idField.getName());
-      if (arg == null || !arg.getType().toString().equals(idField.getType().toString())) {
+      if (arg == null) {
+        // An optional @idField can be left unmapped; a mandatory one cannot.
+        if (idFieldMandatory) {
+          throw invalid(
+              "@inferIdFromArgs '%s.%s' requires an argument '%s' with type '%s' for @idField '%s.%s'",
+              parentType.value(),
+              field.getName(),
+              idField.getName(),
+              idField.getType(),
+              objectType.getName(),
+              idField.getName());
+        }
+        continue;
+      }
+      if (!unwrapNonNull(arg.getType())
+          .toString()
+          .equals(unwrapNonNull(idField.getType()).toString())) {
         throw invalid(
             "@inferIdFromArgs '%s.%s' requires an argument '%s' with type '%s' for @idField '%s.%s'",
             parentType.value(),
             field.getName(),
             idField.getName(),
             idField.getType(),
+            objectType.getName(),
+            idField.getName());
+      }
+      boolean argMandatory = arg.getType() instanceof NonNullType;
+      if (idFieldMandatory && !argMandatory) {
+        throw invalid(
+            "@inferIdFromArgs '%s.%s' requires argument '%s' to be mandatory, since @idField '%s.%s' is mandatory",
+            parentType.value(),
+            field.getName(),
+            idField.getName(),
             objectType.getName(),
             idField.getName());
       }
@@ -384,11 +411,14 @@ public class SchemaReaderUtil {
         .orElseThrow(() -> invalid("Could not find type for field '%s'", field));
   }
 
-  private static List<FieldDefinition> nonNullIdFields(ObjectTypeDefinition type) {
+  private static List<FieldDefinition> idFields(ObjectTypeDefinition type) {
     return type.getFieldDefinitions().stream()
         .filter(field -> field.hasDirective(Directives.ID_FIELD))
-        .filter(field -> field.getType() instanceof NonNullType)
         .toList();
+  }
+
+  private static Type<?> unwrapNonNull(Type<?> type) {
+    return type instanceof NonNullType nonNullType ? nonNullType.getType() : type;
   }
 
   private static boolean isList(Type<?> type) {
@@ -800,22 +830,6 @@ public class SchemaReaderUtil {
       subPackage = "." + subPackage;
     }
     return rootPackageName + subPackage;
-  }
-
-  public String getEntityIdFieldName(TypeDefinition fieldTypeDef) {
-    if (!(fieldTypeDef instanceof ObjectTypeDefinition objectTypeDefinition)) {
-      throw new IllegalArgumentException("Only object types can have identity fields");
-    }
-    List<FieldDefinition> idFields =
-        objectTypeDefinition.getFieldDefinitions().stream()
-            .filter(field -> field.hasDirective(Directives.ID_FIELD))
-            .toList();
-    if (idFields.size() != 1) {
-      throw new IllegalArgumentException(
-          "Type '%s' must declare exactly one @idField when its identity is used"
-              .formatted(objectTypeDefinition.getName()));
-    }
-    return idFields.get(0).getName();
   }
 
   public Optional<GraphQLTypeName> getRootIdentityType(ObjectTypeDefinition typeDefinition) {

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtilTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtilTest.java
@@ -200,6 +200,52 @@ class SchemaReaderUtilTest {
     assertTrue(exception.getMessage().contains("requires an argument"));
   }
 
+  @Test
+  void rejectsTypeWithOnlyNullableIdFields() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                schemaReader(
+                    """
+                    schema @rootPackage(name: "test.schema") { query: Query }
+                    type Query @operation(type: QUERY) { value: String }
+                    type Item { label: String @idField }
+                    """));
+
+    assertTrue(exception.getMessage().contains("Item"));
+    assertTrue(exception.getMessage().contains("non-null @idField"));
+  }
+
+  @Test
+  void rejectsTypeWithNoIdFieldAtAll() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                schemaReader(
+                    """
+                    schema @rootPackage(name: "test.schema") { query: Query }
+                    type Query @operation(type: QUERY) { value: String }
+                    type Item { name: String }
+                    """));
+
+    assertTrue(exception.getMessage().contains("Item"));
+  }
+
+  @Test
+  void allowsComposedOnlyAndOperationTypesWithoutNonNullIdField() {
+    assertDoesNotThrow(
+        () ->
+            schemaReader(
+                """
+                schema @rootPackage(name: "test.schema") { query: Query }
+                type Query @operation(type: QUERY) { item(id: ID!): Item @inferIdFromArgs }
+                type Item { id: ID! @idField details: Details }
+                type Details @composedOnly(inRootType: "Item") { value: String }
+                """));
+  }
+
   private SchemaReaderUtil schemaReader(String schema) throws IOException {
     Path schemaFile = tempDir.resolve("Schema.graphqls");
     Files.writeString(schemaFile, schema);

--- a/vajram/extensions/graphql/vajram-graphql-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtilTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/codegen/SchemaReaderUtilTest.java
@@ -103,6 +103,103 @@ class SchemaReaderUtilTest {
                 """));
   }
 
+  @Test
+  void inferIdFromArgsAllowsOptionalArgForOptionalIdFieldAndMandatoryArgForMandatoryIdField() {
+    assertDoesNotThrow(
+        () ->
+            schemaReader(
+                """
+                schema @rootPackage(name: "test.schema") { query: Query }
+                type Query @operation(type: QUERY) {
+                  item(id: ID!, label: String): Item @inferIdFromArgs
+                }
+                type Item { id: ID! @idField label: String @idField }
+                """));
+  }
+
+  @Test
+  void inferIdFromArgsAllowsMandatoryArgForOptionalIdField() {
+    assertDoesNotThrow(
+        () ->
+            schemaReader(
+                """
+                schema @rootPackage(name: "test.schema") { query: Query }
+                type Query @operation(type: QUERY) {
+                  item(id: ID!, label: String!): Item @inferIdFromArgs
+                }
+                type Item { id: ID! @idField label: String @idField }
+                """));
+  }
+
+  @Test
+  void inferIdFromArgsRejectsOptionalArgForMandatoryIdField() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                schemaReader(
+                    """
+                    schema @rootPackage(name: "test.schema") { query: Query }
+                    type Query @operation(type: QUERY) {
+                      item(id: ID): Item @inferIdFromArgs
+                    }
+                    type Item { id: ID! @idField }
+                    """));
+
+    assertTrue(exception.getMessage().contains("mandatory"));
+  }
+
+  @Test
+  void inferIdFromArgsAllowsMissingArgForOptionalIdField() {
+    // `label` is an optional @idField with no corresponding arg at all - it's simply left unset.
+    assertDoesNotThrow(
+        () ->
+            schemaReader(
+                """
+                schema @rootPackage(name: "test.schema") { query: Query }
+                type Query @operation(type: QUERY) {
+                  item(id: ID!): Item @inferIdFromArgs
+                }
+                type Item { id: ID! @idField label: String @idField }
+                """));
+  }
+
+  @Test
+  void inferIdFromArgsRejectsMissingArgForMandatoryIdField() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                schemaReader(
+                    """
+                    schema @rootPackage(name: "test.schema") { query: Query }
+                    type Query @operation(type: QUERY) {
+                      item(label: String): Item @inferIdFromArgs
+                    }
+                    type Item { id: ID! @idField label: String @idField }
+                    """));
+
+    assertTrue(exception.getMessage().contains("id"));
+  }
+
+  @Test
+  void inferIdFromArgsRejectsTypeMismatch() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                schemaReader(
+                    """
+                    schema @rootPackage(name: "test.schema") { query: Query }
+                    type Query @operation(type: QUERY) {
+                      item(id: Int!): Item @inferIdFromArgs
+                    }
+                    type Item { id: ID! @idField }
+                    """));
+
+    assertTrue(exception.getMessage().contains("requires an argument"));
+  }
+
   private SchemaReaderUtil schemaReader(String schema) throws IOException {
     Path schemaFile = tempDir.resolve("Schema.graphqls");
     Files.writeString(schemaFile, schema);

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Order.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Order.graphqls
@@ -55,7 +55,7 @@ type HelloDetails @composedOnly(inRootType: "Order") {
 
 type Name {
     value: String @idField
-    string: String @idField
+    string: String! @idField
 }
 
 #{

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Query.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Query.graphqls
@@ -3,7 +3,7 @@ type Query @operation(type: QUERY) {
     order(id: ID!): Order @inferIdFromArgs
     dummy(dummyId: ID!): Dummy @inferIdFromArgs
     mostRecentOrder(userId: String!): Order @idFetcher(vajramId: "GetMostRecentOrder", subPackage: "order")
-    """Name has 2 nullable @idField fields; both are mapped from args, one optional and one mandatory"""
+    """Name has an optional `value` @idField and a mandatory `string` @idField; both are mapped from args"""
     name(value: String, string: String!): Name @inferIdFromArgs
     """Name's optional `value` @idField has no corresponding arg here at all - it's left unset"""
     nameByString(string: String!): Name @inferIdFromArgs

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Query.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/graphqls/com/flipkart/krystal/vajram/graphql/samples/Query.graphqls
@@ -3,4 +3,8 @@ type Query @operation(type: QUERY) {
     order(id: ID!): Order @inferIdFromArgs
     dummy(dummyId: ID!): Dummy @inferIdFromArgs
     mostRecentOrder(userId: String!): Order @idFetcher(vajramId: "GetMostRecentOrder", subPackage: "order")
+    """Name has 2 nullable @idField fields; both are mapped from args, one optional and one mandatory"""
+    name(value: String, string: String!): Name @inferIdFromArgs
+    """Name's optional `value` @idField has no corresponding arg here at all - it's left unset"""
+    nameByString(string: String!): Name @inferIdFromArgs
 }

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
@@ -147,6 +147,71 @@ public class VajramGraphQlTest {
   }
 
   @Test
+  void inferIdFromArgs_withOnlyNullableIdFields_buildsIdentityFromArgs() {
+    // `name` returns a `Name` type whose 2 @idField fields (`value`, `string`) are both nullable.
+    // @inferIdFromArgs must map every idField from the matching args, not just non-null ones.
+    CompletableFuture<ExecutionResult> result;
+    try (VajramKryonExecutor executor = createExecutor()) {
+      result =
+          new GraphQlExecutionFacade(GRAPHQL)
+              .executeGraphQl(
+                  executor,
+                  VajramExecutionConfig.builder().build(),
+                  new GraphQLQuery(
+                      """
+                      query {
+                        name(value: "v1", string: "s1") {
+                          value
+                          string
+                        }
+                      }
+                      """,
+                      Map.of()));
+    }
+    assertThat(result).succeedsWithin(TEST_TIMEOUT);
+    ExecutionResult executionResult = result.join();
+    @SuppressWarnings("unchecked")
+    Map<String, Object> queryData = requireNonNull(executionResult.getData());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> nameData = requireNonNull((Map<String, Object>) queryData.get("name"));
+    assertThat(nameData.get("value")).isEqualTo("v1");
+    assertThat(nameData.get("string")).isEqualTo("s1");
+  }
+
+  @Test
+  void inferIdFromArgs_withOptionalIdFieldHavingNoArgAtAll_leavesItUnset() {
+    // `nameByString` doesn't declare a `value` arg at all; Name's optional `value` @idField must
+    // simply be left absent, not cause a build-time or run-time failure.
+    CompletableFuture<ExecutionResult> result;
+    try (VajramKryonExecutor executor = createExecutor()) {
+      result =
+          new GraphQlExecutionFacade(GRAPHQL)
+              .executeGraphQl(
+                  executor,
+                  VajramExecutionConfig.builder().build(),
+                  new GraphQLQuery(
+                      """
+                      query {
+                        nameByString(string: "s1") {
+                          value
+                          string
+                        }
+                      }
+                      """,
+                      Map.of()));
+    }
+    assertThat(result).succeedsWithin(TEST_TIMEOUT);
+    ExecutionResult executionResult = result.join();
+    @SuppressWarnings("unchecked")
+    Map<String, Object> queryData = requireNonNull((Map<String, Object>) executionResult.getData());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> nameData =
+        requireNonNull((Map<String, Object>) queryData.get("nameByString"));
+    assertThat(nameData.get("value")).isNull();
+    assertThat(nameData.get("string")).isEqualTo("s1");
+  }
+
+  @Test
   void graphqlQueryWithQueryLevelAliases_succeeds() throws JsonProcessingException {
     // Two aliases for the same arg-bearing `order` field at query level, each with a different id
     CompletableFuture<ExecutionResult> result;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
@@ -147,9 +147,10 @@ public class VajramGraphQlTest {
   }
 
   @Test
-  void inferIdFromArgs_withOnlyNullableIdFields_buildsIdentityFromArgs() {
-    // `name` returns a `Name` type whose 2 @idField fields (`value`, `string`) are both nullable.
-    // @inferIdFromArgs must map every idField from the matching args, not just non-null ones.
+  void inferIdFromArgs_withOptionalIdField_buildsIdentityFromArgs() {
+    // `name` returns a `Name` type with an optional (`value`) and a mandatory (`string`)
+    // @idField. @inferIdFromArgs must map every idField from the matching args, not just
+    // non-null ones.
     CompletableFuture<ExecutionResult> result;
     try (VajramKryonExecutor executor = createExecutor()) {
       result =

--- a/vajram/extensions/graphql/vajram-graphql/src/main/graphqls/KrystalGraphQLSpec.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql/src/main/graphqls/KrystalGraphQLSpec.graphqls
@@ -44,12 +44,15 @@ directive @idFetcher(vajramId : String!, subPackage: String) on FIELD_DEFINITION
 
 """
 This means the identity used for type aggregation should be taken from the arguments passed to the field
-by matching the argument name with the idField name. If any of the non-null idFields of the type doesn't have a
-corresponding field argument with matching name and type, then a build-time error is thrown
+by matching the argument name with the idField name. A mandatory (non-null) idField must have a
+corresponding field argument with matching name and type, and that argument must also be mandatory,
+or a build-time error is thrown. An optional (nullable) idField may be left unmapped, or matched by an
+argument of the same name and type that is either optional or mandatory.
 
 Invariants:
 Only valid on fields of root operation types.
-Every non-null idField of the type must have a corresponding field argument here with matching name and type
+Every mandatory idField of the type must have a corresponding mandatory field argument here with matching name and type.
+An optional idField may be missing a corresponding argument, or matched by an optional or mandatory argument with matching name and type.
 """
 directive @inferIdFromArgs on FIELD_DEFINITION
 

--- a/vajram/extensions/graphql/vajram-graphql/src/main/graphqls/KrystalGraphQLSpec.graphqls
+++ b/vajram/extensions/graphql/vajram-graphql/src/main/graphqls/KrystalGraphQLSpec.graphqls
@@ -18,6 +18,8 @@ Marks a field as part of the id of its containing GraphQL type.
 Invariants:
 Id fields cannot accept arguments
 Id fields have to be scalars - cannot be graphql objects
+Every type, except types annotated with @composedOnly (and root operation types, which have no
+identity of their own), must declare at least one non-null @idField
 """
 directive @idField on FIELD_DEFINITION
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GraphQL `@inferIdFromArgs` support to map both required and optional identity fields from query arguments.
  * Optional identity fields can now remain unset when no matching argument is provided.
  * Added sample queries demonstrating flexible identity mapping.

* **Bug Fixes**
  * Improved validation for argument names, requiredness, and GraphQL type compatibility.

* **Documentation**
  * Clarified `@inferIdFromArgs` requirements for mandatory and optional fields.

* **Chores**
  * Updated release versions to 11.3.4 and 0.6.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->