### PR TITLE
Add __typename support in graphQl client models and migrate test cases

### DIFF
--- a/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
+++ b/krystal-codegen-common/src/main/java/com/flipkart/krystal/codegen/common/models/CodeGenUtility.java
@@ -396,6 +396,41 @@ public class CodeGenUtility {
         .collect(toImmutableList());
   }
 
+  /**
+   * Like {@link #getModelFields(TypeElement)}, but only methods declared directly on {@code
+   * modelRootElem} itself - methods inherited from supertypes (e.g. via {@code extends}) are
+   * excluded, regardless of whether those supertypes are themselves {@code @ModelRoot}s.
+   */
+  public ImmutableList<ExecutableElement> getDeclaredModelFields(TypeElement modelRootElem) {
+    if (modelRootElem.getAnnotation(ModelRoot.class) == null) {
+      error("Model root type %s does not have @ModelRoot annotation", modelRootElem);
+    }
+    List<ExecutableElement> modelMethods = new ArrayList<>();
+    for (ExecutableElement method : ElementFilter.methodsIn(modelRootElem.getEnclosedElements())) {
+      if (!method.getModifiers().contains(STATIC)) {
+        if (method.getSimpleName().toString().startsWith("_")) {
+          // Ignore methods starting with '_' as they are not model fields and are reserved for
+          // platform use.
+          continue;
+        }
+        validateModelRootMethod(method);
+        modelMethods.add(method);
+      }
+    }
+    return ImmutableList.copyOf(modelMethods);
+  }
+
+  /**
+   * Like {@link #getModelFieldsForCodegen(TypeElement)}, restricted to methods declared directly on
+   * {@code modelRootElem} - see {@link #getDeclaredModelFields(TypeElement)}.
+   */
+  public ImmutableList<ExecutableElement> getDeclaredModelFieldsForCodegen(
+      TypeElement modelRootElem) {
+    return getDeclaredModelFields(modelRootElem).stream()
+        .filter(method -> isMethodEligibleForModelCodeGen(method, modelRootElem))
+        .collect(toImmutableList());
+  }
+
   private void validateModelRootMethod(ExecutableElement method) {
     TypeMirror returnType = method.getReturnType();
     // Validate method return type is not an array

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/AccountAliasedWithOwnerFragment.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/AccountAliasedWithOwnerFragment.java
@@ -1,0 +1,18 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface AccountAliasedWithOwnerFragment extends Model {
+  @Field(name = "owner")
+  OwnerAliasedWithFragment ownerAlias();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/AccountWithOwnerFragment.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/AccountWithOwnerFragment.java
@@ -1,0 +1,16 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface AccountWithOwnerFragment extends Model {
+  OwnerWithFragment owner();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/FirstNameOnlyAliased.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/FirstNameOnlyAliased.java
@@ -1,0 +1,19 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** {@code n: name { first: firstName } } */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface FirstNameOnlyAliased extends Model {
+  @Field(name = "firstName")
+  String first();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentAliasedOp.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentAliasedOp.java
@@ -1,0 +1,27 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side operation root for {@code
+ * GraphQlEndpointsE2eTest#graphQlQuery_namedFragment_withAliasesAtSpreadSiteAndInsideFragment_succeeds}
+ * - exercises a named GraphQL fragment spread with {@code @Field(name=...)} aliasing both at the
+ * spread site ({@code accountAlias}/{@code ownerAlias}) and inside the fragment itself.
+ */
+@GraphQlOpRequest(schemaFilePath = "src/main/graphqls/Schema.graphqls")
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface GetAccountOwnerFragmentAliasedOp extends Model {
+
+  @Field(name = "account")
+  @FieldArg(name = "id", useVariable = "id")
+  AccountAliasedWithOwnerFragment accountAlias();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentAliasedVariables.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentAliasedVariables.java
@@ -1,0 +1,19 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+import com.flipkart.krystal.model.IfAbsent;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.json.Json;
+
+@ForGraphQlOpReq(GetAccountOwnerFragmentAliasedOp.class)
+@ModelRoot(type = REQUEST)
+@SupportedModelProtocol(Json.class)
+public interface GetAccountOwnerFragmentAliasedVariables extends Model {
+  @IfAbsent(FAIL)
+  String id();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentOp.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentOp.java
@@ -1,0 +1,24 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side operation root for {@code
+ * GraphQlEndpointsE2eTest#graphQlQuery_namedFragment_noAliases_returnsOwnerNameAndEmail} -
+ * exercises a named GraphQL fragment spread ({@code owner { ...personFields }}).
+ */
+@GraphQlOpRequest(schemaFilePath = "src/main/graphqls/Schema.graphqls")
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface GetAccountOwnerFragmentOp extends Model {
+
+  @FieldArg(name = "id", useVariable = "id")
+  AccountWithOwnerFragment account();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentVariables.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/GetAccountOwnerFragmentVariables.java
@@ -1,0 +1,19 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+import com.flipkart.krystal.model.IfAbsent;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.json.Json;
+
+@ForGraphQlOpReq(GetAccountOwnerFragmentOp.class)
+@ModelRoot(type = REQUEST)
+@SupportedModelProtocol(Json.class)
+public interface GetAccountOwnerFragmentVariables extends Model {
+  @IfAbsent(FAIL)
+  String id();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerAliasedWithFragment.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerAliasedWithFragment.java
@@ -1,0 +1,16 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** {@code ownerAlias: owner { ...personFields }} */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OwnerAliasedWithFragment extends Model, @GraphQlFragment PersonFieldsAliased {}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerAliasedWithFragment.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerAliasedWithFragment.java
@@ -9,7 +9,7 @@ import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
 import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
 import com.flipkart.krystal.vajram.json.Json;
 
-/** {@code ownerAlias: owner { ...personFields }} */
+/** {@code ownerAlias: owner { ...PersonFieldsAliased }} */
 @GraphQlRequest
 @ModelRoot(type = RESPONSE)
 @SupportedModelProtocol(Json.class)

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerWithFragment.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerWithFragment.java
@@ -9,7 +9,7 @@ import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
 import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
 import com.flipkart.krystal.vajram.json.Json;
 
-/** {@code owner { ...personFields }} */
+/** {@code owner { ...PersonFields }} */
 @GraphQlRequest
 @ModelRoot(type = RESPONSE)
 @SupportedModelProtocol(Json.class)

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerWithFragment.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/OwnerWithFragment.java
@@ -1,0 +1,16 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** {@code owner { ...personFields }} */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OwnerWithFragment extends Model, @GraphQlFragment PersonFields {}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/PersonFields.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/PersonFields.java
@@ -1,0 +1,21 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** {@code fragment personFields on Person { name { firstName lastName } email }} */
+@GraphQlFragment
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface PersonFields extends Model {
+  OwnerNameDetails name();
+
+  String email();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/PersonFieldsAliased.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/main/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/client/PersonFieldsAliased.java
@@ -1,0 +1,24 @@
+package com.flipkart.krystal.lattice.samples.graphql.rest.json.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** {@code fragment personFields on Person { n: name { first: firstName } emailAlias: email }} */
+@GraphQlFragment
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface PersonFieldsAliased extends Model {
+  @Field(name = "name")
+  FirstNameOnlyAliased n();
+
+  @Field(name = "email")
+  String emailAlias();
+}

--- a/lattice/samples/graphql-rest-json-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/GraphQlEndpointsE2eTest.java
+++ b/lattice/samples/graphql-rest-json-lattice-sample/src/test/java/com/flipkart/krystal/lattice/samples/graphql/rest/json/GraphQlEndpointsE2eTest.java
@@ -14,6 +14,12 @@ import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountN
 import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerDetailsOp_GQlClientResp_ImmutJson;
 import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerDetailsOp_SpecReq;
 import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerDetailsVariables_ImmutJson;
+import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerFragmentAliasedOp_GQlClientResp_ImmutJson;
+import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerFragmentAliasedOp_SpecReq;
+import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerFragmentAliasedVariables_ImmutJson;
+import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerFragmentOp_GQlClientResp_ImmutJson;
+import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerFragmentOp_SpecReq;
+import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.GetAccountOwnerFragmentVariables_ImmutJson;
 import com.flipkart.krystal.lattice.samples.graphql.rest.json.client.PersonAliased;
 import com.flipkart.krystal.vajram.graphql.client.GraphQlSpecRequest;
 import com.flipkart.krystal.vajram.json.Json;
@@ -139,66 +145,36 @@ class GraphQlEndpointsE2eTest {
     assertThat(personAlias.imageAlias().thumbnailAlias()).isEqualTo("PRSNACC123-thumbnailUrl.png");
   }
 
-  // The two tests below specifically exercise named/inline GraphQL fragment syntax
-  // (`...personFields`). The generated facade always inlines nested selection sets rather than
-  // emitting named/inline fragments (fragments are a query-authoring convenience the facade
-  // doesn't need to model to be spec-compliant - see plan section 5a), so these two are
-  // intentionally left as handwritten raw queries rather than migrated to
-  // `<Op>QueryFacade.of(...)`.
+  // The two tests below specifically exercise named GraphQL fragment syntax (`...PersonFields`)
+  // via `@GraphQlFragment`-annotated client models, mirroring the other tests' `<Op>_SpecReq`
+  // pattern.
 
   @Test
   void graphQlQuery_namedFragment_noAliases_returnsOwnerNameAndEmail() throws Exception {
-    JsonNode data =
-        postGraphQl(
-            """
-            query {
-              account(id: "ACC123") {
-                owner {
-                  ...personFields
-                }
-              }
-            }
-            fragment personFields on Person {
-              name {
-                firstName
-                lastName
-              }
-              email
-            }
-            """);
+    GetAccountOwnerFragmentVariables_ImmutJson variables =
+        GetAccountOwnerFragmentVariables_ImmutJson._builder().id("ACC123")._build();
+    var response =
+        new GetAccountOwnerFragmentOp_GQlClientResp_ImmutJson(
+                postGraphQl(GetAccountOwnerFragmentOp_SpecReq.of(variables)))
+            .data();
 
-    JsonNode owner = data.path("account").path("owner");
-    assertThat(owner.path("name").path("firstName").asText()).isEqualTo("PRSNACC123-FirstName");
-    assertThat(owner.path("name").path("lastName").asText()).isEqualTo("PRSNACC123-LastName");
-    assertThat(owner.path("email").asText()).isEqualTo("PRSNACC123@PRSNACC123.com");
+    assertThat(response.account().owner().name().firstName()).isEqualTo("PRSNACC123-FirstName");
+    assertThat(response.account().owner().name().lastName()).isEqualTo("PRSNACC123-LastName");
+    assertThat(response.account().owner().email()).isEqualTo("PRSNACC123@PRSNACC123.com");
   }
 
   @Test
   void graphQlQuery_namedFragment_withAliasesAtSpreadSiteAndInsideFragment_succeeds()
       throws Exception {
-    JsonNode data =
-        postGraphQl(
-            """
-            query {
-              accountAlias: account(id: "ACC123") {
-                ownerAlias: owner {
-                  ...personFields
-                }
-              }
-            }
-            fragment personFields on Person {
-              n: name {
-                first: firstName
-              }
-              emailAlias: email
-            }
-            """);
+    GetAccountOwnerFragmentAliasedVariables_ImmutJson variables =
+        GetAccountOwnerFragmentAliasedVariables_ImmutJson._builder().id("ACC123")._build();
+    var response =
+        new GetAccountOwnerFragmentAliasedOp_GQlClientResp_ImmutJson(
+                postGraphQl(GetAccountOwnerFragmentAliasedOp_SpecReq.of(variables)))
+            .data();
 
-    JsonNode ownerAlias = data.path("accountAlias").path("ownerAlias");
-    assertThat(data.has("accountAlias")).isTrue();
-    assertThat(data.path("accountAlias").has("ownerAlias")).isTrue();
-    assertThat(ownerAlias.has("n")).isTrue();
-    assertThat(ownerAlias.path("n").path("first").asText()).isEqualTo("PRSNACC123-FirstName");
-    assertThat(ownerAlias.path("emailAlias").asText()).isEqualTo("PRSNACC123@PRSNACC123.com");
+    assertThat(response.accountAlias().ownerAlias().n().first()).isEqualTo("PRSNACC123-FirstName");
+    assertThat(response.accountAlias().ownerAlias().emailAlias())
+        .isEqualTo("PRSNACC123@PRSNACC123.com");
   }
 }

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlSpecRequestGen.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlSpecRequestGen.java
@@ -3,6 +3,7 @@ package com.flipkart.krystal.vajram.graphql.client.codegen;
 import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
 import static com.flipkart.krystal.vajram.graphql.client.codegen.ClientCodeGenConstants.QUERY_FACADE_SUFFIX;
 import static com.flipkart.krystal.vajram.graphql.client.codegen.ClientCodeGenConstants.RESPONSE_WRAPPER_SUFFIX;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.FINAL;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -63,6 +65,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class GraphQlSpecRequestGen {
 
   private static final String TYPENAME_META_FIELD = "__typename";
+
+  // GraphQL `Name` grammar: https://spec.graphql.org/October2021/#sec-Names
+  private static final Pattern GRAPHQL_NAME_PATTERN = Pattern.compile("[_A-Za-z][_0-9A-Za-z]*");
 
   private final CodeGenUtility util;
   private final Map<String, SchemaContext> schemaCache;
@@ -102,7 +107,8 @@ final class GraphQlSpecRequestGen {
   }
 
   /** A top-level {@code fragment <name> on <typeCondition> { ... }} definition. */
-  private record Fragment(String name, String typeCondition, List<Selection> selections) {}
+  private record Fragment(
+      String name, String typeCondition, String declaringInterface, List<Selection> selections) {}
 
   void generate(TypeElement variablesModel) {
     ForGraphQlOpReq forGraphQlOpReq = variablesModel.getAnnotation(ForGraphQlOpReq.class);
@@ -116,6 +122,12 @@ final class GraphQlSpecRequestGen {
           "Operation root '%s' referenced by @ForGraphQlOpReq must be annotated with @GraphQlOpRequest"
               .formatted(operationRoot.getQualifiedName()),
           variablesModel);
+      return;
+    }
+    if (operationRoot.getAnnotation(ModelRoot.class) == null) {
+      util.error(
+          "Model root type %s does not have @ModelRoot annotation".formatted(operationRoot),
+          operationRoot);
       return;
     }
 
@@ -240,6 +252,21 @@ final class GraphQlSpecRequestGen {
         util.error(
             "@FieldArg is not supported on the '__typename' meta field (method '%s')"
                 .formatted(method.getSimpleName()),
+            method);
+        hasError.set(true);
+        return null;
+      }
+      TypeMirror typenameContent = method.getReturnType();
+      if (util.isOptional(typenameContent)) {
+        typenameContent = util.getOptionalInnerType(typenameContent);
+      }
+      if (util.isErrable(typenameContent)) {
+        typenameContent = util.getErrableInnerType(typenameContent);
+      }
+      if (!TypeName.get(typenameContent).equals(TypeName.get(String.class))) {
+        util.error(
+            "Method '%s' is bound to the '__typename' meta field, which resolves to a String, but its return type is '%s'"
+                .formatted(method.getSimpleName(), method.getReturnType()),
             method);
         hasError.set(true);
         return null;
@@ -404,7 +431,23 @@ final class GraphQlSpecRequestGen {
       // convenience method, so match the mirror by qualified name instead.
       boolean usedAsFragment = hasFragmentAnnotationMirror(iface);
       if (!declaredAsFragment && !usedAsFragment) {
-        // Plain marker/shared interface (e.g. `extends Model`) - no fragment involved.
+        if (ifaceElem.getQualifiedName().contentEquals(Model.class.getCanonicalName())) {
+          // The `Model` marker interface every model extends - no fragment involved.
+          continue;
+        }
+        util.error(
+            ("Interface '%s' extends '%s', which is not annotated with @GraphQlFragment. Only"
+                    + " the '%s' marker interface may be extended without declaring a fragment;"
+                    + " annotate '%s' (both its own declaration and this extends-clause"
+                    + " reference) with @GraphQlFragment if it's meant to be spread as a"
+                    + " fragment")
+                .formatted(
+                    typeElem.getQualifiedName(),
+                    ifaceElem.getQualifiedName(),
+                    Model.class.getCanonicalName(),
+                    ifaceElem.getQualifiedName()),
+            typeElem);
+        hasError.set(true);
         continue;
       }
       if (declaredAsFragment != usedAsFragment) {
@@ -418,17 +461,36 @@ final class GraphQlSpecRequestGen {
         continue;
       }
 
-      GraphQlFragment fragAnno = ifaceElem.getAnnotation(GraphQlFragment.class);
+      GraphQlFragment fragAnno = requireNonNull(ifaceElem.getAnnotation(GraphQlFragment.class));
       String fragmentName =
           fragAnno.name().isBlank() ? ifaceElem.getSimpleName().toString() : fragAnno.name();
+      if (!GRAPHQL_NAME_PATTERN.matcher(fragmentName).matches()) {
+        util.error(
+            ("@GraphQlFragment(name = \"%s\") on '%s' is not a valid GraphQL name - it must match"
+                    + " [_A-Za-z][_0-9A-Za-z]*")
+                .formatted(fragmentName, ifaceElem.getQualifiedName()),
+            typeElem);
+        hasError.set(true);
+        continue;
+      }
 
+      String declaringInterface = ifaceElem.getQualifiedName().toString();
       Fragment existing = fragments.get(fragmentName);
       if (existing == null) {
         List<Selection> fragSelections =
             buildOwnSelections(
                 ifaceElem, contextType, variablesModel, ctx, varDecls, hasError, fragments);
         fragments.put(
-            fragmentName, new Fragment(fragmentName, contextType.getName(), fragSelections));
+            fragmentName,
+            new Fragment(fragmentName, contextType.getName(), declaringInterface, fragSelections));
+      } else if (!existing.declaringInterface().equals(declaringInterface)) {
+        util.error(
+            ("Fragment name '%s' is declared by two different interfaces ('%s' and '%s') within"
+                    + " the same operation - fragment names must be unique per operation")
+                .formatted(fragmentName, existing.declaringInterface(), declaringInterface),
+            typeElem);
+        hasError.set(true);
+        continue;
       } else if (!existing.typeCondition().equals(contextType.getName())) {
         util.error(
             ("Fragment '%s' is used against conflicting GraphQL types '%s' and '%s' within the"

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlSpecRequestGen.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/main/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlSpecRequestGen.java
@@ -19,6 +19,7 @@ import com.flipkart.krystal.vajram.graphql.client.GraphQlSpecRequest;
 import com.flipkart.krystal.vajram.graphql.client.api.Field;
 import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
 import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
 import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
 import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
 import com.flipkart.krystal.vajram.graphql.schema.ArgTypeValidator;
@@ -47,17 +48,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Generates a {@code <OperationRoot>QueryFacade} class for a single {@code @ForGraphQlOpReq}
  * -annotated variables model - see {@link GraphQlFacadeProcessor}.
  */
 final class GraphQlSpecRequestGen {
+
+  private static final String TYPENAME_META_FIELD = "__typename";
 
   private final CodeGenUtility util;
   private final Map<String, SchemaContext> schemaCache;
@@ -74,8 +79,30 @@ final class GraphQlSpecRequestGen {
 
   private record ArgBinding(String argName, String varRef) {}
 
+  /**
+   * A single entry in a selection set - either a field selection ({@code alias}/{@code
+   * fieldName}/{@code args}/{@code nested} populated, {@code fragmentSpread} null) or a fragment
+   * spread ({@code fragmentSpread} populated, all other fields null/empty).
+   */
   private record Selection(
-      String alias, String fieldName, List<ArgBinding> args, List<Selection> nested) {}
+      @Nullable String alias,
+      @Nullable String fieldName,
+      List<ArgBinding> args,
+      List<Selection> nested,
+      @Nullable String fragmentSpread) {
+
+    static Selection field(
+        String alias, String fieldName, List<ArgBinding> args, List<Selection> nested) {
+      return new Selection(alias, fieldName, args, nested, null);
+    }
+
+    static Selection spread(String fragmentName) {
+      return new Selection(null, null, List.of(), List.of(), fragmentName);
+    }
+  }
+
+  /** A top-level {@code fragment <name> on <typeCondition> { ... }} definition. */
+  private record Fragment(String name, String typeCondition, List<Selection> selections) {}
 
   void generate(TypeElement variablesModel) {
     ForGraphQlOpReq forGraphQlOpReq = variablesModel.getAnnotation(ForGraphQlOpReq.class);
@@ -159,14 +186,10 @@ final class GraphQlSpecRequestGen {
 
     Map<String, String> varDecls = new LinkedHashMap<>();
     AtomicBoolean hasError = new AtomicBoolean(false);
-    List<Selection> rootSelections = new ArrayList<>();
-    for (ExecutableElement rootMethod : rootMethods) {
-      Selection selection =
-          buildSelection(rootMethod, rootType, variablesModel, ctx, varDecls, hasError);
-      if (selection != null) {
-        rootSelections.add(selection);
-      }
-    }
+    Map<String, Fragment> fragments = new LinkedHashMap<>();
+    List<Selection> rootSelections =
+        buildOwnSelections(
+            operationRoot, rootType, variablesModel, ctx, varDecls, hasError, fragments);
     if (hasError.get()) {
       return;
     }
@@ -178,15 +201,21 @@ final class GraphQlSpecRequestGen {
             .collect(joining(", "));
     String varDeclsParen = varDeclsStr.isEmpty() ? "" : "(" + varDeclsStr + ")";
 
+    String fragmentsCompact =
+        fragments.values().stream().map(this::renderFragmentCompact).collect(joining(" "));
     String compactSelections =
         rootSelections.stream().map(this::renderCompact).collect(joining(" "));
     String compactQuery =
-        "%s %s%s { %s }".formatted(opKeyword, opName, varDeclsParen, compactSelections);
+        (fragmentsCompact.isEmpty() ? "" : fragmentsCompact + " ")
+            + "%s %s%s { %s }".formatted(opKeyword, opName, varDeclsParen, compactSelections);
 
+    String fragmentsPretty =
+        fragments.values().stream().map(this::renderFragmentPretty).collect(joining("\n\n"));
     String prettySelections =
         rootSelections.stream().map(s -> renderPretty(s, 1)).collect(joining("\n"));
     String prettyQuery =
-        "%s %s%s {\n%s\n}".formatted(opKeyword, opName, varDeclsParen, prettySelections);
+        (fragmentsPretty.isEmpty() ? "" : fragmentsPretty + "\n\n")
+            + "%s %s%s {\n%s\n}".formatted(opKeyword, opName, varDeclsParen, prettySelections);
 
     emitFacade(operationRoot, variablesModel, opName, compactQuery, prettyQuery);
     emitResponseWrapper(operationRoot);
@@ -198,9 +227,26 @@ final class GraphQlSpecRequestGen {
       TypeElement variablesModel,
       SchemaContext ctx,
       Map<String, String> varDecls,
-      AtomicBoolean hasError) {
+      AtomicBoolean hasError,
+      Map<String, Fragment> fragments) {
     String fieldName = resolveFieldName(method);
     String alias = method.getSimpleName().toString();
+
+    if (TYPENAME_META_FIELD.equals(fieldName)) {
+      // `__typename` is a GraphQL introspection meta-field valid on any composite type - it has
+      // no `FieldDefinition` in the schema and takes no arguments, so it's handled directly
+      // instead of going through schema field-existence/arg validation below.
+      if (method.getAnnotationsByType(FieldArg.class).length > 0) {
+        util.error(
+            "@FieldArg is not supported on the '__typename' meta field (method '%s')"
+                .formatted(method.getSimpleName()),
+            method);
+        hasError.set(true);
+        return null;
+      }
+      return Selection.field(alias, fieldName, List.of(), List.of());
+    }
+
     Optional<FieldDefinition> fieldDefOpt =
         parentType.getFieldDefinitions().stream()
             .filter(f -> f.getName().equals(fieldName))
@@ -287,20 +333,124 @@ final class GraphQlSpecRequestGen {
             method);
         hasError.set(true);
       } else {
-        List<Selection> built = new ArrayList<>();
-        for (ExecutableElement nestedMethod : util.getModelFieldsForCodegen(contentType)) {
-          Selection s =
-              buildSelection(
-                  nestedMethod, nestedGqlType.get(), variablesModel, ctx, varDecls, hasError);
-          if (s != null) {
-            built.add(s);
-          }
-        }
-        nested = built;
+        nested =
+            buildOwnSelections(
+                contentType,
+                nestedGqlType.get(),
+                variablesModel,
+                ctx,
+                varDecls,
+                hasError,
+                fragments);
       }
     }
 
-    return new Selection(alias, fieldName, argBindings, nested);
+    return Selection.field(alias, fieldName, argBindings, nested);
+  }
+
+  /**
+   * Builds the selection set for {@code typeElem} against {@code contextType} - fields declared
+   * directly on {@code typeElem} (inlined), plus a {@code ...FragmentName} spread for each
+   * supertype in {@code typeElem}'s {@code extends} clause that qualifies as a
+   * {@code @GraphQlFragment} (registering the fragment's own definition into {@code fragments} on
+   * first use). Used for the operation root, for nested {@code @GraphQlRequest} types, and
+   * recursively for fragment bodies themselves.
+   */
+  private List<Selection> buildOwnSelections(
+      TypeElement typeElem,
+      ObjectTypeDefinition contextType,
+      TypeElement variablesModel,
+      SchemaContext ctx,
+      Map<String, String> varDecls,
+      AtomicBoolean hasError,
+      Map<String, Fragment> fragments) {
+    List<Selection> selections = new ArrayList<>();
+    for (ExecutableElement ownMethod : util.getDeclaredModelFieldsForCodegen(typeElem)) {
+      Selection s =
+          buildSelection(
+              ownMethod, contextType, variablesModel, ctx, varDecls, hasError, fragments);
+      if (s != null) {
+        selections.add(s);
+      }
+    }
+    collectFragmentSelections(
+        typeElem, contextType, variablesModel, ctx, varDecls, hasError, fragments, selections);
+    return selections;
+  }
+
+  /**
+   * Walks {@code typeElem.getInterfaces()} looking for {@code @GraphQlFragment} supertypes,
+   * appending a {@code Selection.spread(name)} to {@code outSelections} for each one found, and
+   * registering its definition into {@code fragments} on first use.
+   */
+  private void collectFragmentSelections(
+      TypeElement typeElem,
+      ObjectTypeDefinition contextType,
+      TypeElement variablesModel,
+      SchemaContext ctx,
+      Map<String, String> varDecls,
+      AtomicBoolean hasError,
+      Map<String, Fragment> fragments,
+      List<Selection> outSelections) {
+    for (TypeMirror iface : typeElem.getInterfaces()) {
+      if (!(iface instanceof DeclaredType dt)
+          || !(dt.asElement() instanceof TypeElement ifaceElem)) {
+        continue;
+      }
+      boolean declaredAsFragment = ifaceElem.getAnnotation(GraphQlFragment.class) != null;
+      // `iface.getAnnotation(GraphQlFragment.class)` is unreliable for a TYPE_USE annotation on
+      // an `extends`-clause reference in some javac versions - it's present in
+      // `getAnnotationMirrors()` but not always surfaced by the `getAnnotation(Class)`
+      // convenience method, so match the mirror by qualified name instead.
+      boolean usedAsFragment = hasFragmentAnnotationMirror(iface);
+      if (!declaredAsFragment && !usedAsFragment) {
+        // Plain marker/shared interface (e.g. `extends Model`) - no fragment involved.
+        continue;
+      }
+      if (declaredAsFragment != usedAsFragment) {
+        util.error(
+            ("Interface '%s' extends '%s' as a fragment inconsistently: both the fragment's own"
+                    + " declaration and the extends-clause reference must be annotated with"
+                    + " @GraphQlFragment")
+                .formatted(typeElem.getQualifiedName(), ifaceElem.getQualifiedName()),
+            typeElem);
+        hasError.set(true);
+        continue;
+      }
+
+      GraphQlFragment fragAnno = ifaceElem.getAnnotation(GraphQlFragment.class);
+      String fragmentName =
+          fragAnno.name().isBlank() ? ifaceElem.getSimpleName().toString() : fragAnno.name();
+
+      Fragment existing = fragments.get(fragmentName);
+      if (existing == null) {
+        List<Selection> fragSelections =
+            buildOwnSelections(
+                ifaceElem, contextType, variablesModel, ctx, varDecls, hasError, fragments);
+        fragments.put(
+            fragmentName, new Fragment(fragmentName, contextType.getName(), fragSelections));
+      } else if (!existing.typeCondition().equals(contextType.getName())) {
+        util.error(
+            ("Fragment '%s' is used against conflicting GraphQL types '%s' and '%s' within the"
+                    + " same operation")
+                .formatted(fragmentName, existing.typeCondition(), contextType.getName()),
+            typeElem);
+        hasError.set(true);
+        continue;
+      }
+      outSelections.add(Selection.spread(fragmentName));
+    }
+  }
+
+  private static boolean hasFragmentAnnotationMirror(TypeMirror typeMirror) {
+    String fragmentAnnoName = GraphQlFragment.class.getCanonicalName();
+    for (AnnotationMirror mirror : typeMirror.getAnnotationMirrors()) {
+      if (mirror.getAnnotationType().asElement() instanceof TypeElement annoElem
+          && annoElem.getQualifiedName().contentEquals(fragmentAnnoName)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static String resolveFieldName(ExecutableElement method) {
@@ -342,6 +492,9 @@ final class GraphQlSpecRequestGen {
   }
 
   private String renderCompact(Selection s) {
+    if (s.fragmentSpread() != null) {
+      return "..." + s.fragmentSpread();
+    }
     String argsStr =
         s.args().isEmpty()
             ? ""
@@ -359,6 +512,9 @@ final class GraphQlSpecRequestGen {
 
   private String renderPretty(Selection s, int depth) {
     String indent = "  ".repeat(depth);
+    if (s.fragmentSpread() != null) {
+      return indent + "..." + s.fragmentSpread();
+    }
     String argsStr =
         s.args().isEmpty()
             ? ""
@@ -373,6 +529,16 @@ final class GraphQlSpecRequestGen {
     String nestedStr =
         s.nested().stream().map(n -> renderPretty(n, depth + 1)).collect(joining("\n"));
     return indent + prefix + argsStr + " {\n" + nestedStr + "\n" + indent + "}";
+  }
+
+  private String renderFragmentCompact(Fragment f) {
+    String body = f.selections().stream().map(this::renderCompact).collect(joining(" "));
+    return "fragment %s on %s { %s }".formatted(f.name(), f.typeCondition(), body);
+  }
+
+  private String renderFragmentPretty(Fragment f) {
+    String body = f.selections().stream().map(s -> renderPretty(s, 1)).collect(joining("\n"));
+    return "fragment %s on %s {\n%s\n}".formatted(f.name(), f.typeCondition(), body);
   }
 
   private void emitFacade(
@@ -432,6 +598,10 @@ final class GraphQlSpecRequestGen {
             .addAnnotation(
                 AnnotationSpec.builder(ModelRoot.class)
                     .addMember("type", "$T.$L", ModelRoot.ModelType.class, "RESPONSE")
+                    // Propagate `pure` from the operation root: since `data` is typed as the
+                    // operation root itself, the wrapper can only be pure if the root (and
+                    // everything it transitively references) is pure too.
+                    .addMember("pure", "$L", operationRoot.getAnnotation(ModelRoot.class).pure())
                     .build())
             .addJavadoc(
                 "Deserialization target for a GraphQL-over-HTTP response body whose {@code data}"

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/CompileTestSupport.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/CompileTestSupport.java
@@ -1,0 +1,101 @@
+package com.flipkart.krystal.vajram.graphql.client.codegen;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Processor;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+/**
+ * Shared in-process {@code javac} harness for annotation-processor tests in this module - runs
+ * {@link GraphQlFacadeProcessor} (or a custom processor) over in-memory source strings and a schema
+ * file, and returns the resulting diagnostics.
+ */
+final class CompileTestSupport {
+
+  private CompileTestSupport() {}
+
+  static List<Diagnostic<? extends JavaFileObject>> compile(String schema, String... sources)
+      throws IOException {
+    return compile(new GraphQlFacadeProcessor(), schema, sources).diagnostics();
+  }
+
+  record CompileResult(List<Diagnostic<? extends JavaFileObject>> diagnostics, Path outputDir) {}
+
+  static CompileResult compile(Processor processor, String schema, String... sources)
+      throws IOException {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+
+    Path moduleRoot = Files.createTempDirectory("graphql-facade-validation-test");
+    moduleRoot.toFile().deleteOnExit();
+    Files.writeString(moduleRoot.resolve("Schema.graphqls"), schema);
+
+    List<JavaFileObject> sourceFiles = new ArrayList<>();
+    for (String source : sources) {
+      sourceFiles.add(new StringSourceFile(source));
+    }
+
+    Path outputDir = Files.createTempDirectory("graphql-facade-validation-test-out");
+    outputDir.toFile().deleteOnExit();
+    JavaCompiler.CompilationTask task =
+        compiler.getTask(
+            new StringWriter(),
+            null,
+            diagnostics,
+            List.of(
+                "-proc:only",
+                "-classpath",
+                System.getProperty("java.class.path"),
+                "-s",
+                outputDir.toString(),
+                "-Akrystal.codegen.phase=MODELS",
+                "-Akrystal.codegen.moduleRootPath=" + moduleRoot),
+            null,
+            sourceFiles);
+    task.setProcessors(List.of(processor));
+    task.call();
+    return new CompileResult(diagnostics.getDiagnostics(), outputDir);
+  }
+
+  private static final class StringSourceFile extends SimpleJavaFileObject {
+    private final String content;
+
+    StringSourceFile(String content) {
+      super(
+          URI.create(
+              "string:///" + extractTypeName(content).replace('.', '/') + Kind.SOURCE.extension),
+          Kind.SOURCE);
+      this.content = content;
+    }
+
+    private static String extractTypeName(String content) {
+      String pkg =
+          content.lines().filter(l -> l.trim().startsWith("package ")).findFirst().orElse("");
+      String pkgName = pkg.replace("package", "").replace(";", "").trim();
+      String typeName =
+          content
+              .lines()
+              .filter(l -> l.trim().startsWith("public interface "))
+              .findFirst()
+              .map(l -> l.trim().split("\\s+")[2])
+              .orElse("Unknown");
+      return (pkgName.isEmpty() ? "" : pkgName + ".") + typeName;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return content;
+    }
+  }
+}

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/FieldArgValidationTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/FieldArgValidationTest.java
@@ -149,4 +149,76 @@ class FieldArgValidationTest {
                 .anyMatch(d -> d.getMessage(null).contains("doesNotExistOnQuery")))
         .isTrue();
   }
+
+  @Test
+  void operationRootWithoutModelRootAnnotation_failsCompilationWithoutCrashing()
+      throws IOException {
+    // Regression test: the operation root is missing @ModelRoot - this must be reported as a
+    // clean diagnostic rather than crashing the annotation processor (e.g. a NullPointerException
+    // from response-wrapper generation reading the annotation's `pure()` member).
+    String operationRoot =
+        """
+        package com.example.accounts3;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+
+        @GraphQlOpRequest(schemaFilePath = "Schema.graphqls")
+        public interface GetAccountOperation extends Model {
+          @FieldArg(name = "id", useVariable = "id")
+          Account account();
+        }
+        """;
+    String account =
+        """
+        package com.example.accounts3;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlRequest
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface Account extends Model {
+          String id();
+        }
+        """;
+    String variables =
+        """
+        package com.example.accounts3;
+
+        import com.flipkart.krystal.model.IfAbsent;
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+        @ForGraphQlOpReq(GetAccountOperation.class)
+        @ModelRoot(type = REQUEST)
+        @SupportedModelProtocol(Json.class)
+        public interface GetAccountVariables extends Model {
+          @IfAbsent(FAIL)
+          String id();
+        }
+        """;
+
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(SCHEMA, operationRoot, account, variables);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains("@ModelRoot")))
+        .isTrue();
+  }
 }

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/FieldArgValidationTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/FieldArgValidationTest.java
@@ -3,19 +3,10 @@ package com.flipkart.krystal.vajram.graphql.client.codegen;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
-import javax.tools.SimpleJavaFileObject;
-import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -98,7 +89,7 @@ class FieldArgValidationTest {
         """;
 
     List<Diagnostic<? extends JavaFileObject>> diagnostics =
-        compile(SCHEMA, operationRoot, account, variables);
+        CompileTestSupport.compile(SCHEMA, operationRoot, account, variables);
 
     assertThat(
             diagnostics.stream()
@@ -150,79 +141,12 @@ class FieldArgValidationTest {
         """;
 
     List<Diagnostic<? extends JavaFileObject>> diagnostics =
-        compile(SCHEMA, operationRoot, variables);
+        CompileTestSupport.compile(SCHEMA, operationRoot, variables);
 
     assertThat(
             diagnostics.stream()
                 .filter(d -> d.getKind() == Kind.ERROR)
                 .anyMatch(d -> d.getMessage(null).contains("doesNotExistOnQuery")))
         .isTrue();
-  }
-
-  private static List<Diagnostic<? extends JavaFileObject>> compile(
-      String schema, String... sources) throws IOException {
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-
-    Path moduleRoot = Files.createTempDirectory("graphql-facade-validation-test");
-    moduleRoot.toFile().deleteOnExit();
-    Files.writeString(moduleRoot.resolve("Schema.graphqls"), schema);
-
-    List<JavaFileObject> sourceFiles = new ArrayList<>();
-    for (String source : sources) {
-      sourceFiles.add(new StringSourceFile(source));
-    }
-
-    Path outputDir = Files.createTempDirectory("graphql-facade-validation-test-out");
-    outputDir.toFile().deleteOnExit();
-    JavaCompiler.CompilationTask task =
-        compiler.getTask(
-            new StringWriter(),
-            null,
-            diagnostics,
-            List.of(
-                "-proc:only",
-                "-classpath",
-                System.getProperty("java.class.path"),
-                "-s",
-                outputDir.toString(),
-                "-Akrystal.codegen.phase=MODELS",
-                "-Akrystal.codegen.moduleRootPath=" + moduleRoot),
-            null,
-            sourceFiles);
-    task.setProcessors(List.of(new GraphQlFacadeProcessor()));
-    task.call();
-    return diagnostics.getDiagnostics();
-  }
-
-  private static final class StringSourceFile extends SimpleJavaFileObject {
-    private final String content;
-
-    StringSourceFile(String content) {
-      super(
-          URI.create(
-              "string:///" + extractTypeName(content).replace('.', '/') + Kind.SOURCE.extension),
-          Kind.SOURCE);
-      this.content = content;
-    }
-
-    private static String extractTypeName(String content) {
-      String pkg =
-          content.lines().filter(l -> l.trim().startsWith("package ")).findFirst().orElse("");
-      String pkgName = pkg.replace("package", "").replace(";", "").trim();
-      String typeName =
-          content
-              .lines()
-              .filter(l -> l.trim().startsWith("public interface "))
-              .findFirst()
-              .map(l -> l.trim().split("\\s+")[2])
-              .orElse("Unknown");
-      return (pkgName.isEmpty() ? "" : pkgName + ".") + typeName;
-    }
-
-    @Override
-    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-      return content;
-    }
   }
 }

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlFragmentTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlFragmentTest.java
@@ -174,6 +174,147 @@ class GraphQlFragmentTest {
         .isTrue();
   }
 
+  @Test
+  void extendsPlainInterfaceWithoutGraphQlFragment_failsCompilation() throws IOException {
+    String plainInterface =
+        """
+        package com.example.orders;
+
+        public interface PlainMarker {
+        }
+        """;
+
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(
+            SCHEMA,
+            OPERATION_ROOT,
+            plainInterface,
+            orderWithFragment("extends Model, PlainMarker"),
+            VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(
+                    d ->
+                        d.getMessage(null).contains("PlainMarker")
+                            && d.getMessage(null).contains("@GraphQlFragment")))
+        .isTrue();
+  }
+
+  @Test
+  void invalidGraphQlFragmentName_failsCompilation() throws IOException {
+    String fragmentWithInvalidName =
+        FRAGMENT_DECLARATION.replace(
+            "@GraphQlFragment\n", "@GraphQlFragment(name = \"bad-name\")\n");
+
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(
+            SCHEMA,
+            OPERATION_ROOT,
+            fragmentWithInvalidName,
+            orderWithFragment("extends Model, @GraphQlFragment OrderFieldsFragment"),
+            VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains("bad-name")))
+        .isTrue();
+  }
+
+  @Test
+  void sameFragmentNameFromDifferentInterfaces_failsCompilation() throws IOException {
+    // Two distinct interfaces both explicitly named "OrderFieldsFragment" and both used against
+    // `Order` - same name and same type condition, but different declaring interfaces.
+    String secondFragmentDeclaration =
+        """
+        package com.example.orders;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlFragment(name = "OrderFieldsFragment")
+        @GraphQlRequest
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface OtherOrderFieldsFragment extends Model {
+          String state();
+        }
+        """;
+
+    String twoFragmentsOperationRoot =
+        """
+        package com.example.orders;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlOpRequest(schemaFilePath = "Schema.graphqls")
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface GetOrderOp extends Model {
+          @FieldArg(name = "id", useVariable = "id")
+          OrderWithFragment order();
+
+          @com.flipkart.krystal.vajram.graphql.client.api.Field(name = "order")
+          @FieldArg(name = "id", useVariable = "id")
+          OrderWithOtherFragment order2();
+        }
+        """;
+
+    String orderWithOtherFragment =
+        """
+        package com.example.orders;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlRequest
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface OrderWithOtherFragment
+            extends Model, @GraphQlFragment OtherOrderFieldsFragment {}
+        """;
+
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(
+            SCHEMA,
+            twoFragmentsOperationRoot,
+            FRAGMENT_DECLARATION,
+            secondFragmentDeclaration,
+            orderWithFragment("extends Model, @GraphQlFragment OrderFieldsFragment"),
+            orderWithOtherFragment,
+            VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(
+                    d ->
+                        d.getMessage(null).contains("OrderFieldsFragment")
+                            && d.getMessage(null).contains("declared by two different")))
+        .isTrue();
+  }
+
   private static String readGeneratedFacade(Path outputDir, String simpleName) throws IOException {
     Path file = outputDir.resolve("com/example/orders/" + simpleName + ".java");
     assertThat(Files.exists(file)).as("generated file %s should exist", file).isTrue();

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlFragmentTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/GraphQlFragmentTest.java
@@ -1,0 +1,182 @@
+package com.flipkart.krystal.vajram.graphql.client.codegen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.flipkart.krystal.vajram.graphql.client.codegen.CompileTestSupport.CompileResult;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies (via in-process annotation processing) that {@link GraphQlFacadeProcessor} spreads
+ * {@code @GraphQlFragment} supertypes as GraphQL fragments, and enforces that fragment membership
+ * is declared consistently on both the fragment's own declaration and the extends-clause reference.
+ */
+class GraphQlFragmentTest {
+
+  private static final String SCHEMA =
+      """
+      schema @rootPackage(name: "com.example.orders") { query: Query }
+      type Query { order(id: ID!): Order }
+      type Order { id: ID! state: String orderItemNames: [String] }
+      """;
+
+  private static final String FRAGMENT_DECLARATION =
+      """
+      package com.example.orders;
+
+      import com.flipkart.krystal.model.Model;
+      import com.flipkart.krystal.model.ModelRoot;
+      import com.flipkart.krystal.model.SupportedModelProtocol;
+      import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+      import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+      import com.flipkart.krystal.vajram.json.Json;
+      import java.util.List;
+
+      import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+      @GraphQlFragment
+      @GraphQlRequest
+      @ModelRoot(type = RESPONSE)
+      @SupportedModelProtocol(Json.class)
+      public interface OrderFieldsFragment extends Model {
+        String state();
+        List<String> orderItemNames();
+      }
+      """;
+
+  private static final String OPERATION_ROOT =
+      """
+      package com.example.orders;
+
+      import com.flipkart.krystal.model.Model;
+      import com.flipkart.krystal.model.ModelRoot;
+      import com.flipkart.krystal.model.SupportedModelProtocol;
+      import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+      import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+      import com.flipkart.krystal.vajram.json.Json;
+
+      import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+      @GraphQlOpRequest(schemaFilePath = "Schema.graphqls")
+      @ModelRoot(type = RESPONSE)
+      @SupportedModelProtocol(Json.class)
+      public interface GetOrderOp extends Model {
+        @FieldArg(name = "id", useVariable = "id")
+        OrderWithFragment order();
+      }
+      """;
+
+  private static final String VARIABLES =
+      """
+      package com.example.orders;
+
+      import com.flipkart.krystal.model.IfAbsent;
+      import com.flipkart.krystal.model.Model;
+      import com.flipkart.krystal.model.ModelRoot;
+      import com.flipkart.krystal.model.SupportedModelProtocol;
+      import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+      import com.flipkart.krystal.vajram.json.Json;
+
+      import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+      import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+      @ForGraphQlOpReq(GetOrderOp.class)
+      @ModelRoot(type = REQUEST)
+      @SupportedModelProtocol(Json.class)
+      public interface GetOrderVariables extends Model {
+        @IfAbsent(FAIL)
+        String id();
+      }
+      """;
+
+  private static String orderWithFragment(String extendsClause) {
+    return """
+        package com.example.orders;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlRequest
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface OrderWithFragment %s {
+        }
+        """
+        .formatted(extendsClause);
+  }
+
+  @Test
+  void fragmentDeclaredOnBothSides_isSpreadAndDefined() throws IOException {
+    CompileResult result =
+        CompileTestSupport.compile(
+            new GraphQlFacadeProcessor(),
+            SCHEMA,
+            OPERATION_ROOT,
+            FRAGMENT_DECLARATION,
+            orderWithFragment("extends Model, @GraphQlFragment OrderFieldsFragment"),
+            VARIABLES);
+
+    assertThat(result.diagnostics().stream().filter(d -> d.getKind() == Kind.ERROR).toList())
+        .isEmpty();
+
+    String generated = readGeneratedFacade(result.outputDir(), "GetOrderOp_SpecReq");
+    assertThat(generated)
+        .contains("fragment OrderFieldsFragment on Order { state orderItemNames }");
+    assertThat(generated).contains("order(id: $id) { ...OrderFieldsFragment }");
+  }
+
+  @Test
+  void fragmentDeclaredOnlyOnFragmentItself_failsCompilation() throws IOException {
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(
+            SCHEMA,
+            OPERATION_ROOT,
+            FRAGMENT_DECLARATION,
+            // extends-clause reference is missing @GraphQlFragment.
+            orderWithFragment("extends Model, OrderFieldsFragment"),
+            VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains("@GraphQlFragment")))
+        .isTrue();
+  }
+
+  @Test
+  void fragmentDeclaredOnlyOnExtendsClause_failsCompilation() throws IOException {
+    String fragmentWithoutAnnotation = FRAGMENT_DECLARATION.replace("@GraphQlFragment\n", "");
+
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(
+            SCHEMA,
+            OPERATION_ROOT,
+            fragmentWithoutAnnotation,
+            orderWithFragment("extends Model, @GraphQlFragment OrderFieldsFragment"),
+            VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains("@GraphQlFragment")))
+        .isTrue();
+  }
+
+  private static String readGeneratedFacade(Path outputDir, String simpleName) throws IOException {
+    Path file = outputDir.resolve("com/example/orders/" + simpleName + ".java");
+    assertThat(Files.exists(file)).as("generated file %s should exist", file).isTrue();
+    return Files.readString(file);
+  }
+}

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/TypenameMetaFieldTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/TypenameMetaFieldTest.java
@@ -135,4 +135,40 @@ class TypenameMetaFieldTest {
                 .anyMatch(d -> d.getMessage(null).contains("__typename")))
         .isTrue();
   }
+
+  @Test
+  void nonStringTypenameAccessor_failsCompilation() throws IOException {
+    String orderWithNonStringTypename =
+        """
+        package com.example.typename;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.Field;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlRequest
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface OrderWithTypename extends Model {
+          String id();
+
+          @Field(name = "__typename")
+          Integer typename();
+        }
+        """;
+
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(SCHEMA, OPERATION_ROOT, orderWithNonStringTypename, VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains("__typename")))
+        .isTrue();
+  }
 }

--- a/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/TypenameMetaFieldTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-client-codegen/src/test/java/com/flipkart/krystal/vajram/graphql/client/codegen/TypenameMetaFieldTest.java
@@ -1,0 +1,138 @@
+package com.flipkart.krystal.vajram.graphql.client.codegen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.flipkart.krystal.vajram.graphql.client.codegen.CompileTestSupport.CompileResult;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link GraphQlFacadeProcessor} support for the {@code __typename} GraphQL introspection
+ * meta-field, which is valid on any composite type and has no schema {@code FieldDefinition} -
+ * unlike ordinary fields, it's selected via {@code @Field(name = "__typename")} without needing a
+ * matching schema field.
+ */
+class TypenameMetaFieldTest {
+
+  private static final String SCHEMA =
+      """
+      schema @rootPackage(name: "com.example.typename") { query: Query }
+      type Query { order(id: ID!): Order }
+      type Order { id: ID! }
+      """;
+
+  private static final String OPERATION_ROOT =
+      """
+      package com.example.typename;
+
+      import com.flipkart.krystal.model.Model;
+      import com.flipkart.krystal.model.ModelRoot;
+      import com.flipkart.krystal.model.SupportedModelProtocol;
+      import com.flipkart.krystal.vajram.graphql.client.api.Field;
+      import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+      import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+      import com.flipkart.krystal.vajram.json.Json;
+
+      import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+      @GraphQlOpRequest(schemaFilePath = "Schema.graphqls")
+      @ModelRoot(type = RESPONSE)
+      @SupportedModelProtocol(Json.class)
+      public interface GetOrderOp extends Model {
+        @FieldArg(name = "id", useVariable = "id")
+        OrderWithTypename order();
+
+        @Field(name = "__typename")
+        String queryTypename();
+      }
+      """;
+
+  private static final String VARIABLES =
+      """
+      package com.example.typename;
+
+      import com.flipkart.krystal.model.IfAbsent;
+      import com.flipkart.krystal.model.Model;
+      import com.flipkart.krystal.model.ModelRoot;
+      import com.flipkart.krystal.model.SupportedModelProtocol;
+      import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+      import com.flipkart.krystal.vajram.json.Json;
+
+      import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+      import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+      @ForGraphQlOpReq(GetOrderOp.class)
+      @ModelRoot(type = REQUEST)
+      @SupportedModelProtocol(Json.class)
+      public interface GetOrderVariables extends Model {
+        @IfAbsent(FAIL)
+        String id();
+      }
+      """;
+
+  private static String orderWithTypename(String extraAnnotationsOnTypename) {
+    return """
+        package com.example.typename;
+
+        import com.flipkart.krystal.model.Model;
+        import com.flipkart.krystal.model.ModelRoot;
+        import com.flipkart.krystal.model.SupportedModelProtocol;
+        import com.flipkart.krystal.vajram.graphql.client.api.Field;
+        import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+        import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+        import com.flipkart.krystal.vajram.json.Json;
+
+        import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+        @GraphQlRequest
+        @ModelRoot(type = RESPONSE)
+        @SupportedModelProtocol(Json.class)
+        public interface OrderWithTypename extends Model {
+          String id();
+
+          %s
+          @Field(name = "__typename")
+          String typename();
+        }
+        """
+        .formatted(extraAnnotationsOnTypename);
+  }
+
+  @Test
+  void typenameField_isSelectedWithoutSchemaFieldDefinition() throws IOException {
+    CompileResult result =
+        CompileTestSupport.compile(
+            new GraphQlFacadeProcessor(), SCHEMA, OPERATION_ROOT, orderWithTypename(""), VARIABLES);
+
+    assertThat(result.diagnostics().stream().filter(d -> d.getKind() == Kind.ERROR).toList())
+        .isEmpty();
+
+    Path file = result.outputDir().resolve("com/example/typename/GetOrderOp_SpecReq.java");
+    assertThat(Files.exists(file)).as("generated file %s should exist", file).isTrue();
+    String generated = Files.readString(file);
+    assertThat(generated).contains("order(id: $id) { id typename: __typename }");
+    assertThat(generated).contains("queryTypename: __typename");
+  }
+
+  @Test
+  void fieldArgOnTypename_failsCompilation() throws IOException {
+    List<Diagnostic<? extends JavaFileObject>> diagnostics =
+        CompileTestSupport.compile(
+            SCHEMA,
+            OPERATION_ROOT,
+            orderWithTypename("@FieldArg(name = \"bogus\", useVariable = \"id\")"),
+            VARIABLES);
+
+    assertThat(
+            diagnostics.stream()
+                .filter(d -> d.getKind() == Kind.ERROR)
+                .anyMatch(d -> d.getMessage(null).contains("__typename")))
+        .isTrue();
+  }
+}

--- a/vajram/extensions/graphql/vajram-graphql-client/src/main/java/com/flipkart/krystal/vajram/graphql/client/api/GraphQlFragment.java
+++ b/vajram/extensions/graphql/vajram-graphql-client/src/main/java/com/flipkart/krystal/vajram/graphql/client/api/GraphQlFragment.java
@@ -1,0 +1,45 @@
+package com.flipkart.krystal.vajram.graphql.client.api;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code @GraphQlRequest} model as a reusable GraphQL fragment, and marks a supertype
+ * reference in another {@code @GraphQlRequest}/{@code @GraphQlOpRequest} model's {@code extends}
+ * clause as a spread of that fragment.
+ *
+ * <p>Both declarations are required for a fragment to be spread - the fragment interface's own
+ * declaration, and the type-use annotation on the reference in the child's {@code extends} clause:
+ *
+ * <pre>{@code
+ * @GraphQlFragment
+ * @GraphQlRequest
+ * @ModelRoot(type = RESPONSE)
+ * @SupportedModelProtocol(Json.class)
+ * public interface ProductFragment extends Model {
+ *   String id();
+ *   String name();
+ * }
+ *
+ * @GraphQlRequest
+ * @ModelRoot(type = RESPONSE)
+ * @SupportedModelProtocol(Json.class)
+ * public interface ProductReq extends @GraphQlFragment ProductFragment {
+ *   String sku(); // fields declared directly here are still inlined alongside the spread
+ * }
+ * }</pre>
+ *
+ * <p>The request-facade codegen emits a top-level {@code fragment ProductFragment on Product { id
+ * name }} definition and a {@code ...ProductFragment} spread in place of inlining the fragment's
+ * fields. A supertype reference annotated on only one of the two sites is a compile error.
+ */
+@Retention(CLASS)
+@Target({TYPE, TYPE_USE})
+public @interface GraphQlFragment {
+  /** GraphQL fragment name. Empty string (default) means use the interface's simple name. */
+  String name() default "";
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/DummyFullDetails.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/DummyFullDetails.java
@@ -1,0 +1,28 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side selection for {@code VajramGraphQlTest#graphqlQueryExecution_succeeds}, including the
+ * {@code __typename} introspection meta-field.
+ */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface DummyFullDetails extends Model {
+  String name();
+
+  Integer age();
+
+  String f1();
+
+  @Field(name = "__typename")
+  String typename();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderExecutionOp.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderExecutionOp.java
@@ -1,0 +1,34 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side operation root for {@code VajramGraphQlTest#graphqlQueryExecution_succeeds}. Covers
+ * multiple root fields, nested scalar/enum fields, and {@code __typename} at both the root and
+ * nested levels.
+ */
+@GraphQlOpRequest(schemaFilePath = "src/main/graphqls/Schema.graphqls")
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface GetOrderExecutionOp extends Model {
+
+  @FieldArg(name = "id", useVariable = "orderId")
+  OrderFullDetails order();
+
+  @FieldArg(name = "dummyId", useVariable = "dummyId")
+  DummyFullDetails dummy();
+
+  @FieldArg(name = "userId", useVariable = "userId")
+  OrderItemNamesOnly mostRecentOrder();
+
+  @Field(name = "__typename")
+  String typename();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderExecutionVariables.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderExecutionVariables.java
@@ -1,0 +1,25 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+import com.flipkart.krystal.model.IfAbsent;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.json.Json;
+
+@ForGraphQlOpReq(GetOrderExecutionOp.class)
+@ModelRoot(type = REQUEST)
+@SupportedModelProtocol(Json.class)
+public interface GetOrderExecutionVariables extends Model {
+  @IfAbsent(FAIL)
+  String orderId();
+
+  @IfAbsent(FAIL)
+  String dummyId();
+
+  @IfAbsent(FAIL)
+  String userId();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithAliasedFragmentOp.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithAliasedFragmentOp.java
@@ -1,0 +1,23 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side operation root for {@code
+ * VajramGraphQlTest#graphqlQueryWithNamedFragment_havingFieldAliasesInsideFragment_succeeds}.
+ */
+@GraphQlOpRequest(schemaFilePath = "src/main/graphqls/Schema.graphqls")
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface GetOrderWithAliasedFragmentOp extends Model {
+
+  @FieldArg(name = "id", useVariable = "id")
+  OrderWithAliasedFragment order();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithAliasedFragmentVariables.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithAliasedFragmentVariables.java
@@ -1,0 +1,19 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+import com.flipkart.krystal.model.IfAbsent;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.json.Json;
+
+@ForGraphQlOpReq(GetOrderWithAliasedFragmentOp.class)
+@ModelRoot(type = REQUEST)
+@SupportedModelProtocol(Json.class)
+public interface GetOrderWithAliasedFragmentVariables extends Model {
+  @IfAbsent(FAIL)
+  String id();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithFragmentOp.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithFragmentOp.java
@@ -1,0 +1,23 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side operation root for {@code
+ * VajramGraphQlTest#graphqlQueryWithNamedFragment_noAliases_succeeds}.
+ */
+@GraphQlOpRequest(schemaFilePath = "src/main/graphqls/Schema.graphqls")
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface GetOrderWithFragmentOp extends Model {
+
+  @FieldArg(name = "id", useVariable = "id")
+  OrderWithFragment order();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithFragmentVariables.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithFragmentVariables.java
@@ -1,0 +1,19 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+import com.flipkart.krystal.model.IfAbsent;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.json.Json;
+
+@ForGraphQlOpReq(GetOrderWithFragmentOp.class)
+@ModelRoot(type = REQUEST)
+@SupportedModelProtocol(Json.class)
+public interface GetOrderWithFragmentVariables extends Model {
+  @IfAbsent(FAIL)
+  String id();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersWithFragmentOp.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersWithFragmentOp.java
@@ -1,0 +1,31 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.FieldArg;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlOpRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/**
+ * Client-side operation root for {@code
+ * VajramGraphQlTest#graphqlQueryWithNamedFragment_underQueryLevelAliases_succeeds}. The same named
+ * fragment ({@link OrderFieldsFragment}, spread via {@link OrderWithFragment}) is used under two
+ * differently-aliased {@code order} selections.
+ */
+@GraphQlOpRequest(schemaFilePath = "src/main/graphqls/Schema.graphqls")
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface GetOrdersWithFragmentOp extends Model {
+
+  @Field(name = "order")
+  @FieldArg(name = "id", useVariable = "o1Id")
+  OrderWithFragment o1();
+
+  @Field(name = "order")
+  @FieldArg(name = "id", useVariable = "o2Id")
+  OrderWithFragment o2();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersWithFragmentVariables.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersWithFragmentVariables.java
@@ -1,0 +1,22 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.IfAbsent.IfAbsentThen.FAIL;
+import static com.flipkart.krystal.model.ModelRoot.ModelType.REQUEST;
+
+import com.flipkart.krystal.model.IfAbsent;
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.ForGraphQlOpReq;
+import com.flipkart.krystal.vajram.json.Json;
+
+@ForGraphQlOpReq(GetOrdersWithFragmentOp.class)
+@ModelRoot(type = REQUEST)
+@SupportedModelProtocol(Json.class)
+public interface GetOrdersWithFragmentVariables extends Model {
+  @IfAbsent(FAIL)
+  String o1Id();
+
+  @IfAbsent(FAIL)
+  String o2Id();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderFieldsAliasedFragment.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderFieldsAliasedFragment.java
@@ -1,0 +1,28 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+import java.util.List;
+
+/**
+ * Same fields as {@link OrderFieldsFragment}, but aliased *inside* the fragment definition itself -
+ * spread via {@link OrderWithAliasedFragment}.
+ */
+@GraphQlFragment
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OrderFieldsAliasedFragment extends Model {
+  @Field(name = "state")
+  State s();
+
+  @Field(name = "orderItemNames")
+  List<String> names();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderFieldsFragment.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderFieldsFragment.java
@@ -1,0 +1,22 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+import java.util.List;
+
+/** A reusable named fragment on {@code Order}, spread via {@link OrderWithFragment}. */
+@GraphQlFragment
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OrderFieldsFragment extends Model {
+  State state();
+
+  List<String> orderItemNames();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderFullDetails.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderFullDetails.java
@@ -1,0 +1,40 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.Field;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Client-side selection for {@code VajramGraphQlTest#graphqlQueryExecution_succeeds} - covers a
+ * broad mix of scalar/enum fields, a duplicate-field alias, and the {@code __typename}
+ * introspection meta-field.
+ */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OrderFullDetails extends Model {
+  List<String> orderItemNames();
+
+  String nameString();
+
+  State state();
+
+  State stateDuplicate();
+
+  OffsetDateTime orderPlacedAt();
+
+  Long orderItemsCount();
+
+  LocalDate orderAcceptDate();
+
+  @Field(name = "__typename")
+  String typename();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderItemNamesOnly.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderItemNamesOnly.java
@@ -1,0 +1,17 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+import java.util.List;
+
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OrderItemNamesOnly extends Model {
+  List<String> orderItemNames();
+}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderWithAliasedFragment.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderWithAliasedFragment.java
@@ -1,0 +1,17 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** Spreads {@link OrderFieldsAliasedFragment} - no fields of its own. */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OrderWithAliasedFragment
+    extends Model, @GraphQlFragment OrderFieldsAliasedFragment {}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderWithFragment.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/main/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderWithFragment.java
@@ -1,0 +1,16 @@
+package com.flipkart.krystal.vajram.graphql.samples.client;
+
+import static com.flipkart.krystal.model.ModelRoot.ModelType.RESPONSE;
+
+import com.flipkart.krystal.model.Model;
+import com.flipkart.krystal.model.ModelRoot;
+import com.flipkart.krystal.model.SupportedModelProtocol;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlFragment;
+import com.flipkart.krystal.vajram.graphql.client.api.GraphQlRequest;
+import com.flipkart.krystal.vajram.json.Json;
+
+/** Spreads {@link OrderFieldsFragment} - no fields of its own. */
+@GraphQlRequest
+@ModelRoot(type = RESPONSE)
+@SupportedModelProtocol(Json.class)
+public interface OrderWithFragment extends Model, @GraphQlFragment OrderFieldsFragment {}

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/VajramGraphQlTest.java
@@ -41,6 +41,10 @@ import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderDummyFanoutOp;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderDummyFanoutOp_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderDummyFanoutOp_SpecReq;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderDummyFanoutVariables_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderExecutionOp;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderExecutionOp_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderExecutionOp_SpecReq;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderExecutionVariables_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderItemFanoutOp;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderItemFanoutOp_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderItemFanoutOp_SpecReq;
@@ -49,14 +53,26 @@ import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderNoArgDummiesFa
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderNoArgDummiesFanoutOp_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderNoArgDummiesFanoutOp_SpecReq;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderNoArgDummiesFanoutVariables_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithAliasedFragmentOp;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithAliasedFragmentOp_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithAliasedFragmentOp_SpecReq;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithAliasedFragmentVariables_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithDummiesOp;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithDummiesOp_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithDummiesOp_SpecReq;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithDummiesVariables_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithFragmentOp;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithFragmentOp_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithFragmentOp_SpecReq;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrderWithFragmentVariables_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersAliasedOp;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersAliasedOp_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersAliasedOp_SpecReq;
 import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersAliasedVariables_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersWithFragmentOp;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersWithFragmentOp_ImmutJson;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersWithFragmentOp_SpecReq;
+import com.flipkart.krystal.vajram.graphql.samples.client.GetOrdersWithFragmentVariables_ImmutJson;
 import com.flipkart.krystal.vajram.graphql.samples.query.Query_GQlAggr_Req;
 import com.flipkart.krystal.vajram.graphql.samples.state.State;
 import com.flipkart.krystal.vajram.json.Json;
@@ -120,59 +136,38 @@ public class VajramGraphQlTest {
   void graphqlQueryExecution_succeeds() throws JsonProcessingException {
     CompletableFuture<ExecutionResult> result;
     try (VajramKryonExecutor executor = createExecutor()) {
+      GetOrderExecutionVariables_ImmutJson variables =
+          GetOrderExecutionVariables_ImmutJson._builder()
+              .orderId("order1")
+              .dummyId("dummy1")
+              .userId("user1")
+              ._build();
       result =
           new GraphQlExecutionFacade(GRAPHQL)
               .executeGraphQl(
                   executor,
                   VajramExecutionConfig.builder().build(),
-                  new GraphQLQuery(
-                      """
-                      query {
-                        order(id: "order1") {
-                          orderItemNames
-                          nameString
-                          state
-                          stateDuplicate
-                          orderPlacedAt
-                          orderItemsCount
-                          orderAcceptDate
-                          __typename
-                        }
-                        dummy(dummyId: "dummy1") {
-                          name
-                          age
-                          f1
-                          __typename
-                        }
-                        mostRecentOrder(userId: "user1") {
-                          orderItemNames
-                        }
-                        __typename
-                      }
-                      """,
-                      Map.of()));
+                  toGraphQLQuery(GetOrderExecutionOp_SpecReq.of(variables)));
     }
     assertThat(result).succeedsWithin(TEST_TIMEOUT);
     ExecutionResult executionResult = result.join();
     @SuppressWarnings("unchecked")
     Map<String, Object> queryData = requireNonNull(executionResult.getData());
-    @SuppressWarnings("unchecked")
-    Map<String, Object> orderData = requireNonNull((Map<String, Object>) queryData.get("order"));
-    @SuppressWarnings("unchecked")
-    Map<String, Object> dummyData = requireNonNull((Map<String, Object>) queryData.get("dummy"));
-    @SuppressWarnings("unchecked")
-    Map<String, Object> mostRecentOrderData =
-        requireNonNull((Map<String, Object>) queryData.get("mostRecentOrder"));
-    assertThat(orderData.get("orderItemNames")).isEqualTo(List.of("order1_1", "order1_2"));
-    assertThat(orderData.get("nameString")).isEqualTo("testOrderName");
-    assertThat(orderData.get("stateDuplicate")).isEqualTo(orderData.get("state"));
-    assertThat(orderData.get("__typename")).isEqualTo("Order");
-    assertThat(orderData.get("orderItemsCount")).isEqualTo(Long.MAX_VALUE);
-    assertThat(orderData.get("orderPlacedAt")).isEqualTo(UNIX_EPOCH_DATE_TIME);
-    assertThat(orderData.get("orderAcceptDate")).isEqualTo(UNIX_EPOCH_DATE);
-    assertThat(dummyData.get("__typename")).isEqualTo("Dummy");
-    assertThat(mostRecentOrderData.get("orderItemNames"))
+    GetOrderExecutionOp_ImmutJson result1 =
+        Json.JSON_MAPPER.convertValue(queryData, GetOrderExecutionOp_ImmutJson.class);
+    GetOrderExecutionOp response = result1;
+
+    assertThat(response.order().orderItemNames()).isEqualTo(List.of("order1_1", "order1_2"));
+    assertThat(response.order().nameString()).isEqualTo("testOrderName");
+    assertThat(response.order().stateDuplicate()).isEqualTo(response.order().state());
+    assertThat(response.order().typename()).isEqualTo("Order");
+    assertThat(response.order().orderItemsCount()).isEqualTo(Long.MAX_VALUE);
+    assertThat(response.order().orderPlacedAt()).isEqualTo(UNIX_EPOCH_DATE_TIME);
+    assertThat(response.order().orderAcceptDate()).isEqualTo(UNIX_EPOCH_DATE);
+    assertThat(response.dummy().typename()).isEqualTo("Dummy");
+    assertThat(response.mostRecentOrder().orderItemNames())
         .isEqualTo(List.of("MostRecentOrderOf_user1_1", "MostRecentOrderOf_user1_2"));
+    assertThat(response.typename()).isEqualTo("Query");
 
     System.out.println(
         Json.OBJECT_WRITER
@@ -437,111 +432,86 @@ public class VajramGraphQlTest {
   }
 
   @Test
-  void graphqlQueryWithNamedFragment_noAliases_succeeds() {
-    // A named fragment spread on `Order`, with no aliases anywhere in the query.
+  void graphqlQueryWithNamedFragment_noAliases_succeeds() throws JsonProcessingException {
+    // A named fragment (`OrderFieldsFragment`, spread via `OrderWithFragment`), with no aliases
+    // anywhere in the query.
     CompletableFuture<ExecutionResult> result;
     try (VajramKryonExecutor executor = createExecutor()) {
+      GetOrderWithFragmentVariables_ImmutJson variables =
+          GetOrderWithFragmentVariables_ImmutJson._builder().id("order1")._build();
       result =
           new GraphQlExecutionFacade(GRAPHQL)
               .executeGraphQl(
                   executor,
                   VajramExecutionConfig.builder().build(),
-                  new GraphQLQuery(
-                      """
-                      query {\
-                        order(id: "order1") {\
-                          ...orderFields\
-                        }
-                      }
-                      fragment orderFields on Order {
-                        state
-                        orderItemNames
-                      }
-                      """,
-                      Map.of()));
+                  toGraphQLQuery(GetOrderWithFragmentOp_SpecReq.of(variables)));
     }
     assertThat(result).succeedsWithin(TEST_TIMEOUT);
     Map<String, Object> queryData = requireNonNull(result.join().getData());
-    @SuppressWarnings("unchecked")
-    Map<String, Object> orderData = requireNonNull((Map<String, Object>) queryData.get("order"));
+    GetOrderWithFragmentOp response =
+        Json.JSON_MAPPER.convertValue(queryData, GetOrderWithFragmentOp_ImmutJson.class);
 
-    assertThat(orderData.get("state")).isEqualTo(State.COMPLETED);
-    assertThat(orderData.get("orderItemNames")).isEqualTo(List.of("order1_1", "order1_2"));
+    assertThat(response.order().state())
+        .isEqualTo(com.flipkart.krystal.vajram.graphql.samples.client.State.COMPLETED);
+    assertThat(response.order().orderItemNames()).isEqualTo(List.of("order1_1", "order1_2"));
   }
 
   @Test
-  void graphqlQueryWithNamedFragment_underQueryLevelAliases_succeeds() {
+  void graphqlQueryWithNamedFragment_underQueryLevelAliases_succeeds()
+      throws JsonProcessingException {
     // The same named fragment is spread under two differently-aliased `order` selections. Each
     // alias must resolve the fragment's fields against its own argument-specific order.
     CompletableFuture<ExecutionResult> result;
     try (VajramKryonExecutor executor = createExecutor()) {
+      GetOrdersWithFragmentVariables_ImmutJson variables =
+          GetOrdersWithFragmentVariables_ImmutJson._builder()
+              .o1Id("order1")
+              .o2Id("order2")
+              ._build();
       result =
           new GraphQlExecutionFacade(GRAPHQL)
               .executeGraphQl(
                   executor,
                   VajramExecutionConfig.builder().build(),
-                  new GraphQLQuery(
-                      """
-                      query {
-                        o1: order(id: "order1") {
-                          ...orderFields
-                        }
-                        o2: order(id: "order2") {
-                          ...orderFields
-                        }
-                      }
-                      fragment orderFields on Order {
-                        state
-                        orderItemNames
-                      }
-                      """,
-                      Map.of()));
+                  toGraphQLQuery(GetOrdersWithFragmentOp_SpecReq.of(variables)));
     }
     assertThat(result).succeedsWithin(TEST_TIMEOUT);
     Map<String, Object> queryData = requireNonNull(result.join().getData());
-    @SuppressWarnings("unchecked")
-    Map<String, Object> o1Data = requireNonNull((Map<String, Object>) queryData.get("o1"));
-    @SuppressWarnings("unchecked")
-    Map<String, Object> o2Data = requireNonNull((Map<String, Object>) queryData.get("o2"));
+    GetOrdersWithFragmentOp response =
+        Json.JSON_MAPPER.convertValue(queryData, GetOrdersWithFragmentOp_ImmutJson.class);
 
-    assertThat(o1Data.get("state")).isEqualTo(State.COMPLETED);
-    assertThat(o1Data.get("orderItemNames")).isEqualTo(List.of("order1_1", "order1_2"));
-    assertThat(o2Data.get("state")).isEqualTo(State.COMPLETED);
-    assertThat(o2Data.get("orderItemNames")).isEqualTo(List.of("order2_1", "order2_2"));
+    assertThat(response.o1().state())
+        .isEqualTo(com.flipkart.krystal.vajram.graphql.samples.client.State.COMPLETED);
+    assertThat(response.o1().orderItemNames()).isEqualTo(List.of("order1_1", "order1_2"));
+    assertThat(response.o2().state())
+        .isEqualTo(com.flipkart.krystal.vajram.graphql.samples.client.State.COMPLETED);
+    assertThat(response.o2().orderItemNames()).isEqualTo(List.of("order2_1", "order2_2"));
   }
 
   @Test
-  void graphqlQueryWithNamedFragment_havingFieldAliasesInsideFragment_succeeds() {
-    // Fields aliased *inside* the fragment definition itself (not at the spread site) must
-    // resolve under their aliased response keys.
+  void graphqlQueryWithNamedFragment_havingFieldAliasesInsideFragment_succeeds()
+      throws JsonProcessingException {
+    // Fields aliased *inside* the fragment definition itself (`OrderFieldsAliasedFragment`, not
+    // at the spread site) must resolve under their aliased response keys.
     CompletableFuture<ExecutionResult> result;
     try (VajramKryonExecutor executor = createExecutor()) {
+      GetOrderWithAliasedFragmentVariables_ImmutJson variables =
+          GetOrderWithAliasedFragmentVariables_ImmutJson._builder().id("order1")._build();
       result =
           new GraphQlExecutionFacade(GRAPHQL)
               .executeGraphQl(
                   executor,
                   VajramExecutionConfig.builder().build(),
-                  new GraphQLQuery(
-                      """
-                      query {
-                        order(id: "order1") {
-                          ...orderFields
-                        }
-                      }
-                      fragment orderFields on Order {
-                        s: state
-                        names: orderItemNames
-                      }
-                      """,
-                      Map.of()));
+                  toGraphQLQuery(GetOrderWithAliasedFragmentOp_SpecReq.of(variables)));
     }
     assertThat(result).succeedsWithin(TEST_TIMEOUT);
     Map<String, Object> queryData = requireNonNull(result.join().getData());
-    @SuppressWarnings("unchecked")
-    Map<String, Object> orderData = requireNonNull((Map<String, Object>) queryData.get("order"));
+    GetOrderWithAliasedFragmentOp response =
+        Json.JSON_MAPPER.convertValue(queryData, GetOrderWithAliasedFragmentOp_ImmutJson.class);
 
-    assertThat(orderData.get("s")).isEqualTo(State.COMPLETED);
-    assertThat(orderData.get("names")).isEqualTo(List.of("order1_1", "order1_2"));
+    assertThat(response.order().s())
+        .isEqualTo(com.flipkart.krystal.vajram.graphql.samples.client.State.COMPLETED);
+    assertThat(response.order().names()).isEqualTo(List.of("order1_1", "order1_2"));
   }
 
   @Test

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/DummyIdOnly.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/DummyIdOnly.java
@@ -1,8 +1,0 @@
-// Unused: see the note in VajramGraphQlTest.java explaining why the 5b migration of this
-// module's tests to the generated <Op>QueryFacade was reverted (JPMS module-info constraints on
-// the shared testKrystalModelsGen proc-only task, which compiles src/main/java and src/test/java
-// together under this module's single module-info.java, make it infeasible to grant the extra
-// test-only `requires` needed by JUnit/AssertJ without broader framework changes out of scope for
-// this feature). This file could not be deleted (filesystem delete permission was denied in the
-// environment this work was performed in); left as an empty placeholder pending manual cleanup.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithDummiesOperation.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithDummiesOperation.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithDummiesVariables.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrderWithDummiesVariables.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersAliasedOperation.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersAliasedOperation.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersAliasedVariables.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/GetOrdersAliasedVariables.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderAliased.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderAliased.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderAliasedWithStateAlias.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderAliasedWithStateAlias.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;

--- a/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderWithDummies.java
+++ b/vajram/extensions/graphql/vajram-graphql-samples/src/test/java/com/flipkart/krystal/vajram/graphql/samples/client/OrderWithDummies.java
@@ -1,2 +1,0 @@
-// See DummyIdOnly.java in this package for why this file is an empty placeholder.
-package com.flipkart.krystal.vajram.graphql.samples.client;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reusable, named GraphQL fragments, including fragment spreads and field aliases.
  - Added support for querying the GraphQL `__typename` meta-field.
  - Added generated client models for fragment-based account and order queries, with JSON support and required variables.
  - Added support for selecting only fields declared directly on a model.

- **Tests**
  - Updated GraphQL examples and end-to-end tests to use generated, typed client models.
  - Added coverage for fragments, aliases, `__typename`, and related validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->